### PR TITLE
Align the bit definition in bigflags structure

### DIFF
--- a/spdmlib/src/message/key_exchange.rs
+++ b/spdmlib/src/message/key_exchange.rs
@@ -115,9 +115,9 @@ impl SpdmCodec for SpdmKeyExchangeRequestPayload {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmKeyExchangeMutAuthAttributes: u8 {
-        const MUT_AUTH_REQ = 0b00000001;
+        const MUT_AUTH_REQ =                    0b00000001;
         const MUT_AUTH_REQ_WITH_ENCAP_REQUEST = 0b00000010;
-        const MUT_AUTH_REQ_WITH_GET_DIGESTS = 0b00000100;
+        const MUT_AUTH_REQ_WITH_GET_DIGESTS =   0b00000100;
         const VALID_MASK = Self::MUT_AUTH_REQ.bits | Self::MUT_AUTH_REQ_WITH_ENCAP_REQUEST.bits | Self::MUT_AUTH_REQ_WITH_GET_DIGESTS.bits;
     }
 }

--- a/spdmlib/src/message/measurement.rs
+++ b/spdmlib/src/message/measurement.rs
@@ -22,7 +22,7 @@ pub const MEASUREMENT_RESPONDER_PARAM2_CONTENT_CHANGED_MASK: u8 = 0b0011_0000;
 bitflags! {
     #[derive(Default)]
     pub struct SpdmMeasurementAttributes: u8 {
-        const SIGNATURE_REQUESTED = 0b00000001;
+        const SIGNATURE_REQUESTED      = 0b0000_0001;
         const RAW_BIT_STREAM_REQUESTED = 0b0000_0010;
         const VALID_MASK = Self::SIGNATURE_REQUESTED.bits | Self::RAW_BIT_STREAM_REQUESTED.bits;
     }

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -104,14 +104,14 @@ impl SpdmMeasurementSpecification {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmMeasurementHashAlgo: u32 {
-        const RAW_BIT_STREAM = 0b0000_0001;
-        const TPM_ALG_SHA_256 = 0b0000_0010;
-        const TPM_ALG_SHA_384 = 0b0000_0100;
-        const TPM_ALG_SHA_512 = 0b0000_1000;
+        const RAW_BIT_STREAM   = 0b0000_0001;
+        const TPM_ALG_SHA_256  = 0b0000_0010;
+        const TPM_ALG_SHA_384  = 0b0000_0100;
+        const TPM_ALG_SHA_512  = 0b0000_1000;
         const TPM_ALG_SHA3_256 = 0b0001_0000;
         const TPM_ALG_SHA3_384 = 0b0010_0000;
         const TPM_ALG_SHA3_512 = 0b0100_0000;
-        const TPM_ALG_SM3 = 0b1000_0000;
+        const TPM_ALG_SM3      = 0b1000_0000;
         const VALID_MASK = Self::RAW_BIT_STREAM.bits
             | Self::TPM_ALG_SHA_256.bits
             | Self::TPM_ALG_SHA_384.bits
@@ -169,13 +169,13 @@ impl Codec for SpdmMeasurementHashAlgo {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmBaseAsymAlgo: u32 {
-        const TPM_ALG_RSASSA_2048 = 0b0000_0001;
-        const TPM_ALG_RSAPSS_2048 = 0b0000_0010;
-        const TPM_ALG_RSASSA_3072 = 0b0000_0100;
-        const TPM_ALG_RSAPSS_3072 = 0b0000_1000;
+        const TPM_ALG_RSASSA_2048         = 0b0000_0001;
+        const TPM_ALG_RSAPSS_2048         = 0b0000_0010;
+        const TPM_ALG_RSASSA_3072         = 0b0000_0100;
+        const TPM_ALG_RSAPSS_3072         = 0b0000_1000;
         const TPM_ALG_ECDSA_ECC_NIST_P256 = 0b0001_0000;
-        const TPM_ALG_RSASSA_4096 = 0b0010_0000;
-        const TPM_ALG_RSAPSS_4096 = 0b0100_0000;
+        const TPM_ALG_RSASSA_4096         = 0b0010_0000;
+        const TPM_ALG_RSAPSS_4096         = 0b0100_0000;
         const TPM_ALG_ECDSA_ECC_NIST_P384 = 0b1000_0000;
         const VALID_MASK = Self::TPM_ALG_RSASSA_2048.bits
             | Self::TPM_ALG_RSAPSS_2048.bits
@@ -399,8 +399,8 @@ impl Codec for SpdmDheAlgo {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmAeadAlgo: u16 {
-        const AES_128_GCM = 0b0000_0001;
-        const AES_256_GCM = 0b0000_0010;
+        const AES_128_GCM       = 0b0000_0001;
+        const AES_256_GCM       = 0b0000_0010;
         const CHACHA20_POLY1305 = 0b0000_0100;
         const VALID_MASK = Self::AES_128_GCM.bits
             | Self::AES_256_GCM.bits
@@ -486,13 +486,13 @@ impl Codec for SpdmAeadAlgo {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmReqAsymAlgo: u16 {
-        const TPM_ALG_RSASSA_2048 = 0b0000_0001;
-        const TPM_ALG_RSAPSS_2048 = 0b0000_0010;
-        const TPM_ALG_RSASSA_3072 = 0b0000_0100;
-        const TPM_ALG_RSAPSS_3072 = 0b0000_1000;
+        const TPM_ALG_RSASSA_2048         = 0b0000_0001;
+        const TPM_ALG_RSAPSS_2048         = 0b0000_0010;
+        const TPM_ALG_RSASSA_3072         = 0b0000_0100;
+        const TPM_ALG_RSAPSS_3072         = 0b0000_1000;
         const TPM_ALG_ECDSA_ECC_NIST_P256 = 0b0001_0000;
-        const TPM_ALG_RSASSA_4096 = 0b0010_0000;
-        const TPM_ALG_RSAPSS_4096 = 0b0100_0000;
+        const TPM_ALG_RSASSA_4096         = 0b0010_0000;
+        const TPM_ALG_RSAPSS_4096         = 0b0100_0000;
         const TPM_ALG_ECDSA_ECC_NIST_P384 = 0b1000_0000;
         const VALID_MASK = Self::TPM_ALG_RSASSA_2048.bits
             | Self::TPM_ALG_RSAPSS_2048.bits

--- a/spdmlib/src/protocol/capability.rs
+++ b/spdmlib/src/protocol/capability.rs
@@ -7,25 +7,25 @@ use codec::{Codec, Reader, Writer};
 bitflags! {
     #[derive(Default)]
     pub struct SpdmRequestCapabilityFlags: u32 {
-        const CERT_CAP = 0b0000_0010;
-        const CHAL_CAP = 0b0000_0100;
-        const ENCRYPT_CAP = 0b0100_0000;
-        const MAC_CAP = 0b1000_0000;
-        const MUT_AUTH_CAP = 0b0000_0001_0000_0000;
-        const KEY_EX_CAP = 0b0000_0010_0000_0000;
-        const PSK_CAP = 0b0000_0100_0000_0000;
-        const PSK_RSVD = 0b0000_1000_0000_0000;
-        const ENCAP_CAP = 0b0001_0000_0000_0000;
-        const HBEAT_CAP = 0b0010_0000_0000_0000;
-        const KEY_UPD_CAP = 0b0100_0000_0000_0000;
-        const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
-        const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
-        const CHUNK_CAP = 0b0000_0010_0000_0000_0000_0000;
-        const EP_INFO_CAP_NO_SIG = 0b0100_0000_0000_0000_0000_0000;
-        const EP_INFO_CAP_SIG = 0b1000_0000_0000_0000_0000_0000;
-        const EVENT_CAP = 0b0000_0010_0000_0000_0000_0000_0000_0000;
-        const MULTI_KEY_CAP_ONLY = 0b0000_0100_0000_0000_0000_0000_0000_0000;
-        const MULTI_KEY_CAP_CONN_SEL = 0b0000_1000_0000_0000_0000_0000_0000_0000;
+        const CERT_CAP                   =                               0b0000_0010;
+        const CHAL_CAP                   =                               0b0000_0100;
+        const ENCRYPT_CAP                =                               0b0100_0000;
+        const MAC_CAP                    =                               0b1000_0000;
+        const MUT_AUTH_CAP               =                     0b0000_0001_0000_0000;
+        const KEY_EX_CAP                 =                     0b0000_0010_0000_0000;
+        const PSK_CAP                    =                     0b0000_0100_0000_0000;
+        const PSK_RSVD                   =                     0b0000_1000_0000_0000;
+        const ENCAP_CAP                  =                     0b0001_0000_0000_0000;
+        const HBEAT_CAP                  =                     0b0010_0000_0000_0000;
+        const KEY_UPD_CAP                =                     0b0100_0000_0000_0000;
+        const HANDSHAKE_IN_THE_CLEAR_CAP =                     0b1000_0000_0000_0000;
+        const PUB_KEY_ID_CAP             =           0b0000_0001_0000_0000_0000_0000;
+        const CHUNK_CAP                  =           0b0000_0010_0000_0000_0000_0000;
+        const EP_INFO_CAP_NO_SIG         =           0b0100_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_SIG            =           0b1000_0000_0000_0000_0000_0000;
+        const EVENT_CAP                  = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_ONLY         = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_CONN_SEL     = 0b0000_1000_0000_0000_0000_0000_0000_0000;
         const VALID_MASK = Self::CERT_CAP.bits
             | Self::CHAL_CAP.bits
             | Self::ENCRYPT_CAP.bits
@@ -63,36 +63,36 @@ impl Codec for SpdmRequestCapabilityFlags {
 bitflags! {
     #[derive(Default)]
     pub struct SpdmResponseCapabilityFlags: u32 {
-        const CACHE_CAP = 0b0000_0001;
-        const CERT_CAP = 0b0000_0010;
-        const CHAL_CAP = 0b0000_0100;
-        const MEAS_CAP_NO_SIG = 0b0000_1000;
-        const MEAS_CAP_SIG = 0b0001_0000;
-        const MEAS_FRESH_CAP = 0b0010_0000;
-        const ENCRYPT_CAP = 0b0100_0000;
-        const MAC_CAP = 0b1000_0000;
-        const MUT_AUTH_CAP = 0b0000_0001_0000_0000;
-        const KEY_EX_CAP = 0b0000_0010_0000_0000;
-        const PSK_CAP_WITHOUT_CONTEXT = 0b0000_0100_0000_0000;
-        const PSK_CAP_WITH_CONTEXT = 0b0000_1000_0000_0000;
-        const ENCAP_CAP = 0b0001_0000_0000_0000;
-        const HBEAT_CAP = 0b0010_0000_0000_0000;
-        const KEY_UPD_CAP = 0b0100_0000_0000_0000;
-        const HANDSHAKE_IN_THE_CLEAR_CAP = 0b1000_0000_0000_0000;
-        const PUB_KEY_ID_CAP = 0b0000_0001_0000_0000_0000_0000;
-        const CHUNK_CAP = 0b0000_0010_0000_0000_0000_0000;
-        const ALIAS_CERT_CAP = 0b0000_0100_0000_0000_0000_0000;
-        const SET_CERT_CAP = 0b0000_1000_0000_0000_0000_0000;
-        const CSR_CAP = 0b0001_0000_0000_0000_0000_0000;
-        const CERT_INSTALL_RESET_CAP = 0b0010_0000_0000_0000_0000_0000;
-        const EP_INFO_CAP_NO_SIG = 0b0100_0000_0000_0000_0000_0000;
-        const EP_INFO_CAP_SIG = 0b1000_0000_0000_0000_0000_0000;
-        const MEL_CAP = 0b0000_0001_0000_0000_0000_0000_0000_0000;
-        const EVENT_CAP = 0b0000_0010_0000_0000_0000_0000_0000_0000;
-        const MULTI_KEY_CAP_ONLY = 0b0000_0100_0000_0000_0000_0000_0000_0000;
-        const MULTI_KEY_CAP_CONN_SEL = 0b0000_1000_0000_0000_0000_0000_0000_0000;
-        const GET_KEY_PAIR_INFO_CAP = 0b0001_0000_0000_0000_0000_0000_0000_0000;
-        const SET_KEY_PAIR_INFO_CAP = 0b0010_0000_0000_0000_0000_0000_0000_0000;
+        const CACHE_CAP                  =                               0b0000_0001;
+        const CERT_CAP                   =                               0b0000_0010;
+        const CHAL_CAP                   =                               0b0000_0100;
+        const MEAS_CAP_NO_SIG            =                               0b0000_1000;
+        const MEAS_CAP_SIG               =                               0b0001_0000;
+        const MEAS_FRESH_CAP             =                               0b0010_0000;
+        const ENCRYPT_CAP                =                               0b0100_0000;
+        const MAC_CAP                    =                               0b1000_0000;
+        const MUT_AUTH_CAP               =                     0b0000_0001_0000_0000;
+        const KEY_EX_CAP                 =                     0b0000_0010_0000_0000;
+        const PSK_CAP_WITHOUT_CONTEXT    =                     0b0000_0100_0000_0000;
+        const PSK_CAP_WITH_CONTEXT       =                     0b0000_1000_0000_0000;
+        const ENCAP_CAP                  =                     0b0001_0000_0000_0000;
+        const HBEAT_CAP                  =                     0b0010_0000_0000_0000;
+        const KEY_UPD_CAP                =                     0b0100_0000_0000_0000;
+        const HANDSHAKE_IN_THE_CLEAR_CAP =                     0b1000_0000_0000_0000;
+        const PUB_KEY_ID_CAP             =           0b0000_0001_0000_0000_0000_0000;
+        const CHUNK_CAP                  =           0b0000_0010_0000_0000_0000_0000;
+        const ALIAS_CERT_CAP             =           0b0000_0100_0000_0000_0000_0000;
+        const SET_CERT_CAP               =           0b0000_1000_0000_0000_0000_0000;
+        const CSR_CAP                    =           0b0001_0000_0000_0000_0000_0000;
+        const CERT_INSTALL_RESET_CAP     =           0b0010_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_NO_SIG         =           0b0100_0000_0000_0000_0000_0000;
+        const EP_INFO_CAP_SIG            =           0b1000_0000_0000_0000_0000_0000;
+        const MEL_CAP                    = 0b0000_0001_0000_0000_0000_0000_0000_0000;
+        const EVENT_CAP                  = 0b0000_0010_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_ONLY         = 0b0000_0100_0000_0000_0000_0000_0000_0000;
+        const MULTI_KEY_CAP_CONN_SEL     = 0b0000_1000_0000_0000_0000_0000_0000_0000;
+        const GET_KEY_PAIR_INFO_CAP      = 0b0001_0000_0000_0000_0000_0000_0000_0000;
+        const SET_KEY_PAIR_INFO_CAP      = 0b0010_0000_0000_0000_0000_0000_0000_0000;
         const VALID_MASK = Self::CACHE_CAP.bits
             | Self::CERT_CAP.bits
             | Self::CHAL_CAP.bits

--- a/tdisp/src/pci_tdisp.rs
+++ b/tdisp/src/pci_tdisp.rs
@@ -521,11 +521,11 @@ impl Codec for ReqGetTdispCapabilities {
 bitflags! {
     #[derive(Default)]
     pub struct LockInterfaceFlag: u16 {
-        const NO_FW_UPDATE = 0b0000_0000_0000_0001;
+        const NO_FW_UPDATE           = 0b0000_0000_0000_0001;
         const SYSTEM_CACHE_LINE_SIZE = 0b0000_0000_0000_0010;
-        const LOCK_MSIX = 0b0000_0000_0000_0100;
-        const BIND_P2P = 0b0000_0000_0000_1000;
-        const ALL_REQUEST_REDIRECT = 0b0000_0000_0001_0000;
+        const LOCK_MSIX              = 0b0000_0000_0000_0100;
+        const BIND_P2P               = 0b0000_0000_0000_1000;
+        const ALL_REQUEST_REDIRECT   = 0b0000_0000_0001_0000;
         const VALID_MASK = Self::NO_FW_UPDATE.bits
         | Self::SYSTEM_CACHE_LINE_SIZE.bits
         | Self::LOCK_MSIX.bits
@@ -702,10 +702,10 @@ bitflags! {
     #[derive(Default)]
     pub struct InterfaceInfo: u16 {
         const DEVICE_FIRMWARE_UPDATES_NOT_PERMITTED = 0b0000_0000_0000_0001;
-        const DMA_REQUESTS_WITHOUT_PASID = 0b0000_0000_0000_0010;
-        const DMA_REQUESTS_WITH_PASID = 0b0000_0000_0000_0100;
-        const ATS_SUPPORTED_ENABLED = 0b0000_0000_0000_1000;
-        const PRS_SUPPORTED_ENABLED = 0b0000_0000_0001_0000;
+        const DMA_REQUESTS_WITHOUT_PASID            = 0b0000_0000_0000_0010;
+        const DMA_REQUESTS_WITH_PASID               = 0b0000_0000_0000_0100;
+        const ATS_SUPPORTED_ENABLED                 = 0b0000_0000_0000_1000;
+        const PRS_SUPPORTED_ENABLED                 = 0b0000_0000_0001_0000;
         const VALID_MASK = Self::DEVICE_FIRMWARE_UPDATES_NOT_PERMITTED.bits
         | Self::DMA_REQUESTS_WITHOUT_PASID.bits
         | Self::DMA_REQUESTS_WITH_PASID.bits
@@ -987,9 +987,9 @@ impl Codec for RspUnBindP2PStreamResponse {
 bitflags! {
     #[derive(Default)]
     pub struct MMIORangeAttribute: u16 {
-        const MSI_X_TABLE = 0b0000_0000_0000_0001;
-        const MSI_X_PBA = 0b0000_0000_0000_0010;
-        const IS_NON_TEE_MEM = 0b0000_0000_0000_0100;
+        const MSI_X_TABLE           = 0b0000_0000_0000_0001;
+        const MSI_X_PBA             = 0b0000_0000_0000_0010;
+        const IS_NON_TEE_MEM        = 0b0000_0000_0000_0100;
         const IS_MEM_ATTR_UPDATABLE = 0b0000_0000_0000_1000;
         const PRS_SUPPORTED_ENABLED = 0b0000_0000_0001_0000;
         const VALID_MASK = Self::MSI_X_TABLE.bits


### PR DESCRIPTION
Fix: https://github.com/ccc-spdm-tools/spdm-rs/issues/162

Code improvement. Align the bit definitions to deduce the danger
  of misconfiguration.