### PR TITLE
Add support for 1.2 SPDM secure version

### DIFF
--- a/spdmlib/src/common/opaque.rs
+++ b/spdmlib/src/common/opaque.rs
@@ -10,7 +10,7 @@ use codec::u24;
 /// It should be 1024 according to SPDM spec.
 pub const MAX_SPDM_OPAQUE_SIZE: usize = 1024;
 
-pub const MAX_SECURE_SPDM_VERSION_COUNT: usize = 0x02;
+pub const MAX_SECURE_SPDM_VERSION_COUNT: usize = 0x03;
 
 pub const DMTF_SPEC_ID: u32 = 0x444D5446;
 pub const DMTF_OPAQUE_VERSION: u8 = 0x01;

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -145,6 +145,7 @@ async fn test_spdm(
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         ..Default::default()
     };
@@ -635,6 +636,7 @@ async fn test_idekm_tdisp(
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         ..Default::default()
     };

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -308,6 +308,7 @@ async fn handle_message(
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         ..Default::default()
     };

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -86,6 +86,7 @@ pub fn create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         mel_specification: SpdmMelSpecification::DMTF_MEL_SPEC,
         ..Default::default()
@@ -215,6 +216,7 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         mel_specification: SpdmMelSpecification::DMTF_MEL_SPEC,
         ..Default::default()
@@ -355,6 +357,7 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         secure_spdm_version: [
             Some(SecuredMessageVersion::try_from(0x10u8).unwrap()),
             Some(SecuredMessageVersion::try_from(0x11u8).unwrap()),
+            Some(SecuredMessageVersion::try_from(0x12u8).unwrap()),
         ],
         mel_specification: SpdmMelSpecification::DMTF_MEL_SPEC,
         ..Default::default()

--- a/test/spdmlib-test/src/responder_tests/key_exchange_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/key_exchange_rsp.rs
@@ -91,6 +91,12 @@ fn test_case0_handle_spdm_key_exchange() {
                                 update_version_number: 0,
                                 alpha: 0,
                             },
+                            SecuredMessageVersion {
+                                major_version: 1,
+                                minor_version: 2,
+                                update_version_number: 0,
+                                alpha: 0,
+                            },
                         ],
                     },
                 },
@@ -179,6 +185,12 @@ fn test_case1_handle_spdm_key_exchange() {
                             SecuredMessageVersion {
                                 major_version: 1,
                                 minor_version: 1,
+                                update_version_number: 0,
+                                alpha: 0,
+                            },
+                            SecuredMessageVersion {
+                                major_version: 1,
+                                minor_version: 2,
                                 update_version_number: 0,
                                 alpha: 0,
                             },

--- a/test/spdmlib-test/src/responder_tests/psk_exchange_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/psk_exchange_rsp.rs
@@ -80,6 +80,12 @@ fn test_case0_handle_spdm_psk_exchange() {
                                 update_version_number: 0,
                                 alpha: 0,
                             },
+                            SecuredMessageVersion {
+                                major_version: 1,
+                                minor_version: 2,
+                                update_version_number: 0,
+                                alpha: 0,
+                            },
                         ],
                     },
                 },
@@ -157,6 +163,12 @@ fn test_case1_handle_spdm_psk_exchange() {
                             SecuredMessageVersion {
                                 major_version: 1,
                                 minor_version: 1,
+                                update_version_number: 0,
+                                alpha: 0,
+                            },
+                            SecuredMessageVersion {
+                                major_version: 1,
+                                minor_version: 2,
                                 update_version_number: 0,
                                 alpha: 0,
                             },


### PR DESCRIPTION
SPDM secure version 1.2 shall be supported thus need to support three SPDM secure version numbers: 1.0, 1.1 and 1.2.