### PR TITLE
Replace deprecated EKU OID error handling

### DIFF
--- a/spdmlib/src/crypto/spdm_ring/cert_operation_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/cert_operation_impl.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-#![allow(deprecated)]
-
 extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;


### PR DESCRIPTION
This PR replaces deprecated EKU OID error handling.

Now, when the certificate validation fails, the error will specifically say which OID is present and which one is required.
E.g.

test crypto::spdm_ring::cert_operation_impl::tests::test_certificate_eku_v3_end_with_eku_example_1 ... ok
X.509 certificate verification failed: RequiredEkuNotFoundContext(RequiredEkuNotFoundContext { required: KeyPurposeId(1.3.6.1.4.1.796.530.3), present: [KeyPurposeId(43.6.1.4.1.131.28.130.18.4)] })

Certificate chain details:
  Total certificates in chain: 3
  CA certificate length: 483
  End entity certificate length: 579
  Number of intermediate certificates: 1
  Timestamp used: 1758899787
