### PR TITLE
Use SPDMRS as prefix for SPDM_RSP_EMU_* path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ NOTE: In order to run the emu without hashed-transcript-data, please change `max
 Open command window and run:
 
 ```bash
-export SPDM_RSP_EMU_CERT_CHAIN_PATH=/path/to/cert_bundle.der
-export SPDM_RSP_EMU_PRIVATE_KEY_PATH=/path/to/device.key.p8
+export SPDMRS_RSP_EMU_CERT_CHAIN_PATH=/path/to/cert_bundle.der
+export SPDMRS_RSP_EMU_PRIVATE_KEY_PATH=/path/to/device.key.p8
 
 cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor"
 ```

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -102,7 +102,7 @@ fn sign_ecdsa_asym_algo(
     // openssl.exe pkcs8 -in private.der -inform DER -topk8 -nocrypt -outform DER > private.p8
 
     // Check for environment variable first
-    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDM_RSP_EMU_PRIVATE_KEY_PATH") {
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
         println!("Loading private key from env: {}", env_key_path);
         PathBuf::from(env_key_path)
     } else {
@@ -145,7 +145,7 @@ fn sign_rsa_asym_algo(
     // openssl.exe genpkey -algorithm rsa -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_keygen_pubexp:65537 -outform DER > private.der
 
     // Check for environment variable first
-    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDM_RSP_EMU_PRIVATE_KEY_PATH") {
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
         println!("Loading private key from env: {}", env_key_path);
         PathBuf::from(env_key_path)
     } else {

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -326,7 +326,7 @@ async fn handle_message(
     };
 
     // Check for environment variable or use default cert chain path
-    let cert_chain_path = std::env::var("SPDM_RSP_EMU_CERT_CHAIN_PATH").ok();
+    let cert_chain_path = std::env::var("SPDMRS_RSP_EMU_CERT_CHAIN_PATH").ok();
 
     if let Some(chain_path) = cert_chain_path {
         // Load pre-assembled cert chain from single DER file


### PR DESCRIPTION
It is added to avoid name space collision.