### PR TITLE
Add configurable target support to build scripts

### DIFF
--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -9,6 +9,7 @@ usage() {
 Usage: $(basename "$0") [OPTION]...
   -c Run check
   -b Build target
+  -t Specify target platform to be built
   -r Build and run tests
   -h Show help info
 EOM

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -72,25 +72,25 @@ build() {
 
     if [ -z "$RUSTFLAGS" ]; then
         echo "Building spdm-rs in no std with no-default-features..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features
     
         echo "Building spdm-rs in no std with spdm-ring feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring"
     
         echo "Building spdm-rs in no std with spdm-ring,is_sync feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring,is_sync"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring,is_sync"
 
         echo "Building spdm-rs in no std with spdm-ring,hashed-transcript-data feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring,hashed-transcript-data"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring,hashed-transcript-data"
     
         echo "Building spdm-rs in no std with spdm-ring,hashed-transcript-data,is_sync feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring,hashed-transcript-data,is_sync"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring,hashed-transcript-data,is_sync"
 
         echo "Building spdm-rs in no std with spdm-ring,hashed-transcript-data,mut-auth feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring,hashed-transcript-data,mut-auth"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring,hashed-transcript-data,mut-auth"
     
         echo "Building spdm-rs in no std with spdm-ring,hashed-transcript-data,mut-auth,is_sync feature..."
-        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target x86_64-unknown-none --release --no-default-features --features="spdm-ring,hashed-transcript-data,mut-auth,is_sync"
+        echo_command cargo build -Z build-std=core,alloc,compiler_builtins --target ${TARGET_OPTION} --release --no-default-features --features="spdm-ring,hashed-transcript-data,mut-auth,is_sync"
     fi
 
     popd
@@ -203,15 +203,21 @@ run() {
 CHECK_OPTION=false
 BUILD_OPTION=false
 RUN_OPTION=false
+TARGET_OPTION=x86_64-unknown-none
+PREBUILD_ARGS=""
 
 process_args() {
-    while getopts ":cbrfh" option; do
+    while getopts ":cbt:rfh" option; do
         case "${option}" in
             c)
                 CHECK_OPTION=true
             ;;
             b)
                 BUILD_OPTION=true
+            ;;
+            t)
+                TARGET_OPTION=${OPTARG}
+                PREBUILD_ARGS="-t ${TARGET_OPTION}"
             ;;
             r)
                 RUN_OPTION=true
@@ -230,7 +236,7 @@ process_args() {
 }
 
 main() {
-    ./sh_script/pre-build.sh
+    ./sh_script/pre-build.sh ${PREBUILD_ARGS}
 
     if [[ ${CHECK_OPTION} == true ]]; then
         check

--- a/sh_script/pre-build.sh
+++ b/sh_script/pre-build.sh
@@ -35,6 +35,8 @@ patch-webpki() {
     # apply the patch set for webpki
     pushd external/webpki
     git reset --hard f84a538a5cd281ba1ffc0d54bbe5824cf5969703
+    git clean -xdf
+    git apply ../patches/webpki/0001-Add-support-for-verifying-certificate-chain-with-EKU.patch
     popd
 }
 

--- a/sh_script/pre-build.sh
+++ b/sh_script/pre-build.sh
@@ -35,7 +35,6 @@ patch-webpki() {
     # apply the patch set for webpki
     pushd external/webpki
     git reset --hard f84a538a5cd281ba1ffc0d54bbe5824cf5969703
-	@@ -16,4 +43,10 @@ format-patch() {
     popd
 }
 

--- a/sh_script/pre-build.sh
+++ b/sh_script/pre-build.sh
@@ -1,19 +1,48 @@
 #!/bin/bash
 
-format-patch() {
+TARGET_OPTION="x86_64-unknown-none"
+process_args() {
+    while getopts ":t:" option; do
+        case "${option}" in
+            t)
+                TARGET_OPTION=${OPTARG}
+            ;;
+            *)
+                echo "Invalid option '-$OPTARG'"
+                exit 1
+            ;;
+        esac
+    done
+}
+
+patch-ring() {
     # apply the patch set for ring
     pushd external/ring
     git reset --hard 464d367252354418a2c17feb806876d4d89a8508
     git clean -xdf
-    git apply ../patches/ring/0001-Support-x86_64-unknown-none-target.patch
-    popd
-    
-    # apply the patch set for webpki
-    pushd external/webpki
-    git reset --hard f84a538a5cd281ba1ffc0d54bbe5824cf5969703
-    git clean -xdf
-    git apply ../patches/webpki/0001-Add-support-for-verifying-certificate-chain-with-EKU.patch
+    case "$TARGET_OPTION" in
+        "x86_64-unknown-none")
+            git apply ../patches/ring/0001-Support-x86_64-unknown-none-target.patch
+        ;;
+        *)
+            echo "Unsupported target for ring, builds may not work!"
+        ;;
+    esac
     popd
 }
 
+patch-webpki() {
+    # apply the patch set for webpki
+    pushd external/webpki
+    git reset --hard f84a538a5cd281ba1ffc0d54bbe5824cf5969703
+	@@ -16,4 +43,10 @@ format-patch() {
+    popd
+}
+
+format-patch() {
+    patch-ring
+    patch-webpki
+}
+
+process_args "$@"
 format-patch


### PR DESCRIPTION
Initial step to formalize some of the work I've done to get this working on riscv64 as per #10.

This change doesn't do much specifically for riscv64 support but allows the user to select the target for an SPDM-RS build. I've left the default as x86_64-unknown-none, since that's the only formally supported architecture at the moment.

The changes to pre_build.sh are because specific architectures might require specific patches. I had experimented with a riscv64 specific patch and expect one will be needed (as will specifics for other architectures if we ever want to support them). This also would allow an integrator to utilize the build scripts for any custom platforms they may want to add.