### PR TITLE
spdmlib/crypto/x509v3: KeyUsage might contain optional BOOLEAN critical field

### DIFF
--- a/spdmlib/src/crypto/x509v3.rs
+++ b/spdmlib/src/crypto/x509v3.rs
@@ -414,6 +414,18 @@ fn get_key_usage_value(data: &[u8]) -> SpdmResult<(bool, u8)> {
                     return Err(SPDM_STATUS_VERIF_FAIL);
                 }
 
+                // Check for optional critical boolean field
+                if data[index] == ASN1_TAG_BOOLEAN {
+                    if index + 1 >= len {
+                        return Err(SPDM_STATUS_VERIF_FAIL);
+                    }
+                    let (bool_length, bool_consumed) = check_length(&data[index + 1..])?;
+                    index += 1 + bool_consumed + bool_length;
+                    if index >= len {
+                        return Err(SPDM_STATUS_VERIF_FAIL);
+                    }
+                }
+
                 if data[index] == ASN1_TAG_EXTN_VALUE {
                     if index + 1 >= len {
                         return Err(SPDM_STATUS_VERIF_FAIL);


### PR DESCRIPTION
This PR adds parsing of optional BOOLEAN critical field, as described by RFC5280:
https://datatracker.ietf.org/doc/html/rfc5280#section-4.1

Within the Extension SEQUENCE, the 'critical' BOOLEAN field is defined as having a DEFAULT value of FALSE.
According to ASN.1 encoding rules, when a field has a DEFAULT value and its value is equal to the default, it is not required to be encoded in the SEQUENCE.

This PR is to fix KeyUsage retrieval when BOOLEAN critical is present in SEQUENCE.