### PR TITLE
upgrade dependency mio.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "afl",
  "async-recursion",
  "async-trait",
+ "codec",
  "executor",
  "flexi_logger",
  "futures",
@@ -1177,9 +1178,9 @@ checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",


### PR DESCRIPTION
Fix https://github.com/ccc-spdm-tools/spdm-rs/issues/45

to fix CI error:

```
This vulnerability was originally reported in the Tokio issue tracker: [tokio-rs/tokio#6369](https://github.com/tokio-rs/tokio/issues/6369)  
      This vulnerability was fixed in: [tokio-rs/mio#1760](https://github.com/tokio-rs/mio/pull/1760)
      
      Thank you to [@rofoun](https://github.com/rofoun) and [@radekvit](https://github.com/radekvit) for discovering and reporting this issue.
    = Announcement: https://github.com/tokio-rs/mio/security/advisories/GHSA-r8w9-5wcg-vfj7
    = Solution: Upgrade to >=0.8.11 (try `cargo update -p mio`)
    = mio v0.8.8
      └── tokio v1.32.0
          ├── spdm-emu v0.1.0
          │   ├── spdm-requester-emu v0.1.0
          │   └── spdm-responder-emu v0.1.0
          ├── spdm-requester-emu v0.1.0 (*)
          └── spdm-responder-emu v0.1.0 (*)
```