### PR TITLE
Move Spdm Message buffers from stack to context

### DIFF
--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -21,6 +21,8 @@ use core::ops::DerefMut;
 
 pub struct RequesterContext {
     pub common: common::SpdmContext,
+    pub send_buffer: Arc<Mutex<[u8; config::MAX_SPDM_MSG_SIZE]>>,
+    pub receive_buffer: Arc<Mutex<[u8; config::MAX_SPDM_MSG_SIZE]>>,
 }
 
 impl RequesterContext {
@@ -37,6 +39,8 @@ impl RequesterContext {
                 config_info,
                 provision_info,
             ),
+            send_buffer: Arc::new(Mutex::new([0u8; config::MAX_SPDM_MSG_SIZE])),
+            receive_buffer: Arc::new(Mutex::new([0u8; config::MAX_SPDM_MSG_SIZE])),
         }
     }
 

--- a/spdmlib/src/requester/get_capabilities_req.rs
+++ b/spdmlib/src/requester/get_capabilities_req.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use crate::error::{SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD};
+use crate::error::{
+    SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD,
+    SPDM_STATUS_INVALID_STATE_LOCAL,
+};
 use crate::message::*;
 use crate::protocol::*;
 use crate::requester::*;
@@ -15,14 +18,20 @@ impl RequesterContext {
             None,
         );
 
-        let mut send_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
-        let send_used = self.encode_spdm_capability(&mut send_buffer)?;
+        let send_buffer_arc = self.send_buffer.clone();
+        let mut send_buffer = send_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
+        let send_used = self.encode_spdm_capability(&mut send_buffer[..])?;
         self.send_message(None, &send_buffer[..send_used], false)
             .await?;
 
-        let mut receive_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
+        let receive_buffer_arc = self.receive_buffer.clone();
+        let mut receive_buffer = receive_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
         let used = self
-            .receive_message(None, &mut receive_buffer, false)
+            .receive_message(None, &mut receive_buffer[..], false)
             .await?;
         self.handle_spdm_capability_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }

--- a/spdmlib/src/requester/get_digests_req.rs
+++ b/spdmlib/src/requester/get_digests_req.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use crate::error::{SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD};
+use crate::error::{
+    SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD,
+    SPDM_STATUS_INVALID_STATE_LOCAL,
+};
 use crate::message::*;
 use crate::protocol::{SpdmVersion, SPDM_MAX_SLOT_NUMBER};
 use crate::requester::*;
@@ -17,15 +20,21 @@ impl RequesterContext {
             session_id,
         );
 
-        let mut send_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
-        let send_used = self.encode_spdm_digest(&mut send_buffer)?;
+        let send_buffer_arc = self.send_buffer.clone();
+        let mut send_buffer = send_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
+        let send_used = self.encode_spdm_digest(&mut send_buffer[..])?;
 
         self.send_message(session_id, &send_buffer[..send_used], false)
             .await?;
 
-        let mut receive_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
+        let receive_buffer_arc = self.receive_buffer.clone();
+        let mut receive_buffer = receive_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
         let used = self
-            .receive_message(session_id, &mut receive_buffer, false)
+            .receive_message(session_id, &mut receive_buffer[..], false)
             .await?;
 
         self.handle_spdm_digest_response(

--- a/spdmlib/src/requester/get_version_req.rs
+++ b/spdmlib/src/requester/get_version_req.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 use crate::error::{
-    SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD, SPDM_STATUS_NEGOTIATION_FAIL,
+    SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD,
+    SPDM_STATUS_INVALID_STATE_LOCAL, SPDM_STATUS_NEGOTIATION_FAIL,
 };
 use crate::message::*;
 use crate::protocol::*;
@@ -15,14 +16,20 @@ impl RequesterContext {
         // reset context on get version request
         self.common.reset_context();
 
-        let mut send_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
-        let send_used = self.encode_spdm_version(&mut send_buffer)?;
+        let send_buffer_arc = self.send_buffer.clone();
+        let mut send_buffer = send_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
+        let send_used = self.encode_spdm_version(&mut send_buffer[..])?;
         self.send_message(None, &send_buffer[..send_used], false)
             .await?;
 
-        let mut receive_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
+        let receive_buffer_arc = self.receive_buffer.clone();
+        let mut receive_buffer = receive_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
         let used = self
-            .receive_message(None, &mut receive_buffer, false)
+            .receive_message(None, &mut receive_buffer[..], false)
             .await?;
         self.handle_spdm_version_response(0, &send_buffer[..send_used], &receive_buffer[..used])
     }

--- a/spdmlib/src/requester/heartbeat_req.rs
+++ b/spdmlib/src/requester/heartbeat_req.rs
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use crate::error::{SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD};
+use crate::error::{
+    SpdmResult, SPDM_STATUS_ERROR_PEER, SPDM_STATUS_INVALID_MSG_FIELD,
+    SPDM_STATUS_INVALID_STATE_LOCAL,
+};
 use crate::message::*;
 use crate::requester::*;
 
@@ -16,15 +19,21 @@ impl RequesterContext {
             Some(session_id),
         );
 
-        let mut send_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
-        let used = self.encode_spdm_heartbeat(&mut send_buffer)?;
+        let send_buffer_arc = self.send_buffer.clone();
+        let mut send_buffer = send_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
+        let used = self.encode_spdm_heartbeat(&mut send_buffer[..])?;
         self.send_message(Some(session_id), &send_buffer[..used], false)
             .await?;
 
         // Receive
-        let mut receive_buffer = [0u8; config::MAX_SPDM_MSG_SIZE];
+        let receive_buffer_arc = self.receive_buffer.clone();
+        let mut receive_buffer = receive_buffer_arc
+            .try_lock()
+            .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
         let used = self
-            .receive_message(Some(session_id), &mut receive_buffer, false)
+            .receive_message(Some(session_id), &mut receive_buffer[..], false)
             .await?;
         self.handle_spdm_heartbeat_response(session_id, &receive_buffer[..used])
     }


### PR DESCRIPTION
Spdm message size could be configured to a large size that make spdm-rs
  library consume large stacks.
This commit moves the send/receive message buffers access from stack
  to context.

Part 1 of the issue https://github.com/ccc-spdm-tools/spdm-rs/issues/305, Part 2 will be another change specially handle stack used for large request when chunk-cap is enabled.
Improvement data is under collection.