### PR TITLE
Fix compilation warning in webpki library

### DIFF
--- a/sh_script/pre-build.sh
+++ b/sh_script/pre-build.sh
@@ -36,6 +36,11 @@ patch-webpki() {
     pushd external/webpki
     git reset --hard f84a538a5cd281ba1ffc0d54bbe5824cf5969703
     git clean -xdf
+
+    # apply the patch to get rid of unused import warning during compilation
+    # https://github.com/briansmith/webpki/commit/8f81719df5b47bda95f15a7655be811e52e12997
+    git cherry-pick 8f81719df5b47bda95f15a7655be811e52e12997
+
     git apply ../patches/webpki/0001-Add-support-for-verifying-certificate-chain-with-EKU.patch
     popd
 }


### PR DESCRIPTION
The following warning is being fixed:

warning: unused import: `CONSTRUCTED`
  --> deps/spdm-rs/external/webpki/src/der.rs:17:24
   |
17 |     der::{nested, Tag, CONSTRUCTED},
   |                        ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

That warning was already fixed with this patch:
https://github.com/briansmith/webpki/commit/8f81719df5b47bda95f15a7655be811e52e12997

Once webpki library version will be bumped up, this patch could be dropped.