### PR TITLE
mask bitfields with VALID_MASK when read.

### DIFF
--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -613,7 +613,7 @@ impl Codec for SpdmOpaqueSupport {
     fn read(r: &mut Reader) -> Option<SpdmOpaqueSupport> {
         let bits = u8::read(r)?;
 
-        SpdmOpaqueSupport::from_bits(bits)
+        SpdmOpaqueSupport::from_bits(bits & SpdmOpaqueSupport::VALID_MASK.bits)
     }
 }
 

--- a/spdmlib/src/message/challenge.rs
+++ b/spdmlib/src/message/challenge.rs
@@ -79,6 +79,7 @@ bitflags! {
     #[derive(Default)]
     pub struct SpdmChallengeAuthAttribute: u8 {
         const BASIC_MUT_AUTH_REQ = 0b10000000;
+        const VALID_MASK = Self::BASIC_MUT_AUTH_REQ.bits;
     }
 }
 
@@ -126,7 +127,9 @@ impl SpdmCodec for SpdmChallengeAuthResponsePayload {
     ) -> Option<SpdmChallengeAuthResponsePayload> {
         let param1 = u8::read(r)?;
         let slot_id = param1 & 0xF;
-        let challenge_auth_attribute = SpdmChallengeAuthAttribute::from_bits(param1 & 0xF0)?;
+        let challenge_auth_attribute = SpdmChallengeAuthAttribute::from_bits(
+            param1 & SpdmChallengeAuthAttribute::VALID_MASK.bits,
+        )?;
         let slot_mask = u8::read(r)?; // param2
         let cert_chain_hash = SpdmDigestStruct::spdm_read(context, r)?;
         let nonce = SpdmNonceStruct::read(r)?;

--- a/spdmlib/src/message/end_session.rs
+++ b/spdmlib/src/message/end_session.rs
@@ -11,6 +11,7 @@ bitflags! {
     #[derive(Default)]
     pub struct SpdmEndSessionRequestAttributes: u8 {
         const PRESERVE_NEGOTIATED_STATE = 0b00000001;
+        const VALID_MASK = Self::PRESERVE_NEGOTIATED_STATE.bits;
     }
 }
 
@@ -22,7 +23,9 @@ impl Codec for SpdmEndSessionRequestAttributes {
     fn read(r: &mut Reader) -> Option<SpdmEndSessionRequestAttributes> {
         let bits = u8::read(r)?;
 
-        SpdmEndSessionRequestAttributes::from_bits(bits)
+        SpdmEndSessionRequestAttributes::from_bits(
+            bits & SpdmEndSessionRequestAttributes::VALID_MASK.bits,
+        )
     }
 }
 

--- a/spdmlib/src/message/finish.rs
+++ b/spdmlib/src/message/finish.rs
@@ -14,6 +14,7 @@ bitflags! {
     #[derive(Default)]
     pub struct SpdmFinishRequestAttributes: u8 {
         const SIGNATURE_INCLUDED = 0b00000001;
+        const VALID_MASK = Self::SIGNATURE_INCLUDED.bits;
     }
 }
 
@@ -25,7 +26,7 @@ impl Codec for SpdmFinishRequestAttributes {
     fn read(r: &mut Reader) -> Option<SpdmFinishRequestAttributes> {
         let bits = u8::read(r)?;
 
-        SpdmFinishRequestAttributes::from_bits(bits)
+        SpdmFinishRequestAttributes::from_bits(bits & SpdmFinishRequestAttributes::VALID_MASK.bits)
     }
 }
 

--- a/spdmlib/src/message/key_exchange.rs
+++ b/spdmlib/src/message/key_exchange.rs
@@ -118,6 +118,7 @@ bitflags! {
         const MUT_AUTH_REQ = 0b00000001;
         const MUT_AUTH_REQ_WITH_ENCAP_REQUEST = 0b00000010;
         const MUT_AUTH_REQ_WITH_GET_DIGESTS = 0b00000100;
+        const VALID_MASK = Self::MUT_AUTH_REQ.bits | Self::MUT_AUTH_REQ_WITH_ENCAP_REQUEST.bits | Self::MUT_AUTH_REQ_WITH_GET_DIGESTS.bits;
     }
 }
 
@@ -129,7 +130,9 @@ impl Codec for SpdmKeyExchangeMutAuthAttributes {
     fn read(r: &mut Reader) -> Option<SpdmKeyExchangeMutAuthAttributes> {
         let bits = u8::read(r)?;
 
-        SpdmKeyExchangeMutAuthAttributes::from_bits(bits)
+        SpdmKeyExchangeMutAuthAttributes::from_bits(
+            bits & SpdmKeyExchangeMutAuthAttributes::VALID_MASK.bits,
+        )
     }
 }
 

--- a/spdmlib/src/message/key_exchange_test.rs
+++ b/spdmlib/src/message/key_exchange_test.rs
@@ -146,7 +146,7 @@ fn test_key_exchange_rsp_struct() {
     u8_slice[6] = 0x8;
     let reader = &mut Reader::init(&u8_slice[2..]);
     let ret = SpdmKeyExchangeResponsePayload::spdm_read(context, reader);
-    assert!(ret.is_none());
+    assert!(ret.is_some());
 }
 
 #[ignore = "extended unit test"]

--- a/spdmlib/src/message/measurement.rs
+++ b/spdmlib/src/message/measurement.rs
@@ -22,6 +22,7 @@ bitflags! {
     pub struct SpdmMeasurementAttributes: u8 {
         const SIGNATURE_REQUESTED = 0b00000001;
         const RAW_BIT_STREAM_REQUESTED = 0b0000_0010;
+        const VALID_MASK = Self::SIGNATURE_REQUESTED.bits | Self::RAW_BIT_STREAM_REQUESTED.bits;
     }
 }
 
@@ -33,7 +34,7 @@ impl Codec for SpdmMeasurementAttributes {
     fn read(r: &mut Reader) -> Option<SpdmMeasurementAttributes> {
         let bits = u8::read(r)?;
 
-        SpdmMeasurementAttributes::from_bits(bits)
+        SpdmMeasurementAttributes::from_bits(bits & SpdmMeasurementAttributes::VALID_MASK.bits)
     }
 }
 

--- a/tdisp/src/pci_tdisp.rs
+++ b/tdisp/src/pci_tdisp.rs
@@ -526,6 +526,11 @@ bitflags! {
         const LOCK_MSIX = 0b0000_0000_0000_0100;
         const BIND_P2P = 0b0000_0000_0000_1000;
         const ALL_REQUEST_REDIRECT = 0b0000_0000_0001_0000;
+        const VALID_MASK = Self::NO_FW_UPDATE.bits
+        | Self::SYSTEM_CACHE_LINE_SIZE.bits
+        | Self::LOCK_MSIX.bits
+        | Self::BIND_P2P.bits
+        | Self::ALL_REQUEST_REDIRECT.bits;
     }
 }
 
@@ -536,7 +541,7 @@ impl Codec for LockInterfaceFlag {
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
         let bits = u16::read(r)?;
-        Some(Self { bits })
+        LockInterfaceFlag::from_bits(bits & LockInterfaceFlag::VALID_MASK.bits)
     }
 }
 
@@ -701,6 +706,11 @@ bitflags! {
         const DMA_REQUESTS_WITH_PASID = 0b0000_0000_0000_0100;
         const ATS_SUPPORTED_ENABLED = 0b0000_0000_0000_1000;
         const PRS_SUPPORTED_ENABLED = 0b0000_0000_0001_0000;
+        const VALID_MASK = Self::DEVICE_FIRMWARE_UPDATES_NOT_PERMITTED.bits
+        | Self::DMA_REQUESTS_WITHOUT_PASID.bits
+        | Self::DMA_REQUESTS_WITH_PASID.bits
+        | Self::ATS_SUPPORTED_ENABLED.bits
+        | Self::PRS_SUPPORTED_ENABLED.bits;
     }
 }
 
@@ -711,7 +721,7 @@ impl Codec for InterfaceInfo {
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
         let bits = u16::read(r)?;
-        Some(Self { bits })
+        InterfaceInfo::from_bits(bits & InterfaceInfo::VALID_MASK.bits)
     }
 }
 
@@ -982,6 +992,11 @@ bitflags! {
         const IS_NON_TEE_MEM = 0b0000_0000_0000_0100;
         const IS_MEM_ATTR_UPDATABLE = 0b0000_0000_0000_1000;
         const PRS_SUPPORTED_ENABLED = 0b0000_0000_0001_0000;
+        const VALID_MASK = Self::MSI_X_TABLE.bits
+        | Self::MSI_X_PBA.bits
+        | Self::IS_NON_TEE_MEM.bits
+        | Self::IS_MEM_ATTR_UPDATABLE.bits
+        | Self::PRS_SUPPORTED_ENABLED.bits;
     }
 }
 
@@ -992,7 +1007,7 @@ impl Codec for MMIORangeAttribute {
 
     fn read(r: &mut codec::Reader) -> Option<Self> {
         let bits = u16::read(r)?;
-        Some(Self { bits })
+        MMIORangeAttribute::from_bits(bits & MMIORangeAttribute::VALID_MASK.bits)
     }
 }
 


### PR DESCRIPTION
When read a bitfield, its reserved field should be ignored. Currently, it is not all the case, this PR rules this out.