### PR TITLE
Update LLVM version to 14.0 for Bump KyleMayes/install-llvm-action from 1 to 2 

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@1a3da29f56261a1e1f937ec88f0856a9b8321d7e # v1
         with:
-          version: "12.0.1"
+          version: "14.0"
           directory: ${{ runner.temp }}/llvm
 
       - name: Install toolchain

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@1a3da29f56261a1e1f937ec88f0856a9b8321d7e # v1
         with:
-          version: "12.0.1"
+          version: "14.0"
           directory: ${{ runner.temp }}/llvm
 
       - name: Checkout sources

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@1a3da29f56261a1e1f937ec88f0856a9b8321d7e # v1
         with:
-          version: "12.0.1"
+          version: "14.0"
           directory: ${{ runner.temp }}/llvm
 
       - name: Checkout sources


### PR DESCRIPTION
Fix CI fail when install llvm-clang:

Ref: #66  
Error: Unsupported version for platform (os=linux, arch=x64, version=12.0.1)!