### PR TITLE
spdmlib: SpdmConnectionState enum shall assign unique values to each of its entries

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -47,7 +47,7 @@ enum_builder! {
         SpdmConnectionAfterCertificate => 0x5,
         // After CHALLENGE/CHALLENGE_AUTH,
         // and ENCAP CHALLENGE/CHALLENGE_AUTH if MUT_AUTH is enabled.
-        SpdmConnectionAuthenticated => 0x5
+        SpdmConnectionAuthenticated => 0x6
     }
 }
 #[allow(clippy::derivable_impls)]


### PR DESCRIPTION
SpdmConnectionAfterCertificate and SpdmConnectionAuthenticated share the same numerical value.
This commit changes SpdmConnectionAuthenticated value to 6.

Fix for https://github.com/ccc-spdm-tools/spdm-rs/issues/214