### PR TITLE
OpenSSF Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Deny](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/deny.yml/badge.svg)](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/deny.yml)
 [![Format](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/format.yml/badge.svg)](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/format.yml)
 [![Fuzzing](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/fuzz.yml/badge.svg)](https://github.com/ccc-spdm-tools/spdm-rs/actions/workflows/fuzz.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8901/badge)](https://www.bestpractices.dev/projects/8901)
 
 # spdm-rs
 


### PR DESCRIPTION
OpenSSF Best Practices Badge with your current % Score should be available with an up-to-date score on your main page now. 

The repository was analysed with [OpenSSF Best Practices Criteria](https://www.bestpractices.dev/en/). There are several criteria I was not able to confirm, but if you can provide URL or confirm password hardening I will update the Badge score for 100% security compliance: 

**Release Notes:**
The project MUST provide, in each release, release notes that are a human-readable summary of major changes in that release to help users determine if they should upgrade and what the upgrade impact will be. The release notes MUST NOT be the raw output of a version control log (e.g., the "git log" command results are not release notes). The release notes MUST identify every publicly known run-time vulnerability fixed in this release that already had a CVE assignment or similar when the release was created. This criterion may be marked as not applicable (N/A) if users typically cannot practically update the software themselves (e.g., as is often true for kernel updates). This criterion applies only to the project results, not to its dependencies.  (URL required)

**Password Security:** 
If the software produced by the project causes the storing of passwords for authentication of external users, the passwords MUST be stored as iterated hashes with a per-user salt by using a key stretching (iterated) algorithm (e.g., Argon2id, Bcrypt, Scrypt, or PBKDF2). See also [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)). 


