### PR TITLE
Fix Cargo Clippy warnings about format strings

### DIFF
--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -246,6 +246,6 @@ fn main() {
     // Re-run the build script if the files at the given paths or envs have changed.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=../Cargo.lock");
-    println!("cargo:rerun-if-changed={}", SPDM_CONFIG_JSON_DEFAULT_PATH);
-    println!("cargo:rerun-if-env-changed={}", SPDM_CONFIG_ENV);
+    println!("cargo:rerun-if-changed={SPDM_CONFIG_JSON_DEFAULT_PATH}");
+    println!("cargo:rerun-if-env-changed={SPDM_CONFIG_ENV}");
 }

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -103,7 +103,7 @@ fn sign_ecdsa_asym_algo(
 
     // Check for environment variable first
     let key_file_path = if let Ok(env_key_path) = std::env::var("SPDM_RSP_EMU_PRIVATE_KEY_PATH") {
-        println!("Loading private key from env: {}", env_key_path);
+        println!("Loading private key from env: {env_key_path}");
         PathBuf::from(env_key_path)
     } else {
         let crate_dir = get_test_key_directory();
@@ -146,7 +146,7 @@ fn sign_rsa_asym_algo(
 
     // Check for environment variable first
     let key_file_path = if let Ok(env_key_path) = std::env::var("SPDM_RSP_EMU_PRIVATE_KEY_PATH") {
-        println!("Loading private key from env: {}", env_key_path);
+        println!("Loading private key from env: {env_key_path}");
         PathBuf::from(env_key_path)
     } else {
         let crate_dir = get_test_key_directory();

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -1340,7 +1340,7 @@ async fn test_idekm_tdisp(
     .await
     .unwrap();
     assert_eq!(tdi_state, TdiState::CONFIG_UNLOCKED);
-    println!("Successful Get Tdisp State: {:X?}!", tdi_state);
+    println!("Successful Get Tdisp State: {tdi_state:X?}!");
 
     let flags = LockInterfaceFlag::NO_FW_UPDATE;
     let default_stream_id = 0;
@@ -1362,10 +1362,7 @@ async fn test_idekm_tdisp(
     .await
     .unwrap();
     assert!(tdisp_error_code.is_none());
-    println!(
-        "Successful Lock Interface, start_interface_nonce: {:X?}!",
-        start_interface_nonce
-    );
+    println!("Successful Lock Interface, start_interface_nonce: {start_interface_nonce:X?}!");
 
     pci_tdisp_req_get_device_interface_state(
         &mut context,
@@ -1376,7 +1373,7 @@ async fn test_idekm_tdisp(
     .await
     .unwrap();
     assert_eq!(tdi_state, TdiState::CONFIG_LOCKED);
-    println!("Successful Get Tdisp State: {:X?}!", tdi_state);
+    println!("Successful Get Tdisp State: {tdi_state:X?}!");
 
     let mut report = [0u8; MAX_DEVICE_REPORT_BUFFER];
     let mut report_size = 0usize;
@@ -1392,10 +1389,7 @@ async fn test_idekm_tdisp(
     .unwrap();
     assert!(tdisp_error_code.is_none());
     let tdi_report = TdiReportStructure::read_bytes(&report).unwrap();
-    println!(
-        "Successful Get Interface Report, tdi_report: {:X?}!",
-        tdi_report
-    );
+    println!("Successful Get Interface Report, tdi_report: {tdi_report:X?}!");
 
     pci_tdisp_req_start_interface_request(
         &mut context,
@@ -1418,7 +1412,7 @@ async fn test_idekm_tdisp(
     .await
     .unwrap();
     assert_eq!(tdi_state, TdiState::RUN);
-    println!("Successful Get Tdisp State: {:X?}!", tdi_state);
+    println!("Successful Get Tdisp State: {tdi_state:X?}!");
 
     pci_tdisp_req_stop_interface_request(&mut context, session_id, interface_id)
         .await
@@ -1434,7 +1428,7 @@ async fn test_idekm_tdisp(
     .await
     .unwrap();
     assert_eq!(tdi_state, TdiState::CONFIG_UNLOCKED);
-    println!("Successful Get Tdisp State: {:X?}!", tdi_state);
+    println!("Successful Get Tdisp State: {tdi_state:X?}!");
 
     // end spdm session
     context.end_session(session_id).await.unwrap();

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -330,11 +330,11 @@ async fn handle_message(
 
     if let Some(chain_path) = cert_chain_path {
         // Load pre-assembled cert chain from single DER file
-        println!("Loading certificate chain from: {}", chain_path);
+        println!("Loading certificate chain from: {chain_path}");
         let cert_chain = std::fs::read(&chain_path)
             .unwrap_or_else(|e| panic!("Unable to read cert chain from {}: {}", chain_path, e));
         let chain_len = cert_chain.len();
-        println!("Loaded certificate chain size: {:?}", chain_len);
+        println!("Loaded certificate chain size: {chain_len:?}");
         my_cert_chain_data.data_size = chain_len as u32;
         my_cert_chain_data.data[0..chain_len].copy_from_slice(&cert_chain);
     } else {


### PR DESCRIPTION
Fix warning generated by cargo clippy:
warning: variables can be used directly in the `format!` string

This warning will arise with newer stable versions of Rust (1.88.0).