### PR TITLE
Fix oss-fuzz build failure issue

### DIFF
--- a/spdmlib/fuzz/Cargo.toml
+++ b/spdmlib/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 fuzzlib = { path = "../../fuzz-target/fuzzlib", default-features = false }
+serde = "=1.0.198"
 
 [dependencies.spdmlib]
 path = ".."


### PR DESCRIPTION
Since the compiler of oss-fuzz is not the latest version, so it will meet build failure for crate "serde 1.0.204". So we use a fixed version serde "1.0.198" to fix the issue.