### PR TITLE
.gitmodules: remove unused briansmith/webpki git module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "external/ring"]
 	path = external/ring
 	url = https://github.com/briansmith/ring.git
-[submodule "external/webpki"]
-	path = external/webpki
-	url = https://github.com/briansmith/webpki.git


### PR DESCRIPTION
Closes #278 - rustls/webpki is already used instead of briansmith/webpki.
This PR is to remove unused git submodule