### PR TITLE
Clean clippy -A clippy::derivable_impls paraments

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: -- -D warnings -A clippy::only-used-in-recursion -A incomplete-features -A clippy::bad_bit_mask -A clippy::derivable_impls
+          args: -- -D warnings -A clippy::bad_bit_mask
 
   rustfmt:
     name: Format
@@ -103,4 +103,4 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: -- -D warnings -A clippy::only-used-in-recursion -A incomplete-features -A clippy::bad_bit_mask -A clippy::derivable_impls
+          args: -- -D warnings -A clippy::bad_bit_mask

--- a/mctp_transport/src/header.rs
+++ b/mctp_transport/src/header.rs
@@ -31,6 +31,7 @@ enum_builder! {
         MctpMessageTypeVendorDefinedIana => 0x7F
     }
 }
+#[allow(clippy::derivable_impls)]
 impl Default for MctpMessageType {
     fn default() -> MctpMessageType {
         MctpMessageType::MctpMessageTypeMctpControl

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -33,12 +33,12 @@ check() {
     set -x
     cargo check
     cargo fmt --all -- --check
-    cargo clippy -- -D warnings -A clippy::only-used-in-recursion -A incomplete-features -A clippy::bad_bit_mask -A clippy::derivable_impls
+    cargo clippy -- -D warnings -A clippy::bad_bit_mask
     
     if [ "${RUNNER_OS:-Linux}" == "Linux" ]; then
     pushd spdmlib_crypto_mbedtls
     cargo check
-    cargo clippy -- -D warnings -A clippy::only-used-in-recursion -A incomplete-features -A clippy::bad_bit_mask -A clippy::derivable_impls
+    cargo clippy -- -D warnings -A clippy::bad_bit_mask
     popd
     fi
     set +x

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -50,6 +50,7 @@ enum_builder! {
         SpdmConnectionAuthenticated => 0x5
     }
 }
+#[allow(clippy::derivable_impls)]
 impl Default for SpdmConnectionState {
     fn default() -> SpdmConnectionState {
         SpdmConnectionState::SpdmConnectionNotStarted

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -28,6 +28,7 @@ enum_builder! {
         SpdmSessionEstablished => 0x2
     }
 }
+#[allow(clippy::derivable_impls)]
 impl Default for SpdmSessionState {
     fn default() -> SpdmSessionState {
         SpdmSessionState::SpdmSessionNotStarted

--- a/spdmlib/src/message/measurement.rs
+++ b/spdmlib/src/message/measurement.rs
@@ -46,6 +46,7 @@ enum_builder! {
         SpdmMeasurementRequestAll => 0xFF
     }
 }
+#[allow(clippy::derivable_impls)]
 impl Default for SpdmMeasurementOperation {
     fn default() -> SpdmMeasurementOperation {
         SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -741,6 +741,7 @@ enum_builder! {
         SpdmMeasurementSummaryHashTypeAll => 0xFF
     }
 }
+#[allow(clippy::derivable_impls)]
 impl Default for SpdmMeasurementSummaryHashType {
     fn default() -> SpdmMeasurementSummaryHashType {
         SpdmMeasurementSummaryHashType::SpdmMeasurementSummaryHashTypeNone


### PR DESCRIPTION
Ref: #11 

Remove unused clippy lints paraments: `clippy::only-used-in-recursion` `incomplete-features `
Add [allow] in code for clippy lint: `clippy::derivable_impls`