### PR TITLE
feat(test): separate USE_ECDSA and REQ_USE_ECDSA with SPDMRS_ env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ export SPDMRS_RSP_EMU_PRIVATE_KEY_PATH=/path/to/device.key.p8
 cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor"
 ```
 
+If RSA is used instead of ECDSA, following environment variables can be set before running spdm-requester-emu, spdm-responder-emu, or spdmlib-test:
+```bash
+export SPDMRS_USE_ECDSA=false        # controls base_asym_algo (BaseAsymAlgo)
+export SPDMRS_REQ_USE_ECDSA=false    # controls req_asym_algo (ReqBaseAsymAlg)
+```
+
 ### Cross test with [spdm_emu](https://github.com/DMTF/spdm-emu)
 Open one command windows in workspace and run:
 

--- a/test/spdm-emu/src/spdm_emu.rs
+++ b/test/spdm-emu/src/spdm_emu.rs
@@ -15,7 +15,14 @@ use spdmlib::config;
 
 pub const SOCKET_HEADER_LEN: usize = 12;
 pub const USE_PCIDOE: bool = true; // align with DMTF spdm_emu
+
+/// Default for base_asym_algo (BaseAsymAlgo - responder signing algorithm).
+/// Override at runtime with SPDMRS_USE_ECDSA env variable.
 pub const USE_ECDSA: bool = true;
+
+/// Default for req_asym_algo (ReqBaseAsymAlg - requester signing algorithm).
+/// Override at runtime with SPDMRS_REQ_USE_ECDSA env variable.
+pub const REQ_USE_ECDSA: bool = true;
 
 pub const SOCKET_TRANSPORT_TYPE_MCTP: u32 = 0x01;
 pub const SOCKET_TRANSPORT_TYPE_PCI_DOE: u32 = 0x02;
@@ -24,6 +31,24 @@ pub const SOCKET_SPDM_COMMAND_NORMAL: u32 = 0x0001;
 pub const SOCKET_SPDM_COMMAND_STOP: u32 = 0xFFFE;
 pub const SOCKET_SPDM_COMMAND_UNKOWN: u32 = 0xFFFF;
 pub const SOCKET_SPDM_COMMAND_TEST: u32 = 0xDEAD;
+
+/// Check if ECDSA should be used for base_asym_algo (BaseAsymAlgo).
+/// SPDMRS_USE_ECDSA=false or 0 -> uses RSA
+/// SPDMRS_USE_ECDSA=true or unset -> uses ECDSA (default)
+pub fn use_ecdsa() -> bool {
+    std::env::var("SPDMRS_USE_ECDSA")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(USE_ECDSA)
+}
+
+/// Check if ECDSA should be used for req_asym_algo (ReqBaseAsymAlg).
+/// SPDMRS_REQ_USE_ECDSA=false or 0 -> uses RSA
+/// SPDMRS_REQ_USE_ECDSA=true or unset -> uses ECDSA (default)
+pub fn req_use_ecdsa() -> bool {
+    std::env::var("SPDMRS_REQ_USE_ECDSA")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(REQ_USE_ECDSA)
+}
 
 #[derive(Debug, Copy, Clone, Default)]
 pub struct SpdmSocketHeader {

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -132,7 +132,7 @@ async fn test_spdm(
         req_capabilities,
         req_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
-        base_asym_algo: if USE_ECDSA {
+        base_asym_algo: if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
@@ -140,7 +140,7 @@ async fn test_spdm(
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
         dhe_algo: SpdmDheAlgo::SECP_384_R1,
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if USE_ECDSA {
+        req_asym_algo: if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
@@ -161,19 +161,19 @@ async fn test_spdm(
         ..Default::default()
     };
 
-    let ca_file_path = if USE_ECDSA {
+    let ca_file_path = if use_ecdsa() {
         "test_key/ecp384/ca.cert.der"
     } else {
         "test_key/rsa3072/ca.cert.der"
     };
     let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-    let inter_file_path = if USE_ECDSA {
+    let inter_file_path = if use_ecdsa() {
         "test_key/ecp384/inter.cert.der"
     } else {
         "test_key/rsa3072/inter.cert.der"
     };
     let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-    let leaf_file_path = if USE_ECDSA {
+    let leaf_file_path = if use_ecdsa() {
         "test_key/ecp384/end_responder.cert.der"
     } else {
         "test_key/rsa3072/end_responder.cert.der"
@@ -638,7 +638,7 @@ async fn test_idekm_tdisp(
         req_capabilities,
         req_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
-        base_asym_algo: if USE_ECDSA {
+        base_asym_algo: if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
@@ -646,7 +646,7 @@ async fn test_idekm_tdisp(
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
         dhe_algo: SpdmDheAlgo::SECP_384_R1,
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if USE_ECDSA {
+        req_asym_algo: if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
@@ -667,19 +667,19 @@ async fn test_idekm_tdisp(
         ..Default::default()
     };
 
-    let ca_file_path = if USE_ECDSA {
+    let ca_file_path = if use_ecdsa() {
         "test_key/ecp384/ca.cert.der"
     } else {
         "test_key/rsa3072/ca.cert.der"
     };
     let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-    let inter_file_path = if USE_ECDSA {
+    let inter_file_path = if use_ecdsa() {
         "test_key/ecp384/inter.cert.der"
     } else {
         "test_key/rsa3072/inter.cert.der"
     };
     let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-    let leaf_file_path = if USE_ECDSA {
+    let leaf_file_path = if use_ecdsa() {
         "test_key/ecp384/end_responder.cert.der"
     } else {
         "test_key/rsa3072/end_responder.cert.der"

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -295,7 +295,7 @@ async fn handle_message(
         rsp_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
         measurement_hash_algo: SpdmMeasurementHashAlgo::TPM_ALG_SHA_384,
-        base_asym_algo: if USE_ECDSA {
+        base_asym_algo: if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
@@ -303,7 +303,7 @@ async fn handle_message(
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
         dhe_algo: SpdmDheAlgo::SECP_384_R1,
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if USE_ECDSA {
+        req_asym_algo: if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
@@ -339,19 +339,19 @@ async fn handle_message(
         my_cert_chain_data.data[0..chain_len].copy_from_slice(&cert_chain);
     } else {
         // Use default individual cert files
-        let ca_file_path = if USE_ECDSA {
+        let ca_file_path = if use_ecdsa() {
             "test_key/ecp384/ca.cert.der"
         } else {
             "test_key/rsa3072/ca.cert.der"
         };
         let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-        let inter_file_path = if USE_ECDSA {
+        let inter_file_path = if use_ecdsa() {
             "test_key/ecp384/inter.cert.der"
         } else {
             "test_key/rsa3072/inter.cert.der"
         };
         let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-        let leaf_file_path = if USE_ECDSA {
+        let leaf_file_path = if use_ecdsa() {
             "test_key/ecp384/end_responder.cert.der"
         } else {
             "test_key/rsa3072/end_responder.cert.der"

--- a/test/spdmlib-test/src/common/mod.rs
+++ b/test/spdmlib-test/src/common/mod.rs
@@ -5,7 +5,32 @@
 #![forbid(unsafe_code)]
 
 // TBD: need test different algorithm combinations
+
+/// Default for base_asym_algo (BaseAsymAlgo - responder signing algorithm).
+/// Override at runtime with SPDMRS_USE_ECDSA env variable.
 pub const USE_ECDSA: bool = true;
+
+/// Default for req_asym_algo (ReqBaseAsymAlg - requester signing algorithm).
+/// Override at runtime with SPDMRS_REQ_USE_ECDSA env variable.
+pub const REQ_USE_ECDSA: bool = true;
+
+/// Check if ECDSA should be used for base_asym_algo (BaseAsymAlgo).
+/// SPDMRS_USE_ECDSA=false or 0 -> uses RSA
+/// SPDMRS_USE_ECDSA=true or unset -> uses ECDSA (default)
+pub fn use_ecdsa() -> bool {
+    std::env::var("SPDMRS_USE_ECDSA")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(USE_ECDSA)
+}
+
+/// Check if ECDSA should be used for req_asym_algo (ReqBaseAsymAlg).
+/// SPDMRS_REQ_USE_ECDSA=false or 0 -> uses RSA
+/// SPDMRS_REQ_USE_ECDSA=true or unset -> uses ECDSA (default)
+pub fn req_use_ecdsa() -> bool {
+    std::env::var("SPDMRS_REQ_USE_ECDSA")
+        .map(|v| v != "false" && v != "0")
+        .unwrap_or(REQ_USE_ECDSA)
+}
 
 pub mod util;
 

--- a/test/spdmlib-test/src/common/util.rs
+++ b/test/spdmlib-test/src/common/util.rs
@@ -5,7 +5,7 @@
 #![allow(unused)]
 
 use super::device_io::TestSpdmDeviceIo;
-use super::USE_ECDSA;
+use super::{req_use_ecdsa, use_ecdsa};
 use crate::common::device_io::{MySpdmDeviceIo, TestTransportEncap};
 use crate::common::secret_callback::*;
 use crate::common::transport::PciDoeTransportEncap;
@@ -224,7 +224,7 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         req_capabilities,
         req_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
-        base_asym_algo: if USE_ECDSA {
+        base_asym_algo: if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
@@ -232,7 +232,7 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
         dhe_algo: SpdmDheAlgo::SECP_384_R1,
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if USE_ECDSA {
+        req_asym_algo: if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
@@ -256,19 +256,19 @@ pub fn req_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
     };
 
     let crate_dir = get_test_key_directory();
-    let ca_file_path = if USE_ECDSA {
+    let ca_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/ca.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/ca.cert.der")
     };
     let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-    let inter_file_path = if USE_ECDSA {
+    let inter_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/inter.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/inter.cert.der")
     };
     let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-    let leaf_file_path = if USE_ECDSA {
+    let leaf_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/end_responder.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/end_responder.cert.der")
@@ -392,7 +392,7 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         rsp_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
         measurement_hash_algo: SpdmMeasurementHashAlgo::TPM_ALG_SHA_384,
-        base_asym_algo: if USE_ECDSA {
+        base_asym_algo: if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
@@ -400,7 +400,7 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
         dhe_algo: SpdmDheAlgo::SECP_384_R1,
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if USE_ECDSA {
+        req_asym_algo: if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
@@ -425,20 +425,20 @@ pub fn rsp_create_info() -> (SpdmConfigInfo, SpdmProvisionInfo) {
     };
 
     let crate_dir = get_test_key_directory();
-    let ca_file_path = if USE_ECDSA {
+    let ca_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/ca.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/ca.cert.der")
     };
     log::info!("{}", ca_file_path.display());
     let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-    let inter_file_path = if USE_ECDSA {
+    let inter_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/inter.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/inter.cert.der")
     };
     let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-    let leaf_file_path = if USE_ECDSA {
+    let leaf_file_path = if use_ecdsa() {
         crate_dir.join("test_key/ecp384/end_responder.cert.der")
     } else {
         crate_dir.join("test_key/rsa3072/end_responder.cert.der")


### PR DESCRIPTION
Separate base_asym_algo and req_asym_algo algorithm selection following
SPDM spec terminology:
- USE_ECDSA controls base_asym_algo (BaseAsymAlgo)
- REQ_USE_ECDSA controls req_asym_algo (ReqBaseAsymAlg)

Both can be overridden at runtime via environment variables:
- SPDMRS_USE_ECDSA=false -> use RSA for base_asym_algo
- SPDMRS_REQ_USE_ECDSA=false -> use RSA for req_asym_algo

Applied globally to spdm-requester-emu, spdm-responder-emu, and
spdmlib-test.