### PR TITLE
Provide extend vdm APIs to avoid using buffers in vdm payload struct.

### DIFF
--- a/spdmlib/src/message/vendor.rs
+++ b/spdmlib/src/message/vendor.rs
@@ -495,7 +495,7 @@ pub struct VendorDefinedStructEx {
     pub vdm_handle: usize, // interpreted/managed by User
 }
 
-static VENDOR_DEFNIED_EX: OnceCell<VendorDefinedStructEx> = OnceCell::uninit();
+pub static VENDOR_DEFNIED_EX: OnceCell<VendorDefinedStructEx> = OnceCell::uninit();
 
 static VENDOR_DEFNIED_DEFAULT_EX: VendorDefinedStructEx = VendorDefinedStructEx {
     vendor_defined_request_handler_ex: |responder_context: &mut ResponderContext,


### PR DESCRIPTION
Provide raw buffers to upper caller in APIs and let the caller decide
  how to manage the buffers.

Test result (migtd 1 session env):
Before this patch
Rsp.
max stack usage: 152f10
max heap usage: 12e9bd
Req.
max stack usage: c7160
max heap usage: 16cf8c

After this patch
Rsp.
max stack usage: b3f88
max heap usage: 140927
Req.
max stack usage: 8a498
max heap usage: 15ef8e

Stack reduce: 47%
Heap reduce: 4%