### PR TITLE
Use SPDMRS as prefix for SPDM_LOG variable

### DIFF
--- a/fuzz-target/fuzzlib/src/lib.rs
+++ b/fuzz-target/fuzzlib/src/lib.rs
@@ -30,7 +30,7 @@ use log::LevelFilter;
 use simple_logger::SimpleLogger;
 
 pub fn new_logger_from_env() -> SimpleLogger {
-    let level = match std::env::var("SPDM_LOG") {
+    let level = match std::env::var("SPDMRS_LOG") {
         Ok(x) => match x.to_lowercase().as_str() {
             "trace" => LevelFilter::Trace,
             "debug" => LevelFilter::Debug,

--- a/fuzz-target/pass_context/src/main.rs
+++ b/fuzz-target/pass_context/src/main.rs
@@ -12,7 +12,7 @@ use log::LevelFilter;
 use simple_logger::SimpleLogger;
 
 fn new_logger_from_env() -> SimpleLogger {
-    let level = match std::env::var("SPDM_LOG") {
+    let level = match std::env::var("SPDMRS_LOG") {
         Ok(x) => match x.to_lowercase().as_str() {
             "trace" => LevelFilter::Trace,
             "debug" => LevelFilter::Debug,

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -1440,10 +1440,10 @@ async fn test_idekm_tdisp(
     context.end_session(session_id).await.unwrap();
 }
 
-// A new logger enables the user to choose log level by setting a `SPDM_LOG` environment variable.
+// A new logger enables the user to choose log level by setting a `SPDMRS_LOG` environment variable.
 // Use the `Trace` level by default.
 fn new_logger_from_env() -> SimpleLogger {
-    let level = match std::env::var("SPDM_LOG") {
+    let level = match std::env::var("SPDMRS_LOG") {
         Ok(x) => match x.to_lowercase().as_str() {
             "trace" => LevelFilter::Trace,
             "debug" => LevelFilter::Debug,

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -101,10 +101,10 @@ async fn process_socket_message(
     }
 }
 
-// A new logger enables the user to choose log level by setting a `SPDM_LOG` environment variable.
+// A new logger enables the user to choose log level by setting a `SPDMRS_LOG` environment variable.
 // Use the `Trace` level by default.
 fn new_logger_from_env() -> SimpleLogger {
-    let level = match std::env::var("SPDM_LOG") {
+    let level = match std::env::var("SPDMRS_LOG") {
         Ok(x) => match x.to_lowercase().as_str() {
             "trace" => LevelFilter::Trace,
             "debug" => LevelFilter::Debug,


### PR DESCRIPTION
This is to avoid name space collision.