### PR TITLE
Create explicit crypto_null stub files for crypto platform functionality.

### DIFF
--- a/spdmlib/src/crypto/crypto_null/aead_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/aead_impl.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::crypto::SpdmAead;
-use crate::error::{SpdmResult};
+use crate::error::SpdmResult;
 
 use crate::protocol::{SpdmAeadAlgo, SpdmAeadIvStruct, SpdmAeadKeyStruct};
 

--- a/spdmlib/src/crypto/crypto_null/aead_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/aead_impl.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmAead;
+use crate::error::{SpdmResult};
+
+use crate::protocol::{SpdmAeadAlgo, SpdmAeadIvStruct, SpdmAeadKeyStruct};
+
+pub static DEFAULT: SpdmAead = SpdmAead {
+    encrypt_cb: encrypt,
+    decrypt_cb: decrypt,
+};
+
+fn encrypt(
+    aead_algo: SpdmAeadAlgo,
+    key: &SpdmAeadKeyStruct,
+    iv: &SpdmAeadIvStruct,
+    aad: &[u8],
+    plain_text: &[u8],
+    tag: &mut [u8],
+    cipher_text: &mut [u8],
+) -> SpdmResult<(usize, usize)> {
+    unimplemented!()
+}
+
+fn decrypt(
+    aead_algo: SpdmAeadAlgo,
+    key: &SpdmAeadKeyStruct,
+    iv: &SpdmAeadIvStruct,
+    aad: &[u8],
+    cipher_text: &[u8],
+    tag: &[u8],
+    plain_text: &mut [u8],
+) -> SpdmResult<usize> {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/asym_verify_impl.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::{SpdmAsymVerify};
+use crate::error::{SpdmResult};
+use crate::protocol::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct};
+
+pub static DEFAULT: SpdmAsymVerify = SpdmAsymVerify {
+    verify_cb: asym_verify,
+};
+
+fn asym_verify(
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    public_cert_der: &[u8],
+    data: &[u8],
+    signature: &SpdmSignatureStruct,
+) -> SpdmResult {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/asym_verify_impl.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use crate::crypto::{SpdmAsymVerify};
-use crate::error::{SpdmResult};
+use crate::crypto::SpdmAsymVerify;
+use crate::error::SpdmResult;
 use crate::protocol::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmSignatureStruct};
 
 pub static DEFAULT: SpdmAsymVerify = SpdmAsymVerify {

--- a/spdmlib/src/crypto/crypto_null/cert_operation_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/cert_operation_impl.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmCertOperation;
+use crate::error::{SpdmResult};
+
+pub static DEFAULT: SpdmCertOperation = SpdmCertOperation {
+    get_cert_from_cert_chain_cb: get_cert_from_cert_chain,
+    verify_cert_chain_cb: verify_cert_chain,
+};
+
+fn get_cert_from_cert_chain(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)> {
+    unimplemented!()
+}
+
+fn verify_cert_chain(cert_chain: &[u8]) -> SpdmResult {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/cert_operation_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/cert_operation_impl.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::crypto::SpdmCertOperation;
-use crate::error::{SpdmResult};
+use crate::error::SpdmResult;
 
 pub static DEFAULT: SpdmCertOperation = SpdmCertOperation {
     get_cert_from_cert_chain_cb: get_cert_from_cert_chain,

--- a/spdmlib/src/crypto/crypto_null/dhe_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/dhe_impl.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+extern crate alloc;
+use alloc::boxed::Box;
+
+use crate::crypto::{SpdmDhe, SpdmDheKeyExchange};
+use crate::protocol::{SpdmDheAlgo, SpdmDheExchangeStruct};
+
+pub static DEFAULT: SpdmDhe = SpdmDhe {
+    generate_key_pair_cb: generate_key_pair,
+};
+
+fn generate_key_pair(
+    dhe_algo: SpdmDheAlgo,
+) -> Option<(SpdmDheExchangeStruct, Box<dyn SpdmDheKeyExchange + Send>)> {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/hash_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hash_impl.rs
@@ -24,7 +24,8 @@ fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestS
 
 #[cfg(feature = "hashed-transcript-data")]
 mod hash_ext {
-    use crate::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
+    use crate::error::SpdmResult;
+    use crate::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
 
     pub fn hash_ctx_update(handle: usize, data: &[u8]) -> SpdmResult {
         unimplemented!()
@@ -39,10 +40,6 @@ mod hash_ext {
     }
 
     pub fn hash_ctx_init(base_hash_algo: SpdmBaseHashAlgo) -> Option<usize> {
-        unimplemented!()
-    }
-
-    fn insert_to_table(value: Box<HashCtxConcrete>) -> usize {
         unimplemented!()
     }
 }

--- a/spdmlib/src/crypto/crypto_null/hash_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hash_impl.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmHash;
+use crate::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
+
+#[cfg(not(feature = "hashed-transcript-data"))]
+pub static DEFAULT: SpdmHash = SpdmHash {
+    hash_all_cb: hash_all,
+};
+#[cfg(feature = "hashed-transcript-data")]
+pub static DEFAULT: SpdmHash = SpdmHash {
+    hash_all_cb: hash_all,
+    hash_ctx_init_cb: hash_ext::hash_ctx_init,
+    hash_ctx_update_cb: hash_ext::hash_ctx_update,
+    hash_ctx_finalize_cb: hash_ext::hash_ctx_finalize,
+    hash_ctx_dup_cb: hash_ext::hash_ctx_dup,
+};
+
+fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestStruct> {
+    unimplemented!()
+}
+
+#[cfg(feature = "hashed-transcript-data")]
+mod hash_ext {
+    use crate::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
+
+    pub fn hash_ctx_update(handle: usize, data: &[u8]) -> SpdmResult {
+        unimplemented!()
+    }
+
+    pub fn hash_ctx_finalize(handle: usize) -> Option<SpdmDigestStruct> {
+        unimplemented!()
+    }
+
+    pub fn hash_ctx_dup(handle: usize) -> Option<usize> {
+        unimplemented!()
+    }
+
+    pub fn hash_ctx_init(base_hash_algo: SpdmBaseHashAlgo) -> Option<usize> {
+        unimplemented!()
+    }
+
+    fn insert_to_table(value: Box<HashCtxConcrete>) -> usize {
+        unimplemented!()
+    }
+}

--- a/spdmlib/src/crypto/crypto_null/hkdf_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hkdf_impl.rs
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmHkdf;
+use crate::protocol::{
+    SpdmBaseHashAlgo, SpdmHkdfInputKeyingMaterial, SpdmHkdfOutputKeyingMaterial,
+    SpdmHkdfPseudoRandomKey
+};
+
+pub static DEFAULT: SpdmHkdf = SpdmHkdf {
+    hkdf_extract_cb: hkdf_extract,
+    hkdf_expand_cb: hkdf_expand,
+};
+
+fn hkdf_extract(
+    hash_algo: SpdmBaseHashAlgo,
+    salt: &[u8],
+    ikm: &SpdmHkdfInputKeyingMaterial,
+) -> Option<SpdmHkdfPseudoRandomKey> {
+    unimplemented!()
+}
+
+fn hkdf_expand(
+    hash_algo: SpdmBaseHashAlgo,
+    prk: &SpdmHkdfPseudoRandomKey,
+    info: &[u8],
+    out_size: u16,
+) -> Option<SpdmHkdfOutputKeyingMaterial> {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/hkdf_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hkdf_impl.rs
@@ -5,7 +5,7 @@
 use crate::crypto::SpdmHkdf;
 use crate::protocol::{
     SpdmBaseHashAlgo, SpdmHkdfInputKeyingMaterial, SpdmHkdfOutputKeyingMaterial,
-    SpdmHkdfPseudoRandomKey
+    SpdmHkdfPseudoRandomKey,
 };
 
 pub static DEFAULT: SpdmHkdf = SpdmHkdf {

--- a/spdmlib/src/crypto/crypto_null/hmac_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hmac_impl.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmHmac;
+use crate::error::{SpdmResult};
+use crate::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
+
+pub static DEFAULT: SpdmHmac = SpdmHmac {
+    hmac_cb: hmac,
+    hmac_verify_cb: hmac_verify,
+};
+
+fn hmac(base_hash_algo: SpdmBaseHashAlgo, key: &[u8], data: &[u8]) -> Option<SpdmDigestStruct> {
+    unimplemented!()
+}
+
+fn hmac_verify(
+    base_hash_algo: SpdmBaseHashAlgo,
+    key: &[u8],
+    data: &[u8],
+    hmac: &SpdmDigestStruct,
+) -> SpdmResult {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/hmac_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/hmac_impl.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::crypto::SpdmHmac;
-use crate::error::{SpdmResult};
+use crate::error::SpdmResult;
 use crate::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
 
 pub static DEFAULT: SpdmHmac = SpdmHmac {

--- a/spdmlib/src/crypto/crypto_null/mod.rs
+++ b/spdmlib/src/crypto/crypto_null/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+// Since crypto implementations are null, all variables will be unused.
+#![allow(unused_variables)]
+
+pub mod aead_impl;
+pub mod asym_verify_impl;
+pub mod cert_operation_impl;
+pub mod dhe_impl;
+pub mod hash_impl;
+pub mod hkdf_impl;
+pub mod hmac_impl;
+pub mod rand_impl;

--- a/spdmlib/src/crypto/crypto_null/rand_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/rand_impl.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+use crate::crypto::SpdmCryptoRandom;
+use crate::error::{SpdmResult};
+
+pub static DEFAULT: SpdmCryptoRandom = SpdmCryptoRandom {
+    get_random_cb: get_random,
+};
+
+fn get_random(data: &mut [u8]) -> SpdmResult<usize> {
+    unimplemented!()
+}

--- a/spdmlib/src/crypto/crypto_null/rand_impl.rs
+++ b/spdmlib/src/crypto/crypto_null/rand_impl.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::crypto::SpdmCryptoRandom;
-use crate::error::{SpdmResult};
+use crate::error::SpdmResult;
 
 pub static DEFAULT: SpdmCryptoRandom = SpdmCryptoRandom {
     get_random_cb: get_random,

--- a/spdmlib/src/crypto/mod.rs
+++ b/spdmlib/src/crypto/mod.rs
@@ -141,7 +141,7 @@ pub mod hmac {
 
     #[cfg(not(any(feature = "spdm-ring")))]
     use super::crypto_null::hmac_impl::DEFAULT;
-    
+
     #[cfg(feature = "spdm-ring")]
     use super::spdm_ring::hmac_impl::DEFAULT;
 


### PR DESCRIPTION
Part of a long series of planned changes to address #10. As spdm_ring doesn't build on riscv64, we cannot use it as a crypto implementation backend. In general, an integrator of the library onto an embedded platform (like riscv64) will want to implement their own crypto hooks, for example with HW accelerators.

Because of this, we want to make it obvious for an integrator as to what functions they would need to provide in order to create their own platform implementation. This change does not modify functionality so much as it does serve as a minor refactor of where the NULL implementations of crypto platform APIs are located. This is done to be more intuitive to an integrator as to how they could add another crypto library, and what functions they would need to implement.

In the long run, it would be desirable to create similar null or stub implementations of all platform functionalities which rely on external crates which may not be usable on an embedded platform.

Note that I did not add crypto_null as a feature, as it seems Rust features are meant to only be additive, and not require mutual exclusivity (as crypto backends would require). This would be an issue in the long term if we are to formally support another crypto implementation upstream, outside of spdm-ring.
