### PR TITLE
Fix error repoted by clippy 0.1.78

### DIFF
--- a/executor/src/executor.rs
+++ b/executor/src/executor.rs
@@ -6,7 +6,7 @@
 
 extern crate alloc;
 use {
-    alloc::{boxed::Box, collections::vec_deque::VecDeque, sync::Arc},
+    alloc::{collections::vec_deque::VecDeque, sync::Arc},
     core::{
         future::Future,
         pin::Pin,

--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -9,8 +9,6 @@
 mod executor;
 use crate::executor::*;
 use core::future::Future;
-extern crate alloc;
-use alloc::boxed::Box;
 use core::task::Poll;
 
 pub fn run<T>(future: impl Future<Output = T> + 'static + Send) -> Poll<T>

--- a/idekm/src/pci_ide_km_requester/mod.rs
+++ b/idekm/src/pci_ide_km_requester/mod.rs
@@ -6,13 +6,9 @@
 pub struct IdekmReqContext;
 
 pub mod pci_ide_km_req_query;
-pub use pci_ide_km_req_query::*;
 
 pub mod pci_ide_km_req_key_prog;
-pub use pci_ide_km_req_key_prog::*;
 
 pub mod pci_ide_km_req_key_set_go;
-pub use pci_ide_km_req_key_set_go::*;
 
 pub mod pci_ide_km_req_key_set_stop;
-pub use pci_ide_km_req_key_set_stop::*;

--- a/spdmlib/src/common/key_schedule.rs
+++ b/spdmlib/src/common/key_schedule.rs
@@ -4,10 +4,8 @@
 
 use crate::crypto;
 use crate::protocol::*;
-use codec::{Codec, Writer};
-extern crate alloc;
 use crate::secret;
-use alloc::boxed::Box;
+use codec::{Codec, Writer};
 
 const MAX_BIN_CONCAT_BUF_SIZE: usize = 2 + 8 + 12 + SPDM_MAX_HASH_SIZE;
 const SALT_0: [u8; SPDM_MAX_HASH_SIZE] = [0u8; SPDM_MAX_HASH_SIZE];

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -11,7 +11,6 @@ use crate::message::SpdmRequestResponseCode;
 use crate::{crypto, protocol::*};
 use spin::Mutex;
 extern crate alloc;
-use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::ops::DerefMut;
 

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use super::spdm_codec::SpdmCodec;
 use super::*;
-use crate::error::{SpdmStatus, SPDM_STATUS_BUFFER_FULL, SPDM_STATUS_UNSUPPORTED_CAP};
-use codec::{u24, Codec, Reader, Writer};
+use crate::error::{SpdmStatus, SPDM_STATUS_UNSUPPORTED_CAP};
+use codec::u24;
 use core::convert::TryFrom;
 
 /// This is used in SpdmOpaqueStruct <- SpdmChallengeAuthResponsePayload / SpdmMeasurementsResponsePayload

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -3,21 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use super::key_schedule::SpdmKeySchedule;
-use crate::config;
-use crate::crypto;
-use crate::error::SpdmResult;
 use crate::error::StatusCodeCrypto;
 use crate::error::SPDM_STATUS_BUFFER_TOO_SMALL;
-use crate::error::SPDM_STATUS_CRYPTO_ERROR;
 use crate::error::SPDM_STATUS_DECODE_AEAD_FAIL;
-use crate::error::SPDM_STATUS_INVALID_STATE_LOCAL;
 use crate::error::SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW;
 use crate::message::SpdmKeyExchangeMutAuthAttributes;
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use codec::enum_builder;
-use codec::{Codec, Reader, Writer};
 
 use super::*;
 

--- a/spdmlib/src/common/spdm_codec.rs
+++ b/spdmlib/src/common/spdm_codec.rs
@@ -13,8 +13,6 @@ use crate::protocol::{
 };
 use codec::{u24, Codec, Reader, Writer};
 use core::fmt::Debug;
-extern crate alloc;
-use alloc::boxed::Box;
 
 pub trait SpdmCodec: Debug + Sized {
     /// Encode yourself by appending onto `bytes`.

--- a/spdmlib/src/crypto/crypto_callbacks.rs
+++ b/spdmlib/src/crypto/crypto_callbacks.rs
@@ -4,9 +4,6 @@
 
 use crate::error::SpdmResult;
 
-extern crate alloc;
-use alloc::boxed::Box;
-
 use crate::protocol::{
     SpdmAeadAlgo, SpdmAeadIvStruct, SpdmAeadKeyStruct, SpdmBaseAsymAlgo, SpdmBaseHashAlgo,
     SpdmDheAlgo, SpdmDheExchangeStruct, SpdmDheFinalKeyStruct, SpdmDigestStruct,

--- a/spdmlib/src/crypto/mod.rs
+++ b/spdmlib/src/crypto/mod.rs
@@ -239,8 +239,6 @@ pub mod asym_verify {
 }
 
 pub mod dhe {
-    extern crate alloc;
-    use alloc::boxed::Box;
 
     use super::CRYPTO_DHE;
     use crate::crypto::{SpdmDhe, SpdmDheKeyExchange};

--- a/spdmlib/src/crypto/spdm_ring/cert_operation_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/cert_operation_impl.rs
@@ -4,7 +4,6 @@
 
 extern crate alloc;
 use alloc::vec;
-use alloc::vec::Vec;
 use core::convert::TryFrom;
 
 use crate::crypto::SpdmCertOperation;

--- a/spdmlib/src/crypto/spdm_ring/dhe_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/dhe_impl.rs
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-extern crate alloc;
-use alloc::boxed::Box;
-
 use crate::crypto::bytes_mut_scrubbed::BytesMutStrubbed;
 use crate::crypto::{SpdmDhe, SpdmDheKeyExchange};
 use crate::protocol::{SpdmDheAlgo, SpdmDheExchangeStruct, SpdmDheFinalKeyStruct};
@@ -38,9 +35,11 @@ impl SpdmDheKeyExchange for SpdmDheKeyExchangeP256 {
         let peer_public_key =
             ring::agreement::UnparsedPublicKey::new(&ring::agreement::ECDH_P256, pubkey.as_ref());
         let mut final_key = BytesMutStrubbed::new();
-        match ring::agreement::agree_ephemeral(self.0, &peer_public_key, |key_material| {
-            final_key.extend_from_slice(key_material);
-        }) {
+        let agree_ephemeral_result =
+            ring::agreement::agree_ephemeral(self.0, &peer_public_key, |key_material| {
+                final_key.extend_from_slice(key_material);
+            });
+        match agree_ephemeral_result {
             Ok(()) => Some(SpdmDheFinalKeyStruct::from(final_key)),
             Err(_) => None,
         }
@@ -76,9 +75,11 @@ impl SpdmDheKeyExchange for SpdmDheKeyExchangeP384 {
         let peer_public_key =
             ring::agreement::UnparsedPublicKey::new(&ring::agreement::ECDH_P384, pubkey.as_ref());
         let mut final_key = BytesMutStrubbed::new();
-        match ring::agreement::agree_ephemeral(self.0, &peer_public_key, |key_material| {
-            final_key.extend_from_slice(key_material);
-        }) {
+        let agree_ephemeral_result =
+            ring::agreement::agree_ephemeral(self.0, &peer_public_key, |key_material| {
+                final_key.extend_from_slice(key_material);
+            });
+        match agree_ephemeral_result {
             Ok(()) => Some(SpdmDheFinalKeyStruct::from(final_key)),
             Err(_) => None,
         }

--- a/spdmlib/src/crypto/spdm_ring/hash_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hash_impl.rs
@@ -35,7 +35,6 @@ fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestS
 #[cfg(feature = "hashed-transcript-data")]
 mod hash_ext {
     use super::*;
-    use alloc::boxed::Box;
     use alloc::collections::BTreeMap;
     use lazy_static::lazy_static;
     use spin::Mutex;

--- a/spdmlib/src/lib.rs
+++ b/spdmlib/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(stmt_expr_attributes)]
 #![feature(try_trait_v2)]
-#![feature(async_fn_in_trait)]
 
 #[macro_use]
 extern crate log;

--- a/spdmlib/src/message/capability.rs
+++ b/spdmlib/src/message/capability.rs
@@ -2,11 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use crate::common::spdm_codec::SpdmCodec;
-use crate::error::SPDM_STATUS_BUFFER_FULL;
+use crate::common;
 use crate::message::*;
-use crate::{common, error::SpdmStatus};
-use codec::{Codec, Reader, Writer};
 
 #[derive(Debug, Clone, Default)]
 pub struct SpdmGetCapabilitiesRequestPayload {

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -6,9 +6,6 @@ use crate::config;
 use crate::crypto::bytes_mut_scrubbed::BytesMutStrubbed;
 use bytes::BytesMut;
 use codec::{enum_builder, u24, Codec, Reader, Writer};
-use core::convert::From;
-extern crate alloc;
-use alloc::boxed::Box;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 pub const SHA256_DIGEST_SIZE: usize = 32;

--- a/spdmlib/src/protocol/mod.rs
+++ b/spdmlib/src/protocol/mod.rs
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-extern crate alloc;
-use alloc::vec::Vec;
-
 use core::convert::TryInto;
 
 mod algo;

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -7,8 +7,6 @@ use crate::error::*;
 use crate::message::*;
 use crate::protocol::*;
 use crate::requester::*;
-extern crate alloc;
-use alloc::boxed::Box;
 
 impl RequesterContext {
     #[maybe_async::maybe_async]

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -214,8 +214,8 @@ impl RequesterContext {
 
         let result = self.verify_spdm_certificate_chain();
         if result.is_ok() {
-            self.common.peer_info.peer_cert_chain[slot_id as usize] =
-                self.common.peer_info.peer_cert_chain_temp.clone();
+            self.common.peer_info.peer_cert_chain[slot_id as usize]
+                .clone_from(&self.common.peer_info.peer_cert_chain_temp);
         }
         self.common.peer_info.peer_cert_chain_temp = None;
         result

--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-extern crate alloc;
-use alloc::boxed::Box;
 use core::ops::DerefMut;
 
 use crate::common::session::SpdmSession;
@@ -23,7 +21,6 @@ use crate::crypto;
 
 use crate::error::SpdmResult;
 use crate::message::*;
-use crate::protocol::{SpdmMeasurementSummaryHashType, SpdmSignatureStruct, SpdmVersion};
 
 impl RequesterContext {
     #[maybe_async::maybe_async]
@@ -104,14 +101,7 @@ impl RequesterContext {
             versions_list: [SecuredMessageVersion::default(); MAX_SECURE_SPDM_VERSION_COUNT],
         };
 
-        for (_, local_version) in self
-            .common
-            .config_info
-            .secure_spdm_version
-            .iter()
-            .flatten()
-            .enumerate()
-        {
+        for local_version in self.common.config_info.secure_spdm_version.iter().flatten() {
             secured_message_version_list.versions_list
                 [secured_message_version_list.version_count as usize] = *local_version;
             secured_message_version_list.version_count += 1;

--- a/spdmlib/src/requester/psk_exchange_req.rs
+++ b/spdmlib/src/requester/psk_exchange_req.rs
@@ -11,7 +11,6 @@ use crate::error::{
     SPDM_STATUS_INVALID_PARAMETER, SPDM_STATUS_SESSION_NUMBER_EXCEED, SPDM_STATUS_VERIF_FAIL,
 };
 use crate::message::*;
-use crate::protocol::SpdmMeasurementSummaryHashType;
 use crate::protocol::*;
 use crate::requester::*;
 extern crate alloc;
@@ -91,14 +90,7 @@ impl RequesterContext {
             versions_list: [SecuredMessageVersion::default(); MAX_SECURE_SPDM_VERSION_COUNT],
         };
 
-        for (_, local_version) in self
-            .common
-            .config_info
-            .secure_spdm_version
-            .iter()
-            .flatten()
-            .enumerate()
-        {
+        for local_version in self.common.config_info.secure_spdm_version.iter().flatten() {
             secured_message_version_list.versions_list
                 [secured_message_version_list.version_count as usize] = *local_version;
             secured_message_version_list.version_count += 1;

--- a/spdmlib/src/requester/psk_finish_req.rs
+++ b/spdmlib/src/requester/psk_finish_req.rs
@@ -9,8 +9,6 @@ use crate::error::{
 use crate::message::*;
 use crate::protocol::*;
 use crate::requester::*;
-extern crate alloc;
-use alloc::boxed::Box;
 
 impl RequesterContext {
     #[maybe_async::maybe_async]

--- a/spdmlib/src/responder/digest_rsp.rs
+++ b/spdmlib/src/responder/digest_rsp.rs
@@ -5,16 +5,13 @@
 use crate::common::SpdmCodec;
 use crate::common::SpdmConnectionState;
 use crate::crypto;
+use crate::error::SpdmResult;
 use crate::error::SPDM_STATUS_INVALID_MSG_FIELD;
 use crate::error::SPDM_STATUS_INVALID_STATE_LOCAL;
 use crate::error::SPDM_STATUS_INVALID_STATE_PEER;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
-extern crate alloc;
-use crate::error::SpdmResult;
-use crate::protocol::gen_array_clone;
-use alloc::boxed::Box;
 
 impl ResponderContext {
     pub fn handle_spdm_digest<'a>(

--- a/spdmlib/src/responder/finish_rsp.rs
+++ b/spdmlib/src/responder/finish_rsp.rs
@@ -5,16 +5,10 @@
 use crate::common::session::SpdmSession;
 use crate::common::{ManagedBuffer12Sign, SpdmCodec};
 use crate::crypto;
-use crate::error::SpdmResult;
-use crate::error::SPDM_STATUS_CRYPTO_ERROR;
-use crate::error::SPDM_STATUS_INVALID_MSG_FIELD;
-use crate::error::SPDM_STATUS_INVALID_STATE_LOCAL;
 use crate::error::*;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
-extern crate alloc;
-use alloc::boxed::Box;
 
 impl ResponderContext {
     pub fn handle_spdm_finish<'a>(

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+use crate::common::opaque::SpdmOpaqueStruct;
 use crate::common::session::SpdmSession;
 #[cfg(feature = "hashed-transcript-data")]
 use crate::common::ManagedBuffer12Sign;
@@ -15,13 +16,10 @@ use crate::error::{
     SpdmResult, SPDM_STATUS_BUFFER_FULL, SPDM_STATUS_CRYPTO_ERROR, SPDM_STATUS_INVALID_MSG_FIELD,
     SPDM_STATUS_INVALID_STATE_LOCAL, SPDM_STATUS_INVALID_STATE_PEER,
 };
+use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
-extern crate alloc;
-use crate::common::opaque::SpdmOpaqueStruct;
-use crate::message::*;
 use crate::secret;
-use alloc::boxed::Box;
 use core::convert::TryFrom;
 use core::ops::DerefMut;
 
@@ -150,13 +148,8 @@ impl ResponderContext {
                 }
                 let mut selected_version: Option<SecuredMessageVersion> = None;
                 for index in 0..secured_message_version_list.version_count as usize {
-                    for (_, local_version) in self
-                        .common
-                        .config_info
-                        .secure_spdm_version
-                        .iter()
-                        .flatten()
-                        .enumerate()
+                    for local_version in
+                        self.common.config_info.secure_spdm_version.iter().flatten()
                     {
                         if secured_message_version_list.versions_list[index] == *local_version {
                             selected_version = Some(*local_version);

--- a/spdmlib/src/responder/psk_exchange_rsp.rs
+++ b/spdmlib/src/responder/psk_exchange_rsp.rs
@@ -18,11 +18,9 @@ use crate::error::SPDM_STATUS_INVALID_STATE_PEER;
 use crate::message::*;
 use crate::protocol::*;
 use crate::responder::*;
+use crate::secret;
 use crate::watchdog::start_watchdog;
 use config::MAX_SPDM_PSK_CONTEXT_SIZE;
-extern crate alloc;
-use crate::secret;
-use alloc::boxed::Box;
 use core::convert::TryFrom;
 use core::ops::DerefMut;
 
@@ -145,13 +143,8 @@ impl ResponderContext {
 
                 let mut selected_version: Option<SecuredMessageVersion> = None;
                 for index in 0..secured_message_version_list.version_count as usize {
-                    for (_, local_version) in self
-                        .common
-                        .config_info
-                        .secure_spdm_version
-                        .iter()
-                        .flatten()
-                        .enumerate()
+                    for local_version in
+                        self.common.config_info.secure_spdm_version.iter().flatten()
                     {
                         if secured_message_version_list.versions_list[index] == *local_version {
                             selected_version = Some(*local_version);

--- a/spdmlib/src/responder/version_rsp.rs
+++ b/spdmlib/src/responder/version_rsp.rs
@@ -76,14 +76,7 @@ impl ResponderContext {
         info!("send spdm version\n");
         let mut version_number_entry_count = 0;
         let mut versions = gen_array_clone(SpdmVersionStruct::default(), MAX_SPDM_VERSION_COUNT);
-        for (_, v) in self
-            .common
-            .config_info
-            .spdm_version
-            .iter()
-            .flatten()
-            .enumerate()
-        {
+        for v in self.common.config_info.spdm_version.iter().flatten() {
             versions[version_number_entry_count] = SpdmVersionStruct {
                 update: 0,
                 version: *v,

--- a/test/spdm-emu/src/async_runtime.rs
+++ b/test/spdm-emu/src/async_runtime.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-extern crate alloc;
-use alloc::boxed::Box;
 use core::{future::Future, pin::Pin};
 
 // Run async task

--- a/test/spdm-emu/src/secret_impl_sample.rs
+++ b/test/spdm-emu/src/secret_impl_sample.rs
@@ -13,10 +13,6 @@ use spdmlib::crypto;
 use spdmlib::crypto::hash;
 use spdmlib::message::*;
 use spdmlib::protocol::*;
-use spdmlib::protocol::{
-    SpdmBaseHashAlgo, SpdmDigestStruct, SpdmHkdfOutputKeyingMaterial,
-    SpdmMeasurementRecordStructure, SpdmMeasurementSpecification, SpdmMeasurementSummaryHashType,
-};
 use spdmlib::secret::*;
 
 pub static SECRET_MEASUREMENT_IMPL_INSTANCE: SpdmSecretMeasurement = SpdmSecretMeasurement {

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -18,7 +18,6 @@ use idekm::pci_idekm::KEY_SUB_STREAM_CPL;
 use idekm::pci_idekm::KEY_SUB_STREAM_NPR;
 use idekm::pci_idekm::KEY_SUB_STREAM_PR;
 use idekm::pci_idekm::PCI_IDE_KM_IDE_REG_BLOCK_MAX_COUNT;
-use log::LevelFilter;
 use log::*;
 use simple_logger::SimpleLogger;
 

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -183,7 +183,7 @@ fn emu_main_inner() {
     let mctp_transport_encap: Arc<Mutex<(dyn SpdmTransportEncap + Send + Sync)>> =
         Arc::new(Mutex::new(MctpTransportEncap {}));
 
-    for stream in listener.incoming() {
+    if let Some(stream) = listener.incoming().next() {
         let stream = stream.expect("Read stream error!");
         let stream = Arc::new(Mutex::new(stream));
         println!("new connection!");


### PR DESCRIPTION
Fix: #44 

Version: clippy 0.1.78 (4a0cc88 2024-03-11)
`cargo clippy -- -D warnings -A clippy::only-used-in-recursion -A incomplete-features -A clippy::bad_bit_mask -A clippy::derivable_impls`