### PR TITLE
Upgrate SPDM 1.3 Version Support

### DIFF
--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -177,7 +177,7 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
             Some(SpdmVersion::SpdmVersion10),
             Some(SpdmVersion::SpdmVersion11),
             Some(SpdmVersion::SpdmVersion12),
-            None,
+            Some(SpdmVersion::SpdmVersion13),
         ],
         req_capabilities: req_capabilities,
         req_ct_exponent: 0,

--- a/test/spdmlib-test/src/responder_tests/version_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/version_rsp.rs
@@ -80,6 +80,8 @@ fn test_case0_handle_spdm_version() {
             assert_eq!(payload.versions[1].version, SpdmVersion::SpdmVersion11);
             assert_eq!(payload.versions[2].update, 0);
             assert_eq!(payload.versions[2].version, SpdmVersion::SpdmVersion12);
+            assert_eq!(payload.versions[3].update, 0);
+            assert_eq!(payload.versions[3].version, SpdmVersion::SpdmVersion13);
         }
     };
     executor::block_on(future);


### PR DESCRIPTION
Fix https://github.com/ccc-spdm-tools/spdm-rs/issues/135

This Patch adds spdm 1.3 version support
  1. Remains version configs of requester/responder as spdm 1.2 to avoid version negotiated to 1.3
      since spdm 1.3 required features are not ready.
  2. Remains UpdateVersionNumber of VersionNumberEntry for version 1.3 in Ger_Version Response as
      0. Will track the updating to 1.3.2 (most recent in other issuee).