### PR TITLE
ignore unknown versions in version response.

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -1151,7 +1151,7 @@ pub struct SpdmNegotiateInfo {
     pub rsp_max_spdm_msg_size_sel: u32, // spdm 1.2
 }
 
-pub const MAX_MANAGED_BUFFER_A_SIZE: usize = 150 + 2 * MAX_SPDM_VERSION_COUNT;
+pub const MAX_MANAGED_BUFFER_A_SIZE: usize = 150 + 2 * 255; // for version response, there can be more than MAX_SPDM_VERSION_COUNT versions.
 pub const MAX_MANAGED_BUFFER_B_SIZE: usize =
     24 + SPDM_MAX_HASH_SIZE * SPDM_MAX_SLOT_NUMBER + config::MAX_SPDM_CERT_CHAIN_DATA_SIZE;
 pub const MAX_MANAGED_BUFFER_C_SIZE: usize =


### PR DESCRIPTION
Current design will reject version response if there is a version other than 0x10, 0x11 and 0x12. This patch make it accept such version response, instead, unknown versions will be ignored.