### PR TITLE
bump tokio to 1.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
There is the following vulnerability in 1.43.0.
This patch bumps the version to the 1.43.2 to fix the issue.

```
┌─────────┬─────────────────────┬──────────┬────────┬───────────────────┬────────────────────────┬───────────────────────────────────────────────────────────┐
│ Library │    Vulnerability    │ Severity │ Status │ Installed Version │     Fixed Version      │                           Title                           │
├─────────┼─────────────────────┼──────────┼────────┼───────────────────┼────────────────────────┼─────────────────────────────────────────���─────────────────┤
│ tokio   │ GHSA-rr8g-9fpq-6wmg │ LOW      │ fixed  │ 1.43.0            │ 1.44.2, 1.38.2, 1.43.1 │ Tokio broadcast channel calls clone in parallel, but does │
│         │                     │          │        │                   │                        │ not require `Sync`...                                     │
│         │                     │          │        │                   │                        │ https://github.com/advisories/GHSA-rr8g-9fpq-6wmg         │
└─────────┴─────────────────────┴──────────┴────────┴───────────────────┴────────────────────────┴───────────────────────────────────────────────────────────┘
```