### PR TITLE
Add vdm custom transcript before key exchange and finish

### DIFF
--- a/spdmlib/src/requester/key_exchange_req.rs
+++ b/spdmlib/src/requester/key_exchange_req.rs
@@ -575,6 +575,7 @@ impl RequesterContext {
             false,
             &session.runtime_info.message_k,
             None,
+            None,
         )?;
 
         if self.common.negotiate_info.spdm_version_sel >= SpdmVersion::SpdmVersion12 {

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -678,6 +678,7 @@ impl ResponderContext {
             false,
             &session.runtime_info.message_k,
             None,
+            None,
         )?;
         if self.common.negotiate_info.spdm_version_sel >= SpdmVersion::SpdmVersion12 {
             message.reset_message();


### PR DESCRIPTION
This patch adds the interface to let upper user to overwrite transcripts
  of hash of specified chain or public key, by user assigned vdm transcripts.