### PR TITLE
Spdm 1.3 Digest Support.

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -1598,17 +1598,40 @@ impl SpdmRuntimeInfo {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct SpdmProvisionInfo {
     pub my_cert_chain_data: [Option<SpdmCertChainData>; SPDM_MAX_SLOT_NUMBER],
     pub my_cert_chain: [Option<SpdmCertChainBuffer>; SPDM_MAX_SLOT_NUMBER],
     pub peer_root_cert_data: [Option<SpdmCertChainData>; MAX_ROOT_CERT_SUPPORT],
+    pub local_supported_slot_mask: u8,
+    pub local_key_pair_id: [Option<u8>; SPDM_MAX_SLOT_NUMBER],
+    pub local_cert_info: [Option<SpdmCertificateModelType>; SPDM_MAX_SLOT_NUMBER],
+    pub local_key_usage_bit_mask: [Option<SpdmKeyUsageMask>; SPDM_MAX_SLOT_NUMBER],
+}
+
+impl Default for SpdmProvisionInfo {
+    fn default() -> Self {
+        SpdmProvisionInfo {
+            my_cert_chain_data: [None; SPDM_MAX_SLOT_NUMBER],
+            my_cert_chain: [None; SPDM_MAX_SLOT_NUMBER],
+            peer_root_cert_data: [None; MAX_ROOT_CERT_SUPPORT],
+            local_supported_slot_mask: 0xff,
+            local_key_pair_id: [None; SPDM_MAX_SLOT_NUMBER],
+            local_cert_info: [None; SPDM_MAX_SLOT_NUMBER],
+            local_key_usage_bit_mask: [None; SPDM_MAX_SLOT_NUMBER],
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct SpdmPeerInfo {
     pub peer_cert_chain: [Option<SpdmCertChainBuffer>; SPDM_MAX_SLOT_NUMBER],
     pub peer_cert_chain_temp: Option<SpdmCertChainBuffer>,
+    pub peer_supported_slot_mask: u8,
+    pub peer_provisioned_slot_mask: u8,
+    pub peer_key_pair_id: [Option<u8>; SPDM_MAX_SLOT_NUMBER],
+    pub peer_cert_info: [Option<SpdmCertificateModelType>; SPDM_MAX_SLOT_NUMBER],
+    pub peer_key_usage_bit_mask: [Option<SpdmKeyUsageMask>; SPDM_MAX_SLOT_NUMBER],
 }
 
 #[cfg(feature = "mut-auth")]

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -1686,6 +1686,13 @@ mod tests {
                     },
                     SPDM_MAX_SLOT_NUMBER,
                 ),
+                supported_slot_mask: 0b11111111,
+                key_pair_id: gen_array_clone(0u8, SPDM_MAX_SLOT_NUMBER),
+                certificate_info: gen_array_clone(
+                    SpdmCertificateModelType::SpdmCertModelTypeNone,
+                    SPDM_MAX_SLOT_NUMBER,
+                ),
+                key_usage_mask: gen_array_clone(SpdmKeyUsageMask::empty(), SPDM_MAX_SLOT_NUMBER),
             }),
         };
         create_spdm_context!(context);

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -214,12 +214,14 @@ async fn test_spdm(
             ],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            ..Default::default()
         }
     } else {
         common::SpdmProvisionInfo {
             my_cert_chain_data: [None, None, None, None, None, None, None, None],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            ..Default::default()
         }
     };
 
@@ -707,12 +709,14 @@ async fn test_idekm_tdisp(
             ],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            ..Default::default()
         }
     } else {
         common::SpdmProvisionInfo {
             my_cert_chain_data: [None, None, None, None, None, None, None, None],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            ..Default::default()
         }
     };
 

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -365,6 +365,7 @@ async fn handle_message(
         ],
         my_cert_chain: [None, None, None, None, None, None, None, None],
         peer_root_cert_data: gen_array_clone(None, MAX_ROOT_CERT_SUPPORT),
+        ..Default::default()
     };
 
     spdmlib::secret::asym_sign::register(SECRET_ASYM_IMPL_INSTANCE.clone());

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -136,6 +136,28 @@ pub fn create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         ],
         my_cert_chain: [None, None, None, None, None, None, None, None],
         peer_root_cert_data: peer_root_cert_data_list,
+        local_supported_slot_mask: 0xff,
+        local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
+        local_cert_info: [
+            Some(SpdmCertificateModelType::SpdmCertModelTypeNone),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        local_key_usage_bit_mask: [
+            Some(SpdmKeyUsageMask::empty()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
     };
 
     (config_info, provision_info)
@@ -287,12 +309,35 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
             ],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            local_supported_slot_mask: 0xff,
+            local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
+            local_cert_info: [
+                Some(SpdmCertificateModelType::SpdmCertModelTypeNone),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            local_key_usage_bit_mask: [
+                Some(SpdmKeyUsageMask::empty()),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
         }
     } else {
         SpdmProvisionInfo {
             my_cert_chain_data: [None, None, None, None, None, None, None, None],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            ..Default::default()
         }
     };
 
@@ -417,6 +462,28 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         ],
         my_cert_chain: [None, None, None, None, None, None, None, None],
         peer_root_cert_data: gen_array_clone(None, MAX_ROOT_CERT_SUPPORT),
+        local_supported_slot_mask: 0xff,
+        local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
+        local_cert_info: [
+            Some(SpdmCertificateModelType::SpdmCertModelTypeNone),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+        local_key_usage_bit_mask: [
+            Some(SpdmKeyUsageMask::empty()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
     };
 
     (config_info, provision_info)

--- a/test/spdmlib-test/src/responder_tests/encap_get_digest.rs
+++ b/test/spdmlib-test/src/responder_tests/encap_get_digest.rs
@@ -91,6 +91,13 @@ fn test_handle_encap_response_digest() {
                 },
                 SPDM_MAX_SLOT_NUMBER,
             ),
+            supported_slot_mask: 0b11111111,
+            key_pair_id: gen_array_clone(0u8, SPDM_MAX_SLOT_NUMBER),
+            certificate_info: gen_array_clone(
+                SpdmCertificateModelType::SpdmCertModelTypeNone,
+                SPDM_MAX_SLOT_NUMBER,
+            ),
+            key_usage_mask: gen_array_clone(SpdmKeyUsageMask::empty(), SPDM_MAX_SLOT_NUMBER),
         }),
     };
     assert!(digests_rsp

--- a/test/spdmlib-test/src/responder_tests/encap_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/encap_rsp.rs
@@ -347,6 +347,13 @@ fn write_spdm_get_digest_response(
                 },
                 SPDM_MAX_SLOT_NUMBER,
             ),
+            supported_slot_mask: 0b11111111,
+            key_pair_id: gen_array_clone(0u8, SPDM_MAX_SLOT_NUMBER),
+            certificate_info: gen_array_clone(
+                SpdmCertificateModelType::SpdmCertModelTypeNone,
+                SPDM_MAX_SLOT_NUMBER,
+            ),
+            key_usage_mask: gen_array_clone(SpdmKeyUsageMask::empty(), SPDM_MAX_SLOT_NUMBER),
         }),
     };
     let _ = response


### PR DESCRIPTION
Fix: https://github.com/ccc-spdm-tools/spdm-rs/issues/181

This commit adds spdm 1.3 digest support including:
1. Message and context definitions.
2. Digest get and rsp handling flow for 1.3 new fields.
3. Unit tests update.

This patch remains:
1. Multi key conn unsupported, this patch only adds digests relative flow for multi key conn.
2. Digests field data handling remains bypassed as former implementation.