### PR TITLE
In spec only S3 old key dropped before verify new key operation

### DIFF
--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -70,7 +70,7 @@ impl ResponderContext {
             }
             SpdmKeyUpdateOperation::SpdmUpdateAllKeys => {
                 let _ = session.create_data_secret_update(spdm_version_sel, true, true);
-                let _ = session.activate_data_secret_update(spdm_version_sel, true, true, true);
+                let _ = session.activate_data_secret_update(spdm_version_sel, false, true, true);
             }
             SpdmKeyUpdateOperation::SpdmVerifyNewKey => {
                 let _ = session.activate_data_secret_update(spdm_version_sel, true, false, true);


### PR DESCRIPTION
Ref: #7 

https://github.com/ccc-spdm-tools/spdm-rs/blob/acf74d70142fc48b1f3e0a6ab61181fd9a558f40/spdmlib/src/responder/key_update_rsp.rs#L71-L76

![image](https://github.com/ccc-spdm-tools/spdm-rs/assets/109128373/fd2ff24a-f5e3-4862-bf33-b139cabda81a)
