### PR TITLE
Fix bad bit mask errors and clean clippy lints paraments

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: -- -D warnings -A clippy::bad_bit_mask
+          args: -- -D warnings
 
   rustfmt:
     name: Format
@@ -103,4 +103,4 @@ jobs:
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: clippy
-          args: -- -D warnings -A clippy::bad_bit_mask
+          args: -- -D warnings

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -33,12 +33,12 @@ check() {
     set -x
     cargo check
     cargo fmt --all -- --check
-    cargo clippy -- -D warnings -A clippy::bad_bit_mask
+    cargo clippy -- -D warnings
     
     if [ "${RUNNER_OS:-Linux}" == "Linux" ]; then
     pushd spdmlib_crypto_mbedtls
     cargo check
-    cargo clippy -- -D warnings -A clippy::bad_bit_mask
+    cargo clippy -- -D warnings
     popd
     fi
     set +x

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -13,7 +13,7 @@ use spin::Mutex;
 extern crate alloc;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
-use core::ops::DerefMut;
+use core::{convert::TryFrom, ops::DerefMut};
 
 pub use opaque::*;
 pub use spdm_codec::SpdmCodec;
@@ -1464,12 +1464,41 @@ impl Default for ManagedBuffer12Sign {
     }
 }
 
-bitflags! {
-    #[derive(Default)]
-    pub struct SpdmMeasurementContentChanged: u8 {
-        const NOT_SUPPORTED = 0b0000_0000;
-        const DETECTED_CHANGE = 0b0001_0000;
-        const NO_CHANGE = 0b0010_0000;
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum SpdmMeasurementContentChanged {
+    NotSupported,
+    DetectedChange,
+    NoChange,
+}
+
+impl Default for SpdmMeasurementContentChanged {
+    fn default() -> Self {
+        Self::NotSupported
+    }
+}
+
+impl TryFrom<u8> for SpdmMeasurementContentChanged {
+    type Error = ();
+    fn try_from(content_changed: u8) -> Result<Self, <Self as TryFrom<u8>>::Error> {
+        if content_changed == 0b0000_0000 {
+            Ok(Self::NotSupported)
+        } else if content_changed == 0b0001_0000 {
+            Ok(Self::DetectedChange)
+        } else if content_changed == 0b0010_0000 {
+            Ok(Self::NoChange)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<SpdmMeasurementContentChanged> for u8 {
+    fn from(content_changed: SpdmMeasurementContentChanged) -> Self {
+        match content_changed {
+            SpdmMeasurementContentChanged::NotSupported => 0b0000_0000,
+            SpdmMeasurementContentChanged::DetectedChange => 0b0001_0000,
+            SpdmMeasurementContentChanged::NoChange => 0b0010_0000,
+        }
     }
 }
 

--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -5,7 +5,6 @@
 use super::*;
 use crate::error::{SpdmStatus, SPDM_STATUS_UNSUPPORTED_CAP};
 use codec::u24;
-use core::convert::TryFrom;
 
 /// This is used in SpdmOpaqueStruct <- SpdmChallengeAuthResponsePayload / SpdmMeasurementsResponsePayload
 /// It should be 1024 according to SPDM spec.

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -1091,7 +1091,7 @@ mod tests {
                 SpdmMeasurementsResponsePayload {
                     number_of_measurement: 100u8,
                     slot_id: 7u8,
-                    content_changed: SpdmMeasurementContentChanged::NOT_SUPPORTED,
+                    content_changed: SpdmMeasurementContentChanged::NotSupported,
                     measurement_record: SpdmMeasurementRecordStructure {
                         number_of_blocks: 5,
                         measurement_record_length: u24::new(writer.used() as u32),
@@ -1131,7 +1131,7 @@ mod tests {
             assert_eq!(payload.slot_id, 7);
             assert_eq!(
                 payload.content_changed,
-                SpdmMeasurementContentChanged::NOT_SUPPORTED
+                SpdmMeasurementContentChanged::NotSupported
             );
             assert_eq!(payload.measurement_record.number_of_blocks, 5);
             for i in 0..SPDM_NONCE_SIZE {

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -194,7 +194,7 @@ impl ResponderContext {
             if runtime_content_change_support && (spdm_version_sel >= SpdmVersion::SpdmVersion12) {
                 content_changed
             } else {
-                SpdmMeasurementContentChanged::NOT_SUPPORTED
+                SpdmMeasurementContentChanged::NotSupported
             };
 
         let mut nonce = [0u8; SPDM_NONCE_SIZE];


### PR DESCRIPTION
Fix: #11

Refer to SPDM spec v1.2.0 **Table 43** - Successful MEASUREMENTS response message format
It's not valid to use bit mask to get `Param2 Bit [5:4]` status and `0b0000_0000` is not allowed to define in `bitflags!`.

**Solution**: 
Replace the `bitflags` with `enum`
![image](https://github.com/ccc-spdm-tools/spdm-rs/assets/109128373/5f7503d1-5510-49ab-93c4-93efa1f4326c)
