### PR TITLE
Add slot_id = 0xff support for key exchange and finish

### DIFF
--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -1099,6 +1099,10 @@ impl Codec for SpdmAlgStruct {
 
 pub const SPDM_MAX_SLOT_NUMBER: usize = 8;
 
+pub const SPDM_PUB_KEY_SLOT_ID_KEY_EXCHANGE: u8 = 0xFF;
+pub const SPDM_PUB_KEY_SLOT_ID_KEY_EXCHANGE_RSP: u8 = 0xF;
+pub const SPDM_PUB_KEY_SLOT_ID_FINISH: u8 = 0xFF;
+
 enum_builder! {
     @U8
     EnumName: SpdmCertificateModelType;

--- a/spdmlib/src/requester/finish_req.rs
+++ b/spdmlib/src/requester/finish_req.rs
@@ -52,10 +52,14 @@ impl RequesterContext {
         info!("in_clear_text {:?}\n", in_clear_text);
 
         let req_slot_id = if let Some(req_slot_id) = req_slot_id {
-            if req_slot_id >= SPDM_MAX_SLOT_NUMBER as u8 {
+            if req_slot_id != SPDM_PUB_KEY_SLOT_ID_FINISH
+                && req_slot_id >= SPDM_MAX_SLOT_NUMBER as u8
+            {
                 return Err(SPDM_STATUS_INVALID_STATE_LOCAL);
             }
-            if self.common.provision_info.my_cert_chain[req_slot_id as usize].is_none() {
+            if req_slot_id < SPDM_MAX_SLOT_NUMBER as u8
+                && self.common.provision_info.my_cert_chain[req_slot_id as usize].is_none()
+            {
                 return Err(SPDM_STATUS_INVALID_STATE_LOCAL);
             }
             req_slot_id

--- a/spdmlib/src/responder/finish_rsp.rs
+++ b/spdmlib/src/responder/finish_rsp.rs
@@ -397,14 +397,24 @@ impl ResponderContext {
                 .calc_rsp_transcript_hash(false, session.get_slot_id(), true, session)?;
 
         let peer_slot_id = self.common.runtime_info.get_peer_used_cert_chain_slot_id();
-        let peer_cert = &self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
-            .as_ref()
-            .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
-            .data[(4usize + self.common.get_hash_size() as usize)
-            ..(self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
+        let peer_cert = if peer_slot_id == SPDM_PUB_KEY_SLOT_ID_KEY_EXCHANGE_RSP {
+            let peer_pub_key = self
+                .common
+                .provision_info
+                .peer_pub_key
+                .as_ref()
+                .ok_or(SPDM_STATUS_INVALID_PARAMETER)?;
+            &peer_pub_key.data[..peer_pub_key.data_size as usize]
+        } else {
+            &self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
                 .as_ref()
                 .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
-                .data_size as usize)];
+                .data[(4usize + self.common.get_hash_size() as usize)
+                ..(self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
+                    .as_ref()
+                    .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
+                    .data_size as usize)]
+        };
         let mut transcript_sign = ManagedBuffer12Sign::default();
         if self.common.negotiate_info.spdm_version_sel >= SpdmVersion::SpdmVersion12 {
             transcript_sign.reset_message();
@@ -443,15 +453,24 @@ impl ResponderContext {
                 .calc_rsp_transcript_hash(false, session.get_slot_id(), true, session)?;
 
         let peer_slot_id = self.common.runtime_info.get_peer_used_cert_chain_slot_id();
-        let peer_cert = &self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
-            .as_ref()
-            .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
-            .data[(4usize + self.common.get_hash_size() as usize)
-            ..(self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
+        let peer_cert = if peer_slot_id == SPDM_PUB_KEY_SLOT_ID_KEY_EXCHANGE_RSP {
+            let peer_pub_key = self
+                .common
+                .provision_info
+                .peer_pub_key
+                .as_ref()
+                .ok_or(SPDM_STATUS_INVALID_PARAMETER)?;
+            &peer_pub_key.data[..peer_pub_key.data_size as usize]
+        } else {
+            &self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
                 .as_ref()
                 .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
-                .data_size as usize)];
-
+                .data[(4usize + self.common.get_hash_size() as usize)
+                ..(self.common.peer_info.peer_cert_chain[peer_slot_id as usize]
+                    .as_ref()
+                    .ok_or(SPDM_STATUS_INVALID_PARAMETER)?
+                    .data_size as usize)]
+        };
         let mut transcript_hash_sign = ManagedBuffer12Sign::default();
         if self.common.negotiate_info.spdm_version_sel >= SpdmVersion::SpdmVersion12 {
             transcript_hash_sign.reset_message();

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -139,6 +139,8 @@ pub fn create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         ],
         my_cert_chain: [None, None, None, None, None, None, None, None],
         peer_root_cert_data: peer_root_cert_data_list,
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0xff,
         local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
         local_cert_info: [
@@ -315,6 +317,8 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
             ],
             my_cert_chain: [None, None, None, None, None, None, None, None],
             peer_root_cert_data: peer_root_cert_data_list,
+            my_pub_key: None,
+            peer_pub_key: None,
             local_supported_slot_mask: 0xff,
             local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
             local_cert_info: [
@@ -470,6 +474,8 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         ],
         my_cert_chain: [None, None, None, None, None, None, None, None],
         peer_root_cert_data: gen_array_clone(None, MAX_ROOT_CERT_SUPPORT),
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0xff,
         local_key_pair_id: [Some(0), None, None, None, None, None, None, None],
         local_cert_info: [

--- a/test/spdmlib-test/src/test_library_codec.rs
+++ b/test/spdmlib-test/src/test_library_codec.rs
@@ -397,6 +397,8 @@ fn test_spdm_provision_info_codec() {
         my_cert_chain_data: [None; SPDM_MAX_SLOT_NUMBER],
         my_cert_chain: [None; SPDM_MAX_SLOT_NUMBER],
         peer_root_cert_data: [None; MAX_ROOT_CERT_SUPPORT],
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0xFF,
         local_key_pair_id: [None; SPDM_MAX_SLOT_NUMBER],
         local_cert_info: [None; SPDM_MAX_SLOT_NUMBER],
@@ -467,6 +469,8 @@ fn test_spdm_provision_info_codec_with_populated_data() {
             // Leave rest as None to stay within buffer limits
             arr
         },
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0x03, // Only first two slots
         local_key_pair_id: [Some(1), Some(2), None, None, None, None, None, None],
         local_cert_info: [
@@ -569,6 +573,8 @@ fn test_spdm_provision_info_codec_edge_cases() {
         my_cert_chain_data: [None; SPDM_MAX_SLOT_NUMBER],
         my_cert_chain: [None; SPDM_MAX_SLOT_NUMBER],
         peer_root_cert_data: [None; MAX_ROOT_CERT_SUPPORT],
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0xFF,
         local_key_pair_id: [None; SPDM_MAX_SLOT_NUMBER],
         local_cert_info: [None; SPDM_MAX_SLOT_NUMBER],
@@ -1173,6 +1179,8 @@ fn test_large_struct_memory_boundaries() {
         my_cert_chain_data: [None; SPDM_MAX_SLOT_NUMBER],
         my_cert_chain: [None; SPDM_MAX_SLOT_NUMBER],
         peer_root_cert_data: [None; MAX_ROOT_CERT_SUPPORT],
+        my_pub_key: None,
+        peer_pub_key: None,
         local_supported_slot_mask: 0xFF,
         local_key_pair_id: [None; SPDM_MAX_SLOT_NUMBER],
         local_cert_info: [None; SPDM_MAX_SLOT_NUMBER],


### PR DESCRIPTION
Bypass the slot_id check and transcript for provisioned pub key
  in key exchange and finish messages.
This commit provides part of the flow of provisioned pub key support.