### PR TITLE
Fix error caused by check_for_redundant_imports clippy logic

### DIFF
--- a/executor/src/lib.rs
+++ b/executor/src/lib.rs
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //
 
-#![cfg_attr(any(target_os = "uefi", target_os = "none"), no_std)]
+#![no_std]
+#[cfg(feature = "std")]
+extern crate std;
 
 mod executor;
 use crate::executor::*;

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -1093,6 +1093,7 @@ impl SpdmSession {
 
 #[cfg(test)]
 mod tests_session {
+    extern crate std;
     use super::*;
 
     #[test]
@@ -1110,7 +1111,7 @@ mod tests_session {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         session.set_session_state(crate::common::session::SpdmSessionState::SpdmSessionHandshaking);
-        println!("session.session_id::{:?}", session.session_id);
+        std::println!("session.session_id::{:?}", session.session_id);
         assert!(session
             .set_dhe_secret(
                 SpdmVersion::SpdmVersion12,
@@ -1177,7 +1178,7 @@ mod tests_session {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         session.set_session_state(crate::common::session::SpdmSessionState::SpdmSessionHandshaking);
-        println!("session.session_id::{:?}", session.session_id);
+        std::println!("session.session_id::{:?}", session.session_id);
         assert!(session
             .set_dhe_secret(
                 SpdmVersion::SpdmVersion12,
@@ -1244,7 +1245,7 @@ mod tests_session {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         session.set_session_state(crate::common::session::SpdmSessionState::SpdmSessionHandshaking);
-        println!("session.session_id::{:?}", session.session_id);
+        std::println!("session.session_id::{:?}", session.session_id);
         assert!(session
             .set_dhe_secret(
                 SpdmVersion::SpdmVersion12,
@@ -1312,7 +1313,7 @@ mod tests_session {
             SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         );
         session.set_session_state(crate::common::session::SpdmSessionState::SpdmSessionHandshaking);
-        println!("session.session_id::{:?}", session.session_id);
+        std::println!("session.session_id::{:?}", session.session_id);
         assert!(session
             .set_dhe_secret(
                 SpdmVersion::SpdmVersion12,
@@ -1451,7 +1452,7 @@ mod tests_session {
         );
         session.set_session_state(crate::common::session::SpdmSessionState::SpdmSessionHandshaking);
         session.transport_param.sequence_number_count = 1;
-        println!("session.session_id::{:?}", session.session_id);
+        std::println!("session.session_id::{:?}", session.session_id);
         assert!(session
             .set_dhe_secret(
                 SpdmVersion::SpdmVersion12,

--- a/spdmlib/src/crypto/crypto_tests.rs
+++ b/spdmlib/src/crypto/crypto_tests.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+extern crate std;
+use std::{boxed::Box, string::String, vec::Vec};
+
 use super::aead::{decrypt, encrypt};
 #[cfg(feature = "hashed-transcript-data")]
 use super::hash;
@@ -217,5 +220,5 @@ fn from_hex_digit(d: u8) -> Result<u8, String> {
             return Ok(d - range.start() + offset);
         }
     }
-    Err(format!("Invalid hex digit '{}'", d as char))
+    Err(std::format!("Invalid hex digit '{}'", d as char))
 }

--- a/spdmlib/src/crypto/spdm_ring/aead_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/aead_impl.rs
@@ -159,6 +159,8 @@ fn make_key<K: ring::aead::BoundKey<OneNonceSequence>>(
 mod tests {
     use super::*;
     use crate::protocol::*;
+    extern crate std;
+    use std::boxed::Box;
 
     #[test]
     fn test_case0_encrypt() {
@@ -216,7 +218,7 @@ mod tests {
         let aad = &mut [100u8; 16];
         let cipher_text = &mut [100u8; 16];
         let ret_tag_size = encrypt(aead_algo, key, iv, aad, plain_text, tag, cipher_text);
-        println!("ret_tag_size{:?}", ret_tag_size);
+        std::println!("ret_tag_size{:?}", ret_tag_size);
     }
     #[test]
     fn test_case3_encrypt() {
@@ -234,7 +236,7 @@ mod tests {
         let aad = &mut [100u8; 16];
         let cipher_text = &mut [100u8; 16];
         let ret_tag_size = encrypt(aead_algo, key, iv, aad, plain_text, tag, cipher_text);
-        println!("ret_tag_size{:?}", ret_tag_size);
+        std::println!("ret_tag_size{:?}", ret_tag_size);
     }
     #[test]
     fn test_case4_encrypt() {
@@ -252,7 +254,7 @@ mod tests {
         let aad = &mut [100u8; 16];
         let cipher_text = &mut [100u8; 16];
         let ret_tag_size = encrypt(aead_algo, key, iv, aad, plain_text, tag, cipher_text);
-        println!("ret_tag_size{:?}", ret_tag_size);
+        std::println!("ret_tag_size{:?}", ret_tag_size);
     }
     #[test]
     fn test_case5_encrypt() {
@@ -270,7 +272,7 @@ mod tests {
         let aad = &mut [100u8; 16];
         let cipher_text = &mut [100u8; 1];
         let ret_tag_size = encrypt(aead_algo, key, iv, aad, plain_text, tag, cipher_text);
-        println!("ret_tag_size{:?}", ret_tag_size);
+        std::println!("ret_tag_size{:?}", ret_tag_size);
     }
     #[test]
     fn test_case6_encrypt() {
@@ -288,7 +290,7 @@ mod tests {
         let aad = &mut [100u8; 16];
         let cipher_text = &mut [100u8; 1];
         let ret_tag_size = encrypt(aead_algo, key, iv, aad, plain_text, tag, cipher_text);
-        println!("ret_tag_size{:?}", ret_tag_size);
+        std::println!("ret_tag_size{:?}", ret_tag_size);
     }
     #[test]
     #[should_panic]

--- a/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
@@ -90,8 +90,9 @@ impl ring::hkdf::KeyType for SpdmCryptoHkdfKeyLen {
 #[cfg(test)]
 mod tests {
     use crate::protocol::SPDM_MAX_HASH_SIZE;
-
+    extern crate alloc;
     use super::*;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_hkdf_expand() {

--- a/spdmlib/src/crypto/spdm_ring/hmac_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hmac_impl.rs
@@ -52,8 +52,9 @@ fn hmac_verify(
 #[cfg(test)]
 mod tests {
     use crate::protocol::{SpdmFinishedKeyStruct, SPDM_MAX_HASH_SIZE};
-
+    extern crate alloc;
     use super::*;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_hmac_verify() {

--- a/spdmlib/src/crypto/spdm_ring/mod.rs
+++ b/spdmlib/src/crypto/spdm_ring/mod.rs
@@ -10,3 +10,4 @@ pub mod hash_impl;
 pub mod hkdf_impl;
 pub mod hmac_impl;
 pub mod rand_impl;
+extern crate alloc;

--- a/spdmlib/src/crypto/x509v3.rs
+++ b/spdmlib/src/crypto/x509v3.rs
@@ -925,6 +925,7 @@ pub fn check_leaf_certificate(cert: &[u8], is_alias_cert_model: bool) -> SpdmRes
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use super::*;
 
     #[test]

--- a/spdmlib/src/lib.rs
+++ b/spdmlib/src/lib.rs
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+#![no_std]
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
 #![feature(stmt_expr_attributes)]
 #![feature(try_trait_v2)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[macro_use]
 extern crate log;

--- a/spdmlib/src/message/challenge.rs
+++ b/spdmlib/src/message/challenge.rs
@@ -166,6 +166,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_challenge_request_payload() {

--- a/spdmlib/src/message/digest.rs
+++ b/spdmlib/src/message/digest.rs
@@ -99,6 +99,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_digests_response_payload() {

--- a/spdmlib/src/message/finish.rs
+++ b/spdmlib/src/message/finish.rs
@@ -149,6 +149,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_finish_request_payload() {

--- a/spdmlib/src/message/key_exchange.rs
+++ b/spdmlib/src/message/key_exchange.rs
@@ -269,6 +269,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_key_exchange_mut_auth_attributes() {

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -582,6 +582,7 @@ mod tests {
     use codec::u24;
     use testlib::{create_spdm_context, new_spdm_message, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_message_header() {

--- a/spdmlib/src/message/mod_test.common.inc.rs
+++ b/spdmlib/src/message/mod_test.common.inc.rs
@@ -8,6 +8,7 @@ use crate::message::SpdmMessage;
 use codec::{Reader, Writer};
 use spin::Mutex;
 extern crate alloc;
+use alloc::boxed::Box;
 use alloc::sync::Arc;
 
 #[allow(unused, unused_mut)]

--- a/spdmlib/src/message/psk_exchange.rs
+++ b/spdmlib/src/message/psk_exchange.rs
@@ -284,6 +284,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_psk_exchange_request_payload() {

--- a/spdmlib/src/message/psk_finish.rs
+++ b/spdmlib/src/message/psk_finish.rs
@@ -74,6 +74,7 @@ mod tests {
     use crate::protocol::*;
     use testlib::{create_spdm_context, DeviceIO, TransportEncap};
     extern crate alloc;
+    use alloc::boxed::Box;
 
     #[test]
     fn test_case0_spdm_psk_finish_request_payload() {

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -6,7 +6,6 @@ use crate::config;
 use crate::crypto::bytes_mut_scrubbed::BytesMutStrubbed;
 use bytes::BytesMut;
 use codec::{enum_builder, u24, Codec, Reader, Writer};
-use core::convert::From;
 extern crate alloc;
 use alloc::boxed::Box;
 use zeroize::{Zeroize, ZeroizeOnDrop};

--- a/spdmlib_crypto_mbedtls/src/aead_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/aead_impl.rs
@@ -5,6 +5,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
 use mbedtls::cipher::{raw, Authenticated, Cipher, Decryption, Encryption, Fresh};
 use spdmlib::crypto::SpdmAead;
 use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_PARAMETER};
@@ -130,6 +133,9 @@ mod test {
             SpdmAeadIvStruct, SpdmAeadKeyStruct, SPDM_MAX_AEAD_IV_SIZE, SPDM_MAX_AEAD_KEY_SIZE,
         },
     };
+    extern crate std;
+    use std::{boxed::Box, string::String};
+
     #[test]
     fn test_case_gcm256() {
         // Test vector from GCM Test Vectors (SP 800-38D)
@@ -234,6 +240,6 @@ mod test {
                 return Ok(d - range.start() + offset);
             }
         }
-        Err(format!("Invalid hex digit '{}'", d as char))
+        Err(std::format!("Invalid hex digit '{}'", d as char))
     }
 }

--- a/spdmlib_crypto_mbedtls/src/dhe_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/dhe_impl.rs
@@ -5,6 +5,9 @@
 #[cfg(not(feature = "std"))]
 use alloc::{boxed::Box, vec::Vec};
 
+#[cfg(feature = "std")]
+use std::{boxed::Box, vec::Vec};
+
 use mbedtls::ecp::EcPoint;
 use mbedtls::pk::{EcGroup, EcGroupId, Pk};
 use mbedtls::rng::RngCallback;

--- a/spdmlib_crypto_mbedtls/src/hash_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hash_impl.rs
@@ -13,8 +13,7 @@ pub use hash_ext::DEFAULT;
 mod hash_ext {
     extern crate alloc;
     use super::*;
-    use alloc::boxed::Box;
-    use alloc::collections::BTreeMap;
+    use alloc::{boxed::Box, collections::BTreeMap};
     use lazy_static::lazy_static;
     use spdmlib::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
     use spin::Mutex;
@@ -106,8 +105,9 @@ fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestS
 
 #[test]
 fn test_case1_hash_all() {
+    extern crate std;
     use std::fmt::Write;
-    use std::string::String;
+    use std::string::{String, ToString};
     let base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
     let data = &b"hello"[..];
 
@@ -116,7 +116,7 @@ fn test_case1_hash_all() {
     for d in hash_all.as_ref() {
         let _ = write!(&mut res, "{:02x}", d);
     }
-    println!("res: {}", String::from_utf8_lossy(res.as_ref()));
+    std::println!("res: {}", String::from_utf8_lossy(res.as_ref()));
     assert_eq!(hash_all.data_size, 32);
 
     assert_eq!(

--- a/spdmlib_crypto_mbedtls/src/hkdf_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hkdf_impl.rs
@@ -85,8 +85,10 @@ fn hkdf_expand(
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
     use super::*;
     use spdmlib::protocol::{SpdmBaseHashAlgo, SPDM_MAX_HASH_SIZE};
+    use std::boxed::Box;
     #[test]
     fn test_case0_hkdf_expand() {
         let base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;

--- a/spdmlib_crypto_mbedtls/src/hmac_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hmac_impl.rs
@@ -43,8 +43,9 @@ fn hmac_verify(
 #[cfg(test)]
 mod tests {
     use spdmlib::protocol::{SpdmFinishedKeyStruct, SPDM_MAX_HASH_SIZE};
-
+    extern crate std;
     use super::*;
+    use std::boxed::Box;
     #[test]
     fn test_case_rfc4231_2() {
         let key = &mut SpdmFinishedKeyStruct {

--- a/spdmlib_crypto_mbedtls/src/lib.rs
+++ b/spdmlib_crypto_mbedtls/src/lib.rs
@@ -2,10 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod aead_impl;
 

--- a/test/spdm-emu/src/async_runtime.rs
+++ b/test/spdm-emu/src/async_runtime.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-extern crate alloc;
-use alloc::boxed::Box;
 use core::{future::Future, pin::Pin};
 
 // Run async task


### PR DESCRIPTION
Fix: #44 

Test with clippy version: 0.1.78 (4a0cc88 2024-03-11)