### PR TITLE
Fix other operation fail after key_update fail and rollback

### DIFF
--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -928,7 +928,9 @@ impl SpdmSession {
                             &self.application_secret_backup.response_direction,
                         );
                         if r_backup != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
-                            self.application_secret.response_direction.sequence_number += 1;
+                            self.application_secret_backup
+                                .response_direction
+                                .sequence_number += 1;
                         }
                         r_backup
                     } else if r != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {


### PR DESCRIPTION
Ref: #7 

Fix this scenario:
After responder receive the incorrect UpdateAllkeys request and send error message with S3 old key, the requester will do rollback and use S3 old key to decode message. The other operation will be passed after keys rollback.