### PR TITLE
Test: add fuzz test for x509 parser

### DIFF
--- a/fuzz-target/fuzzlib/Cargo.toml
+++ b/fuzz-target/fuzzlib/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = "0.1.71"
 async-recursion = "1.0.4"
 spin = { version = "0.9.8" }
 executor = { path = "../../executor" }
+codec = {path= "../../codec"}
 
 [features]
 default = ["hashed-transcript-data", "afl"]

--- a/fuzz-target/fuzzlib/src/lib.rs
+++ b/fuzz-target/fuzzlib/src/lib.rs
@@ -15,10 +15,14 @@ pub use spdmlib_test::common::secret_callback::*;
 pub use spdmlib_test::common::transport::PciDoeTransportEncap;
 pub use spdmlib_test::common::util::{get_rsp_cert_chain_buff, req_create_info, rsp_create_info};
 
+pub use codec;
+pub use executor;
+pub use log::info;
 pub use spdmlib;
 pub use spdmlib::common::{SpdmDeviceIo, SpdmTransportEncap};
 pub use spdmlib::error::SpdmResult;
-pub use spdmlib::{common, config, requester, responder};
+pub use spdmlib::{common, config, error, protocol, requester, responder};
+pub use spin;
 
 pub use flexi_logger;
 pub use flexi_logger::FileSpec;

--- a/spdmlib/fuzz/Cargo.toml
+++ b/spdmlib/fuzz/Cargo.toml
@@ -247,3 +247,15 @@ name = "encapsulated_request_req"
 path = "fuzz_targets/encapsulated_request_req.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_x509v3"
+path = "fuzz_targets/fuzz_x509v3.rs"
+test = false
+doc = false
+bench = false
+
+[patch.crates-io]
+  ring = { path = "../../external/ring" }
+  webpki = { path = "../../external/webpki" }
+  mbedtls-platform-support = { path = "../../spdmlib_crypto_mbedtls/mbedtls-platform-support" }

--- a/spdmlib/fuzz/fuzz_targets/fuzz_x509v3.rs
+++ b/spdmlib/fuzz/fuzz_targets/fuzz_x509v3.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+pub use fuzzlib::*;
+
+include!("../../src/crypto/x509v3.rs");
+
+fuzz_target!(|cert: &[u8]| {
+    for f in [
+        SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+        SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+        SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
+    ] {
+        let _ = check_cert_chain_format(cert, f);
+        let _ = check_leaf_certificate(cert, true);
+        let _ = check_leaf_certificate(cert, false);
+        let _ = is_root_certificate(cert);
+    }
+});


### PR DESCRIPTION
Add tests for x509 public functions.
```
        let _ = check_cert_chain_format(cert, f);
        let _ = check_leaf_certificate(cert, true);
        let _ = check_leaf_certificate(cert, false);
        let _ = is_root_certificate(cert);
```

This test currently fails due to #15.

```
cd spdmlib
cargo fuzz run fuzz_x509v3
```

**Results:**
Input cause failure.
[48, 136, 255, 255, 255, 255, 255, 255, 255, 255]