### PR TITLE
Ignore duplicated version number entries exist in VERSION response.

### DIFF
--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -606,6 +606,12 @@ mod tests {
 
     #[test]
     fn test_case0_spdm_message() {
+        let mut versions = gen_array_clone(SpdmVersionStruct::default(), MAX_SPDM_VERSION_COUNT);
+        versions[0].update = 100;
+        versions[0].version = SpdmVersion::SpdmVersion10;
+        versions[1].update = 100;
+        versions[1].version = SpdmVersion::SpdmVersion11;
+
         let value = SpdmMessage {
             header: SpdmMessageHeader {
                 version: SpdmVersion::SpdmVersion10,
@@ -613,13 +619,7 @@ mod tests {
             },
             payload: SpdmMessagePayload::SpdmVersionResponse(SpdmVersionResponsePayload {
                 version_number_entry_count: 0x02,
-                versions: gen_array_clone(
-                    SpdmVersionStruct {
-                        update: 100,
-                        version: SpdmVersion::SpdmVersion11,
-                    },
-                    MAX_SPDM_VERSION_COUNT,
-                ),
+                versions,
             }),
         };
 
@@ -633,10 +633,10 @@ mod tests {
         );
         if let SpdmMessagePayload::SpdmVersionResponse(payload) = &spdm_message.payload {
             assert_eq!(payload.version_number_entry_count, 0x02);
-            for i in 0..2 {
-                assert_eq!(payload.versions[i].update, 100);
-                assert_eq!(payload.versions[i].version, SpdmVersion::SpdmVersion11);
-            }
+            assert_eq!(payload.versions[0].update, 100);
+            assert_eq!(payload.versions[0].version, SpdmVersion::SpdmVersion10);
+            assert_eq!(payload.versions[1].update, 100);
+            assert_eq!(payload.versions[1].version, SpdmVersion::SpdmVersion11);
         }
     }
     #[test]

--- a/spdmlib/src/message/version_test.rs
+++ b/spdmlib/src/message/version_test.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 
 #[test]
 fn test_case1_spdmversion_struct() {
-    // Validata VERSION response VersionNumberEntryCount beyond maximum allowed size.
+    // Validate VERSION response VersionNumberEntryCount beyond maximum allowed size.
     let u8_slice = &mut [0u8; 100];
 
     // VersionNumberEntryCount = 0xfe
@@ -19,7 +19,7 @@ fn test_case1_spdmversion_struct() {
     let res = SpdmVersionResponsePayload::spdm_read(&mut context, &mut reader);
     assert!(res.is_none());
 
-    // Validata VERSION response VersionNumberEntryCount 0 size.
+    // Validate VERSION response VersionNumberEntryCount 0 size.
     let u8_slice = &mut [0u8; 100];
 
     // VersionNumberEntryCount = 0x0
@@ -27,5 +27,19 @@ fn test_case1_spdmversion_struct() {
     let mut reader = Reader::init(u8_slice);
     create_spdm_context!(context);
     let res = SpdmVersionResponsePayload::spdm_read(&mut context, &mut reader);
-    assert!(res.is_none())
+    assert!(res.is_none());
+
+    // Validate VERSION response VersionNumberEntryCount beyond MAX_SPDM_VERSION_COUNT and with duplicated version entries.
+    let u8_slice: &mut [u8; 16] = &mut [
+        0x0, 0x0, 0x0, 0x6, 0x0, 0x10, 0x0, 0x10, 0x0, 0x11, 0x0, 0x12, 0x0, 0x13, 0x0, 0x13,
+    ];
+    let mut reader = Reader::init(u8_slice);
+    create_spdm_context!(context);
+    let res = SpdmVersionResponsePayload::spdm_read(&mut context, &mut reader);
+    let version = res.unwrap();
+    assert_eq!(version.version_number_entry_count, 4);
+    assert_eq!(version.versions[0].version, SpdmVersion::SpdmVersion10);
+    assert_eq!(version.versions[1].version, SpdmVersion::SpdmVersion11);
+    assert_eq!(version.versions[2].version, SpdmVersion::SpdmVersion12);
+    assert_eq!(version.versions[3].version, SpdmVersion::SpdmVersion13);
 }


### PR DESCRIPTION
Fix https://github.com/ccc-spdm-tools/spdm-rs/issues/151

Add duplicated entry check and ignore the duplicated entry when handling VERSION
  response payload.
Add unit test to check the version entries are successfully read when duplicated
  entries exist in version response.
Modify the relative unit test to check non-repetitive version entries of response
  payload.