### PR TITLE
SPDM 1.3 Add Capability Support

### DIFF
--- a/spdmlib/src/message/capability_test.rs
+++ b/spdmlib/src/message/capability_test.rs
@@ -43,3 +43,135 @@ fn test_capability_struct() {
     let res = SpdmCapabilitiesResponsePayload::spdm_read(&mut context, &mut reader);
     assert!(res.is_none());
 }
+
+#[test]
+fn test_capability_request_struct() {
+    // 0. Version 1.3 Successful Setting.
+    let u8_slice = &mut [0u8; 100];
+    create_spdm_context!(context);
+    context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+
+    let flags = SpdmRequestCapabilityFlags::CERT_CAP
+        | SpdmRequestCapabilityFlags::ENCRYPT_CAP
+        | SpdmRequestCapabilityFlags::MAC_CAP
+        | SpdmRequestCapabilityFlags::KEY_EX_CAP
+        | SpdmRequestCapabilityFlags::ENCAP_CAP
+        | SpdmRequestCapabilityFlags::HBEAT_CAP
+        | SpdmRequestCapabilityFlags::KEY_UPD_CAP
+        | SpdmRequestCapabilityFlags::MUT_AUTH_CAP
+        | SpdmRequestCapabilityFlags::EP_INFO_CAP_NO_SIG
+        | SpdmRequestCapabilityFlags::EVENT_CAP
+        | SpdmRequestCapabilityFlags::MULTI_KEY_CAP_ONLY;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+    LittleEndian::write_u32(&mut u8_slice[12..16], 4096);
+    LittleEndian::write_u32(&mut u8_slice[16..20], 4096);
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmGetCapabilitiesRequestPayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_some());
+    let res = res.unwrap();
+    assert!(res.ct_exponent == 0);
+    assert!(res.flags.bits() == flags.bits());
+    assert!(res.data_transfer_size == 4096);
+    assert!(res.max_spdm_msg_size == 4096);
+
+    // 1. Validate SUPPORTED_ALGOS_EXT_CAP bit is set and CHUNK_CAP not supported. Expectation failed.
+    let u8_slice = &mut [0u8; 100];
+    create_spdm_context!(context);
+    context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+
+    u8_slice[2] = 1; // Set SUPPORTED_ALGOS_EXT_CAP bit in param1.
+    let flags = SpdmRequestCapabilityFlags::CERT_CAP | SpdmRequestCapabilityFlags::CHAL_CAP;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+    LittleEndian::write_u32(&mut u8_slice[12..16], 4096);
+    LittleEndian::write_u32(&mut u8_slice[16..20], 4096);
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmGetCapabilitiesRequestPayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_none());
+
+    // 2. Validate sample illegal capability flags settings. Expectation failed.
+    let u8_slice = &mut [0u8; 100];
+    create_spdm_context!(context);
+    context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+
+    let flags = SpdmRequestCapabilityFlags::EP_INFO_CAP_SIG
+        | SpdmRequestCapabilityFlags::EP_INFO_CAP_NO_SIG;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+    LittleEndian::write_u32(&mut u8_slice[12..16], 4096);
+    LittleEndian::write_u32(&mut u8_slice[16..20], 4096);
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmGetCapabilitiesRequestPayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_none());
+
+    let flags =
+        SpdmRequestCapabilityFlags::MULTI_KEY_CAP_ONLY | SpdmRequestCapabilityFlags::PUB_KEY_ID_CAP;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmGetCapabilitiesRequestPayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_none());
+}
+
+#[test]
+fn test_capability_response_struct() {
+    // 0. Version 1.3 Successful Setting.
+    let u8_slice = &mut [0u8; 100];
+    create_spdm_context!(context);
+    context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+
+    let flags = SpdmResponseCapabilityFlags::CERT_CAP
+        | SpdmResponseCapabilityFlags::CHAL_CAP
+        | SpdmResponseCapabilityFlags::MEAS_CAP_SIG
+        | SpdmResponseCapabilityFlags::MEAS_FRESH_CAP
+        | SpdmResponseCapabilityFlags::ENCRYPT_CAP
+        | SpdmResponseCapabilityFlags::MAC_CAP
+        | SpdmResponseCapabilityFlags::KEY_EX_CAP
+        | SpdmResponseCapabilityFlags::PSK_CAP_WITH_CONTEXT
+        | SpdmResponseCapabilityFlags::ENCAP_CAP
+        | SpdmResponseCapabilityFlags::HBEAT_CAP
+        | SpdmResponseCapabilityFlags::KEY_UPD_CAP
+        | SpdmResponseCapabilityFlags::MUT_AUTH_CAP
+        | SpdmResponseCapabilityFlags::EP_INFO_CAP_NO_SIG
+        | SpdmResponseCapabilityFlags::MEL_CAP
+        | SpdmResponseCapabilityFlags::EVENT_CAP
+        | SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY
+        | SpdmResponseCapabilityFlags::GET_KEY_PAIR_INFO_CAP
+        | SpdmResponseCapabilityFlags::SET_KEY_PAIR_INFO_CAP;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+    LittleEndian::write_u32(&mut u8_slice[12..16], 4096);
+    LittleEndian::write_u32(&mut u8_slice[16..20], 4096);
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmCapabilitiesResponsePayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_some());
+    let res = res.unwrap();
+    assert!(res.ct_exponent == 0);
+    assert!(res.flags.bits() == flags.bits());
+    assert!(res.data_transfer_size == 4096);
+    assert!(res.max_spdm_msg_size == 4096);
+
+    // 1. Validate sample illegal capability flags settings. Expectation failed.
+    let u8_slice = &mut [0u8; 100];
+    create_spdm_context!(context);
+    context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+
+    let flags = SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY
+        | SpdmResponseCapabilityFlags::MULTI_KEY_CAP_CONN_SEL
+        | SpdmResponseCapabilityFlags::GET_KEY_PAIR_INFO_CAP;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+    LittleEndian::write_u32(&mut u8_slice[12..16], 4096);
+    LittleEndian::write_u32(&mut u8_slice[16..20], 4096);
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmCapabilitiesResponsePayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_none());
+
+    let flags = SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY;
+    LittleEndian::write_u32(&mut u8_slice[8..12], flags.bits());
+
+    let mut reader = Reader::init(&u8_slice[2..]);
+    let res = SpdmCapabilitiesResponsePayload::spdm_read(&mut context, &mut reader);
+    assert!(res.is_none());
+}

--- a/spdmlib/src/protocol/capability.rs
+++ b/spdmlib/src/protocol/capability.rs
@@ -21,6 +21,11 @@ bitflags! {
         const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
         const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
         const CHUNK_CAP = 0b0000_0010_0000_0000_0000_0000;
+        const EP_INFO_CAP_NO_SIG = 0b0100_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_SIG = 0b1000_0000_0000_0000_0000_0000;
+        const EVENT_CAP = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_ONLY = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_CONN_SEL = 0b0000_1000_0000_0000_0000_0000_0000_0000;
         const VALID_MASK = Self::CERT_CAP.bits
             | Self::CHAL_CAP.bits
             | Self::ENCRYPT_CAP.bits
@@ -34,7 +39,12 @@ bitflags! {
             | Self::KEY_UPD_CAP.bits
             | Self::HANDSHAKE_IN_THE_CLEAR_CAP.bits
             | Self::PUB_KEY_ID_CAP.bits
-            | Self::CHUNK_CAP.bits;
+            | Self::CHUNK_CAP.bits
+            | Self::EP_INFO_CAP_NO_SIG.bits
+            | Self::EP_INFO_CAP_SIG.bits
+            | Self::EVENT_CAP.bits
+            | Self::MULTI_KEY_CAP_ONLY.bits
+            | Self::MULTI_KEY_CAP_CONN_SEL.bits;
     }
 }
 
@@ -75,6 +85,14 @@ bitflags! {
         const SET_CERT_CAP = 0b0000_1000_0000_0000_0000_0000;
         const CSR_CAP = 0b0001_0000_0000_0000_0000_0000;
         const CERT_INSTALL_RESET_CAP = 0b0010_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_NO_SIG = 0b0100_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_SIG = 0b1000_0000_0000_0000_0000_0000;
+        const MEL_CAP = 0b0000_0001_0000_0000_0000_0000_0000_0000;
+        const EVENT_CAP = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_ONLY = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_CONN_SEL = 0b0000_1000_0000_0000_0000_0000_0000_0000;
+        const GET_KEY_PAIR_INFO_CAP = 0b0001_0000_0000_0000_0000_0000_0000_0000;
+        const SET_KEY_PAIR_INFO_CAP = 0b0010_0000_0000_0000_0000_0000_0000_0000;
         const VALID_MASK = Self::CACHE_CAP.bits
             | Self::CERT_CAP.bits
             | Self::CHAL_CAP.bits
@@ -96,7 +114,15 @@ bitflags! {
             | Self::ALIAS_CERT_CAP.bits
             | Self::SET_CERT_CAP.bits
             | Self::CSR_CAP.bits
-            | Self::CERT_INSTALL_RESET_CAP.bits;
+            | Self::CERT_INSTALL_RESET_CAP.bits
+            | Self::EP_INFO_CAP_NO_SIG.bits
+            | Self::EP_INFO_CAP_SIG.bits
+            | Self::MEL_CAP.bits
+            | Self::EVENT_CAP.bits
+            | Self::MULTI_KEY_CAP_ONLY.bits
+            | Self::MULTI_KEY_CAP_CONN_SEL.bits
+            | Self::GET_KEY_PAIR_INFO_CAP.bits
+            | Self::SET_KEY_PAIR_INFO_CAP.bits;
     }
 }
 
@@ -109,5 +135,25 @@ impl Codec for SpdmResponseCapabilityFlags {
         let bits = u32::read(r)?;
 
         SpdmResponseCapabilityFlags::from_bits(bits & SpdmResponseCapabilityFlags::VALID_MASK.bits)
+    }
+}
+
+bitflags! {
+    #[derive(Default)]
+    pub struct SpdmCapabilityParam1: u8 {
+        const SUPPORTED_ALGOS_EXT_CAP = 0b0000_0001;
+        const VALID_MASK = Self::SUPPORTED_ALGOS_EXT_CAP.bits;
+    }
+}
+
+impl Codec for SpdmCapabilityParam1 {
+    fn encode(&self, bytes: &mut Writer) -> Result<usize, codec::EncodeErr> {
+        self.bits().encode(bytes)
+    }
+
+    fn read(r: &mut Reader) -> Option<SpdmCapabilityParam1> {
+        let bits = u8::read(r)?;
+
+        SpdmCapabilityParam1::from_bits(bits & SpdmCapabilityParam1::VALID_MASK.bits)
     }
 }

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -51,7 +51,12 @@ pub fn create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
             | SpdmResponseCapabilityFlags::HBEAT_CAP
             | SpdmResponseCapabilityFlags::KEY_UPD_CAP
             | SpdmResponseCapabilityFlags::MUT_AUTH_CAP
-            | SpdmResponseCapabilityFlags::ENCAP_CAP,
+            | SpdmResponseCapabilityFlags::EP_INFO_CAP_NO_SIG
+            | SpdmResponseCapabilityFlags::MEL_CAP
+            | SpdmResponseCapabilityFlags::EVENT_CAP
+            | SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY
+            | SpdmResponseCapabilityFlags::GET_KEY_PAIR_INFO_CAP
+            | SpdmResponseCapabilityFlags::SET_KEY_PAIR_INFO_CAP,
         req_capabilities: SpdmRequestCapabilityFlags::CERT_CAP
             | SpdmRequestCapabilityFlags::ENCRYPT_CAP
             | SpdmRequestCapabilityFlags::MAC_CAP
@@ -60,7 +65,9 @@ pub fn create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
             | SpdmRequestCapabilityFlags::HBEAT_CAP
             | SpdmRequestCapabilityFlags::KEY_UPD_CAP
             | SpdmRequestCapabilityFlags::MUT_AUTH_CAP
-            | SpdmRequestCapabilityFlags::ENCAP_CAP,
+            | SpdmRequestCapabilityFlags::EP_INFO_CAP_NO_SIG
+            | SpdmRequestCapabilityFlags::EVENT_CAP
+            | SpdmRequestCapabilityFlags::MULTI_KEY_CAP_ONLY,
         rsp_ct_exponent: 0,
         req_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
@@ -166,7 +173,10 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         | SpdmRequestCapabilityFlags::HBEAT_CAP
         // | SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP
         // | SpdmResponseCapabilityFlags::PUB_KEY_ID_CAP
-        | SpdmRequestCapabilityFlags::KEY_UPD_CAP;
+        | SpdmRequestCapabilityFlags::KEY_UPD_CAP
+        | SpdmRequestCapabilityFlags::EP_INFO_CAP_NO_SIG
+        | SpdmRequestCapabilityFlags::EVENT_CAP
+        | SpdmRequestCapabilityFlags::MULTI_KEY_CAP_ONLY;
     let req_capabilities = if cfg!(feature = "mut-auth") {
         req_capabilities | SpdmRequestCapabilityFlags::MUT_AUTH_CAP
     } else {
@@ -296,7 +306,13 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         | SpdmResponseCapabilityFlags::HBEAT_CAP
         // | SpdmResponseCapabilityFlags::HANDSHAKE_IN_THE_CLEAR_CAP
         // | SpdmResponseCapabilityFlags::PUB_KEY_ID_CAP
-        | SpdmResponseCapabilityFlags::KEY_UPD_CAP;
+        | SpdmResponseCapabilityFlags::KEY_UPD_CAP
+        | SpdmResponseCapabilityFlags::EP_INFO_CAP_NO_SIG
+        | SpdmResponseCapabilityFlags::MEL_CAP
+        | SpdmResponseCapabilityFlags::EVENT_CAP
+        | SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY
+        | SpdmResponseCapabilityFlags::GET_KEY_PAIR_INFO_CAP
+        | SpdmResponseCapabilityFlags::SET_KEY_PAIR_INFO_CAP;
     let rsp_capabilities = if cfg!(feature = "mut-auth") {
         rsp_capabilities | SpdmResponseCapabilityFlags::MUT_AUTH_CAP
     } else {

--- a/test/spdmlib-test/src/responder_tests/capability_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/capability_rsp.rs
@@ -73,7 +73,13 @@ fn test_case0_handle_spdm_capability() {
             | SpdmResponseCapabilityFlags::ENCAP_CAP
             | SpdmResponseCapabilityFlags::MUT_AUTH_CAP
             | SpdmResponseCapabilityFlags::HBEAT_CAP
-            | SpdmResponseCapabilityFlags::KEY_UPD_CAP;
+            | SpdmResponseCapabilityFlags::KEY_UPD_CAP
+            | SpdmResponseCapabilityFlags::EP_INFO_CAP_NO_SIG
+            | SpdmResponseCapabilityFlags::MEL_CAP
+            | SpdmResponseCapabilityFlags::EVENT_CAP
+            | SpdmResponseCapabilityFlags::MULTI_KEY_CAP_ONLY
+            | SpdmResponseCapabilityFlags::GET_KEY_PAIR_INFO_CAP
+            | SpdmResponseCapabilityFlags::SET_KEY_PAIR_INFO_CAP;
         let data = context.common.runtime_info.message_a.as_ref();
         let u8_slice = &mut [0u8; 2048];
         for (i, data) in data.iter().enumerate() {


### PR DESCRIPTION
Fix: https://github.com/ccc-spdm-tools/spdm-rs/issues/136

This Patch Adds:
1. Definitions of get_capacity_req and capacity_rep added in spdm
  1.3.
2. Capability Violation checks for newly added flags.
3. Unit test cases for capability 1.3 fields.
4. Error Response if responder does not support Large SPDM message
  transfer mechanism while Requester set bit0 of param1 in capability
  request message. (Spec requested).

Remains:
1. Config info of capability as 1.2 since relative 1.3 features not
  implemented.
2. Supported Algorithms extend capability bit (Param 1 Bit 0) as
  unimplemented. Will track this feature in another issue.
