### PR TITLE
spdm rsp handler error propagation

### DIFF
--- a/spdmlib/src/responder/algorithm_rsp.rs
+++ b/spdmlib/src/responder/algorithm_rsp.rs
@@ -20,8 +20,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_algorithm(bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_algorithm(bytes, writer)
     }
 
     pub fn write_spdm_algorithm<'a>(

--- a/spdmlib/src/responder/capability_rsp.rs
+++ b/spdmlib/src/responder/capability_rsp.rs
@@ -18,8 +18,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_capability_response(bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_capability_response(bytes, writer)
     }
 
     pub fn write_spdm_capability_response<'a>(

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -19,8 +19,7 @@ impl ResponderContext {
         session_id: Option<u32>,
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_certificate_response(session_id, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_certificate_response(session_id, bytes, writer)
     }
 
     fn write_spdm_certificate_response<'a>(

--- a/spdmlib/src/responder/challenge_rsp.rs
+++ b/spdmlib/src/responder/challenge_rsp.rs
@@ -26,8 +26,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_challenge_response(bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_challenge_response(bytes, writer)
     }
 
     pub fn write_spdm_challenge_response<'a>(

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -805,15 +805,6 @@ impl ResponderContext {
             self.common.chunk_context.chunk_status = common::SpdmChunkStatus::Idle;
         }
 
-        // Propagate the error upward if it is VDM defined error, otherwise remap to Ok.
-        let result = result.or_else(|e| {
-            if e.severity == StatusSeverity::ERROR && matches!(e.status_code, StatusCode::VDM(_)) {
-                Err(e)
-            } else {
-                Ok(())
-            }
-        });
-
         (result, rsp_slice)
     }
 
@@ -1085,8 +1076,7 @@ impl ResponderContext {
             self.common.chunk_context.chunk_message_data.fill(0);
         }
 
-        // Error Response contained in rsp_slice, remap error to Ok(()) for dispatcher.
-        (Ok(()), rsp_slice)
+        (result, rsp_slice)
     }
 
     #[cfg(feature = "chunk-cap")]

--- a/spdmlib/src/responder/digest_rsp.rs
+++ b/spdmlib/src/responder/digest_rsp.rs
@@ -23,8 +23,7 @@ impl ResponderContext {
         session_id: Option<u32>,
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_digest_response(session_id, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_digest_response(session_id, bytes, writer)
     }
 
     fn write_spdm_digest_response<'a>(

--- a/spdmlib/src/responder/encap_rsp.rs
+++ b/spdmlib/src/responder/encap_rsp.rs
@@ -27,18 +27,14 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        if self
-            .encap_check_version_cap_state(
-                SpdmRequestResponseCode::SpdmRequestGetEncapsulatedRequest.get_u8(),
-                writer,
-            )
-            .is_err()
-        {
-            (Ok(()), Some(writer.used_slice()))
-        } else {
-            let (_, rsp_slice) = self.write_encap_request_response(bytes, writer);
-            (Ok(()), rsp_slice)
+        let result = self.encap_check_version_cap_state(
+            SpdmRequestResponseCode::SpdmRequestGetEncapsulatedRequest.get_u8(),
+            writer,
+        );
+        if result.is_err() {
+            return (result, Some(writer.used_slice()));
         }
+        self.write_encap_request_response(bytes, writer)
     }
 
     fn write_encap_request_response<'a>(

--- a/spdmlib/src/responder/end_session_rsp.rs
+++ b/spdmlib/src/responder/end_session_rsp.rs
@@ -33,8 +33,7 @@ impl ResponderContext {
             stop_watchdog(session_id);
         }
 
-        let (_, rsp_slice) = self.write_spdm_end_session_response(session_id, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_end_session_response(session_id, bytes, writer)
     }
 
     pub fn write_spdm_end_session_response<'a>(

--- a/spdmlib/src/responder/error_rsp.rs
+++ b/spdmlib/src/responder/error_rsp.rs
@@ -40,8 +40,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_error_response(error_code, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_error_response(error_code, bytes, writer)
     }
 
     pub fn write_error_response<'a>(

--- a/spdmlib/src/responder/finish_rsp.rs
+++ b/spdmlib/src/responder/finish_rsp.rs
@@ -34,7 +34,7 @@ impl ResponderContext {
             }
         }
 
-        (Ok(()), rsp_slice)
+        (result, rsp_slice)
     }
 
     // Return true on success, false otherwise.

--- a/spdmlib/src/responder/heartbeat_rsp.rs
+++ b/spdmlib/src/responder/heartbeat_rsp.rs
@@ -16,8 +16,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_heartbeat_response(session_id, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_heartbeat_response(session_id, bytes, writer)
     }
 
     pub fn write_spdm_heartbeat_response<'a>(

--- a/spdmlib/src/responder/key_exchange_rsp.rs
+++ b/spdmlib/src/responder/key_exchange_rsp.rs
@@ -42,7 +42,7 @@ impl ResponderContext {
             }
         }
 
-        (Ok(()), rsp_slice)
+        (result, rsp_slice)
     }
 
     pub fn write_spdm_key_exchange_response<'a>(

--- a/spdmlib/src/responder/key_update_rsp.rs
+++ b/spdmlib/src/responder/key_update_rsp.rs
@@ -16,8 +16,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_key_update_response(session_id, bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_key_update_response(session_id, bytes, writer)
     }
 
     pub fn write_spdm_key_update_response<'a>(

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -40,7 +40,7 @@ impl ResponderContext {
             }
         }
 
-        (Ok(()), rsp_slice)
+        (status, rsp_slice)
     }
 
     pub fn write_spdm_measurement_response<'a>(

--- a/spdmlib/src/responder/psk_exchange_rsp.rs
+++ b/spdmlib/src/responder/psk_exchange_rsp.rs
@@ -42,7 +42,7 @@ impl ResponderContext {
             }
         }
 
-        (Ok(()), rsp_slice)
+        (result, rsp_slice)
     }
 
     pub fn write_spdm_psk_exchange_response<'a>(

--- a/spdmlib/src/responder/psk_finish_rsp.rs
+++ b/spdmlib/src/responder/psk_finish_rsp.rs
@@ -25,7 +25,7 @@ impl ResponderContext {
             }
         }
 
-        (Ok(()), rsp_slice)
+        (result, rsp_slice)
     }
 
     // Return true on success, false otherwise

--- a/spdmlib/src/responder/vendor_rsp.rs
+++ b/spdmlib/src/responder/vendor_rsp.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::common::SpdmCodec;
+use crate::error::SpdmResult;
 use crate::error::SPDM_STATUS_INVALID_MSG_FIELD;
 use crate::error::SPDM_STATUS_INVALID_STATE_LOCAL;
-use crate::error::{SpdmResult, StatusCode, StatusSeverity};
 use crate::message::*;
 use crate::responder::*;
 
@@ -16,18 +16,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (spdm_status, rsp_slice) =
-            self.write_spdm_vendor_defined_response(session_id, bytes, writer);
-
-        // Propagate the error upward if it is VDM defined error, otherwise convert to Ok.
-        let result = spdm_status.or_else(|e| {
-            if e.severity == StatusSeverity::ERROR && matches!(e.status_code, StatusCode::VDM(_)) {
-                Err(e)
-            } else {
-                Ok(())
-            }
-        });
-        (result, rsp_slice)
+        self.write_spdm_vendor_defined_response(session_id, bytes, writer)
     }
 
     pub fn write_spdm_vendor_defined_response<'a>(

--- a/spdmlib/src/responder/version_rsp.rs
+++ b/spdmlib/src/responder/version_rsp.rs
@@ -16,8 +16,7 @@ impl ResponderContext {
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
-        let (_, rsp_slice) = self.write_spdm_version_response(bytes, writer);
-        (Ok(()), rsp_slice)
+        self.write_spdm_version_response(bytes, writer)
     }
 
     pub fn write_spdm_version_response<'a>(


### PR DESCRIPTION
Commit: Let responder handlers upward propagate spdm status when error happens -
A proposal to let responder upward propagate spdm error returns.
Pros: 
  Let application caller get more knowledge on return status. 
  Let upper application have abilities to react to some error generated by handlers that could not be fully managed by a spdm message handler, for example, SPDM_STATUS_INVALID_STATE_LOCAL. 
  Maintain the same logic of spdm handlers and app message handler. The app message is propagating the error returns.
```
    fn dispatch_secured_app_message<'a>(
        &mut self,
        session_id: u32,
        bytes: &[u8],
        app_handle: usize,
        writer: &'a mut Writer,
    ) -> (SpdmResult, Option<&'a [u8]>) {
        debug!("dispatching secured app message\n");

        dispatch_secured_app_message_cb(self, session_id, bytes, app_handle, writer)
    }
```
Cons:
  API return logic change - Need upper caller to check spdm errors and map out unneeded spdm errors, rather than formerly returning Ok(Ok()) in process_message when invalid request arrives.
  Divergent from Spdmlib logic, where is sending error response while returning success in responder functions -- This divergence could be explained by the rust's functionality that could let function process_message return an error wrapped by an Ok: Ok(Err(SpdmStatus)), while C could only return a simple data libspdm_return_t.