### PR TITLE
Fix all cargo clippy warnings in project code

### DIFF
--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -478,7 +478,7 @@ mod tests {
             buf: u8_slice,
             offs: 0,
         };
-        assert_eq!(reader.any_left(), true);
+        assert!(reader.any_left());
     }
     #[test]
     fn test_case1_any_left() {
@@ -487,7 +487,7 @@ mod tests {
             buf: u8_slice,
             offs: 4,
         };
-        assert_eq!(reader.any_left(), false);
+        assert!(!reader.any_left());
     }
     #[test]
     fn test_case0_read_bytes() {
@@ -504,7 +504,7 @@ mod tests {
             buf: u8_slice,
             offs: 4,
         };
-        assert_eq!(reader.sub(4).is_none(), true);
+        assert!(reader.sub(4).is_none());
     }
 
     #[test]

--- a/mctp_transport/src/header.rs
+++ b/mctp_transport/src/header.rs
@@ -10,6 +10,7 @@ use spdmlib::error::{
     SPDM_STATUS_ENCAP_FAIL,
 };
 extern crate alloc;
+#[cfg(not(feature = "is_sync"))]
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::ops::Deref;
@@ -211,11 +212,6 @@ mod tests {
     }
     #[test]
     fn test_case0_encap() {
-        use crate::header::tests::alloc::sync::Arc;
-        extern crate alloc;
-        use core::ops::DerefMut;
-        use spin::Mutex;
-
         {
             let mut mctp_transport_encap = MctpTransportEncap {};
             let mut transport_buffer = [100u8; config::SENDER_BUFFER_SIZE];

--- a/pcidoe_transport/src/header.rs
+++ b/pcidoe_transport/src/header.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
 extern crate alloc;
+#[cfg(not(feature = "is_sync"))]
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use codec::enum_builder;
@@ -272,7 +273,7 @@ mod tests_header {
         assert_eq!(4, reader.left());
         let pcidoemessageheader = PciDoeMessageHeader::read(&mut reader);
         assert_eq!(0, reader.left());
-        assert_eq!(pcidoemessageheader.is_none(), true);
+        assert!(pcidoemessageheader.is_none());
     }
     #[test]
     #[should_panic]

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -2878,18 +2878,12 @@ impl Codec for SpdmEncapContext {
 }
 
 #[cfg(feature = "chunk-cap")]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub enum SpdmChunkStatus {
+    #[default]
     Idle,
     ChunkSendAndAck,
     ChunkGetAndResponse,
-}
-
-#[cfg(feature = "chunk-cap")]
-impl Default for SpdmChunkStatus {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 #[cfg(feature = "chunk-cap")]

--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -1892,15 +1892,19 @@ mod tests_session {
     #[test]
     #[should_panic]
     fn test_case0_setup() {
-        let mut session = SpdmSession::default();
-        session.session_id = 0xffffu32;
+        let mut session = SpdmSession {
+            session_id: 0xffffu32,
+            ..SpdmSession::default()
+        };
         let session_id = 4294901758u32;
         let _ = session.setup(session_id).is_err();
     }
     #[test]
     fn test_case0_teardown() {
-        let mut session = SpdmSession::default();
-        session.session_id = 0x0f0f0f0fu32;
+        let mut session = SpdmSession {
+            session_id: 0x0f0f0f0fu32,
+            ..SpdmSession::default()
+        };
         session.teardown();
         assert!(session.session_id != 0x0f0f0f0fu32);
     }

--- a/spdmlib/src/crypto/crypto_tests.rs
+++ b/spdmlib/src/crypto/crypto_tests.rs
@@ -23,23 +23,23 @@ fn test_case_hash() {
     // Len = 8
     // Msg = d3
     // MD = 28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1
-    let mut ctx = hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_256).unwrap();
+    let ctx = hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_256).unwrap();
     let data = &from_hex("d3").unwrap();
     let md = &from_hex("28969cdfa74a12c82f3bad960b0b000aca2ac329deea5c2328ebc6f2ba9802c1").unwrap();
-    hash::hash_ctx_update(&mut ctx, data).unwrap();
+    hash::hash_ctx_update(&ctx, data).unwrap();
     let res = hash::hash_ctx_finalize(ctx).unwrap();
     assert_eq!(res.as_ref(), md);
 
     // Len = 512
     // Msg = 5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509
     // MD = 42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa
-    let mut ctx2 = hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_256).unwrap();
+    let ctx2 = hash::hash_ctx_init(SpdmBaseHashAlgo::TPM_ALG_SHA_256).unwrap();
     let data = &from_hex("5a86b737eaea8ee976a0a24da63e7ed7eefad18a101c1211e2b3650c5187c2a8a650547208251f6d4237e661c7bf4c77f335390394c37fa1a9f9be836ac28509").unwrap();
     let md = &from_hex("42e61e174fbb3897d6dd6cef3dd2802fe67b331953b06114a65c772859dfc1aa").unwrap();
-    hash::hash_ctx_update(&mut ctx2, &data.as_slice()[0..10]).unwrap();
-    let mut ctx3 = ctx2.clone();
-    hash::hash_ctx_update(&mut ctx2, &data[10..]).unwrap();
-    hash::hash_ctx_update(&mut ctx3, &data[10..]).unwrap();
+    hash::hash_ctx_update(&ctx2, &data.as_slice()[0..10]).unwrap();
+    let ctx3 = ctx2.clone();
+    hash::hash_ctx_update(&ctx2, &data[10..]).unwrap();
+    hash::hash_ctx_update(&ctx3, &data[10..]).unwrap();
     let res = hash::hash_ctx_finalize(ctx2).unwrap();
     let res3 = hash::hash_ctx_finalize(ctx3).unwrap();
     assert_eq!(res.as_ref(), md);
@@ -157,7 +157,7 @@ fn test_case_chacha20_poly1305() {
 }
 
 fn from_hex(hex_str: &str) -> Result<Vec<u8>, String> {
-    if hex_str.len() % 2 != 0 {
+    if !hex_str.len().is_multiple_of(2) {
         return Err(String::from(
             "Hex string does not have an even number of digits",
         ));
@@ -173,7 +173,7 @@ fn from_hex(hex_str: &str) -> Result<Vec<u8>, String> {
 }
 
 fn from_hex_to_aead_key(hex_str: &str) -> Result<SpdmAeadKeyStruct, String> {
-    if hex_str.len() % 2 != 0 || hex_str.len() > SPDM_MAX_AEAD_KEY_SIZE * 2 {
+    if !hex_str.len().is_multiple_of(2) || hex_str.len() > SPDM_MAX_AEAD_KEY_SIZE * 2 {
         return Err(String::from(
             "Hex string does not have an even number of digits",
         ));
@@ -192,7 +192,7 @@ fn from_hex_to_aead_key(hex_str: &str) -> Result<SpdmAeadKeyStruct, String> {
 }
 
 fn from_hex_to_aead_iv(hex_str: &str) -> Result<SpdmAeadIvStruct, String> {
-    if hex_str.len() % 2 != 0 || hex_str.len() > SPDM_MAX_AEAD_IV_SIZE * 2 {
+    if !hex_str.len().is_multiple_of(2) || hex_str.len() > SPDM_MAX_AEAD_IV_SIZE * 2 {
         return Err(String::from(
             "Hex string does not have an even number of digits",
         ));

--- a/spdmlib/src/crypto/spdm_ring/aead_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/aead_impl.rs
@@ -312,9 +312,7 @@ mod tests {
         let ret_tag_size = decrypt(aead_algo, key, iv, aad, cipher_text, tag, plain_text);
 
         match ret_tag_size {
-            Ok(16) => {
-                assert!(true)
-            }
+            Ok(16) => {}
             _ => {
                 panic!()
             }

--- a/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/asym_verify_impl.rs
@@ -316,8 +316,8 @@ mod tests {
     #[test]
     fn test_case0_ecc_signature_bin_to_der() {
         let signature = &mut [0x00u8; 64];
-        for i in 10..signature.len() {
-            signature[i] = 0x10;
+        for item in signature.iter_mut().skip(10) {
+            *item = 0x10;
         }
 
         let der_signature = &mut [0u8; 64];
@@ -328,8 +328,8 @@ mod tests {
     #[test]
     fn test_case1_ecc_signature_bin_to_der() {
         let signature = &mut [0x00u8; 64];
-        for i in 10..signature.len() {
-            signature[i] = 0xff;
+        for item in signature.iter_mut().skip(10) {
+            *item = 0xff;
         }
 
         let der_signature = &mut [0u8; 64];

--- a/spdmlib/src/crypto/spdm_ring/dhe_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/dhe_impl.rs
@@ -199,8 +199,9 @@ mod tests {
     }
     #[test]
     fn test_case1_dhe() {
-        for dhe_algo in [SpdmDheAlgo::empty()].iter() {
-            assert_eq!(generate_key_pair(*dhe_algo).is_none(), true);
+        {
+            let dhe_algo = SpdmDheAlgo::empty();
+            assert!(generate_key_pair(dhe_algo).is_none());
         }
     }
 
@@ -341,17 +342,17 @@ mod tests {
     fn test_multiple_serialization_rounds() {
         // Test that we can serialize and deserialize multiple times
         for dhe_algo in [SpdmDheAlgo::SECP_256_R1, SpdmDheAlgo::SECP_384_R1].iter() {
-            let (public_key, mut private_key_box) =
+            let (_public_key, mut private_key_box) =
                 generate_key_pair(*dhe_algo).expect("Failed to generate initial key pair");
 
             // Perform multiple serialization/deserialization rounds
             for round in 0..3 {
                 let private_key_bytes = private_key_box
                     .export_private_key()
-                    .expect(&alloc::format!("Failed to export key in round {}", round));
+                    .unwrap_or_else(|| panic!("Failed to export key in round {}", round));
 
                 private_key_box = import_private_key(*dhe_algo, &private_key_bytes)
-                    .expect(&alloc::format!("Failed to import key in round {}", round));
+                    .unwrap_or_else(|| panic!("Failed to import key in round {}", round));
             }
 
             // Generate a peer key and verify the final key still works

--- a/spdmlib/src/crypto/spdm_ring/hash_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hash_impl.rs
@@ -130,7 +130,7 @@ mod tests {
         let data = &mut [0u8; 64];
 
         let hash_all = hash_all(base_hash_algo, data);
-        assert_eq!(hash_all.is_none(), true);
+        assert!(hash_all.is_none());
     }
     #[test]
     fn test_case0_hash_update() {

--- a/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hkdf_impl.rs
@@ -107,14 +107,7 @@ mod tests {
         let out_size = 64;
         let hkdf_expand = hkdf_expand(base_hash_algo, &prk, info, out_size);
 
-        match hkdf_expand {
-            Some(_) => {
-                assert!(true)
-            }
-            None => {
-                assert!(false)
-            }
-        }
+        assert!(hkdf_expand.is_some());
     }
     #[test]
     fn test_case1_hkdf_expand() {
@@ -129,15 +122,8 @@ mod tests {
         let out_size = 64;
         let hkdf_expand = hkdf_expand(base_hash_algo, &prk, info, out_size);
 
-        match hkdf_expand {
-            Some(_) => {
-                // when bash_hash_algo is empty
-                // hkdf_expand will failed and return None.
-                assert!(false)
-            }
-            None => {
-                assert!(true)
-            }
-        }
+        // when bash_hash_algo is empty
+        // hkdf_expand will failed and return None.
+        assert!(hkdf_expand.is_none());
     }
 }

--- a/spdmlib/src/crypto/spdm_ring/hmac_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/hmac_impl.rs
@@ -68,9 +68,7 @@ mod tests {
         let spdm_digest_struct = hmac_verify(base_hash_algo, key.as_ref(), data, &spdm_digest);
 
         match spdm_digest_struct {
-            Ok(()) => {
-                assert!(true)
-            }
+            Ok(()) => {}
             _ => {
                 panic!()
             }
@@ -88,9 +86,7 @@ mod tests {
         let spdm_digest_struct = hmac_verify(base_hash_algo, key.as_ref(), data, &spdm_digest);
 
         match spdm_digest_struct {
-            Ok(()) => {
-                assert!(true)
-            }
+            Ok(()) => {}
             _ => {
                 panic!()
             }
@@ -110,9 +106,7 @@ mod tests {
         let spdm_digest_struct = hmac_verify(base_hash_algo, key.as_ref(), data, &spdm_digest);
 
         match spdm_digest_struct {
-            Ok(()) => {
-                assert!(true)
-            }
+            Ok(()) => {}
             _ => {
                 panic!()
             }

--- a/spdmlib/src/crypto/spdm_ring/rand_impl.rs
+++ b/spdmlib/src/crypto/spdm_ring/rand_impl.rs
@@ -43,9 +43,7 @@ mod tests {
         let data_len = get_random(data);
 
         match data_len {
-            Ok(16) => {
-                assert!(true)
-            }
+            Ok(16) => {}
             _ => {
                 panic!()
             }
@@ -56,9 +54,7 @@ mod tests {
         let data = &mut [100u8; 80];
         let data_len = get_random(data);
         match data_len {
-            Ok(80) => {
-                assert!(true)
-            }
+            Ok(80) => {}
             _ => {
                 panic!()
             }

--- a/spdmlib/src/crypto/x509v3.rs
+++ b/spdmlib/src/crypto/x509v3.rs
@@ -1652,8 +1652,8 @@ mod tests {
             .expect("unable to read ca cert!");
         let mut malformed_cert = cert.clone();
         malformed_cert[1] = 0x88;
-        for i in 2..10 {
-            malformed_cert[i] = 0xff;
+        for item in malformed_cert.iter_mut().take(10).skip(2) {
+            *item = 0xff;
         }
         assert_eq!(
             check_cert_format(

--- a/spdmlib/src/lib.rs
+++ b/spdmlib/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![no_std]
 #![forbid(unsafe_code)]
+#![allow(clippy::duplicate_mod)]
 
 #[cfg(feature = "std")]
 extern crate std;

--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -929,7 +929,7 @@ mod tests {
         assert_eq!(48, reader.left());
         let spdm_negotiate_algorithms_request_payload =
             SpdmNegotiateAlgorithmsRequestPayload::spdm_read(&mut context, &mut reader);
-        assert_eq!(spdm_negotiate_algorithms_request_payload.is_none(), true);
+        assert!(spdm_negotiate_algorithms_request_payload.is_none());
     }
     #[test]
     fn test_case0_spdm_algorithms_response_payload() {
@@ -1082,7 +1082,7 @@ mod tests {
         assert_eq!(48, reader.left());
         let spdm_algorithms_response_payload =
             SpdmAlgorithmsResponsePayload::spdm_read(&mut context, &mut reader);
-        assert_eq!(spdm_algorithms_response_payload.is_none(), true);
+        assert!(spdm_algorithms_response_payload.is_none());
         u8_slice[30] = 0;
 
         u8_slice[0] = 1; // number of algorithm structure tables
@@ -1091,7 +1091,7 @@ mod tests {
         assert_eq!(48, reader.left());
         let spdm_algorithms_response_payload =
             SpdmAlgorithmsResponsePayload::spdm_read(&mut context, &mut reader);
-        assert_eq!(spdm_algorithms_response_payload.is_none(), true);
+        assert!(spdm_algorithms_response_payload.is_none());
         u8_slice[0] = 0;
         u8_slice[35] = 0;
 
@@ -1100,7 +1100,7 @@ mod tests {
         assert_eq!(48, reader.left());
         let spdm_algorithms_response_payload =
             SpdmAlgorithmsResponsePayload::spdm_read(&mut context, &mut reader);
-        assert_eq!(spdm_algorithms_response_payload.is_none(), false);
+        assert!(spdm_algorithms_response_payload.is_some());
         assert_eq!(
             spdm_algorithms_response_payload
                 .unwrap()

--- a/spdmlib/src/message/certificate.rs
+++ b/spdmlib/src/message/certificate.rs
@@ -238,10 +238,11 @@ mod tests {
     fn test_case0_spdm_get_certificate_request_payload() {
         let u8_slice = &mut [0u8; 12];
         let mut writer = Writer::init(u8_slice);
-        let mut value = SpdmGetCertificateRequestPayload::default();
-        value.slot_id = 4;
-        value.offset = 100;
-        value.length = 100;
+        let value = SpdmGetCertificateRequestPayload {
+            slot_id: 4,
+            offset: 100,
+            length: 100,
+        };
 
         create_spdm_context!(context);
 
@@ -259,11 +260,12 @@ mod tests {
     fn test_case0_spdm_certificate_response_payload() {
         let u8_slice = &mut [0u8; 6 + MAX_SPDM_CERT_PORTION_LEN];
         let mut writer = Writer::init(u8_slice);
-        let mut value = SpdmCertificateResponsePayload::default();
-        value.slot_id = 4;
-        value.portion_length = MAX_SPDM_CERT_PORTION_LEN as u32;
-        value.remainder_length = 100;
-        value.cert_chain = [100u8; MAX_SPDM_CERT_PORTION_LEN];
+        let value = SpdmCertificateResponsePayload {
+            slot_id: 4,
+            portion_length: MAX_SPDM_CERT_PORTION_LEN as u32,
+            remainder_length: 100,
+            cert_chain: [100u8; MAX_SPDM_CERT_PORTION_LEN],
+        };
 
         create_spdm_context!(context);
 

--- a/spdmlib/src/message/challenge_test.rs
+++ b/spdmlib/src/message/challenge_test.rs
@@ -55,7 +55,7 @@ fn test_challenge_struct() {
         + INVALID_OPAQUE_DATA_LENGTH as usize
         + SHA256_DIGEST_SIZE * 2];
     LittleEndian::write_u16(
-        &mut u8_slice[(36 + 2 * SHA256_DIGEST_SIZE as usize)..],
+        &mut u8_slice[(36 + 2 * SHA256_DIGEST_SIZE)..],
         INVALID_OPAQUE_DATA_LENGTH,
     );
     let reader = &mut Reader::init(&u8_slice[2..]);
@@ -80,7 +80,7 @@ fn test_challenge_struct_opaque_data_length_negative() {
         + SHA256_DIGEST_SIZE * 2];
     const OPAQUE_DATA_LENGTH: u16 = 1024u16;
     LittleEndian::write_u16(
-        &mut u8_slice[(36 + 2 * SHA256_DIGEST_SIZE as usize)..],
+        &mut u8_slice[(36 + 2 * SHA256_DIGEST_SIZE)..],
         OPAQUE_DATA_LENGTH,
     );
     let reader = &mut Reader::init(&u8_slice[2..]);

--- a/spdmlib/src/message/chunk_get_test.rs
+++ b/spdmlib/src/message/chunk_get_test.rs
@@ -55,7 +55,7 @@ fn test_chunk_get_and_response_struct() {
     assert_eq!(u8_slice[4..6], [0, 0]);
     LittleEndian::write_u32(field_slice, chunk_size as u32);
     assert_eq!(u8_slice[6..10], field_slice[..]);
-    LittleEndian::write_u32(field_slice, large_message_size as u32);
+    LittleEndian::write_u32(field_slice, large_message_size);
     assert_eq!(u8_slice[10..14], field_slice[..]);
 
     context.chunk_context.transferred_size = 0;

--- a/spdmlib/src/message/chunk_send.rs
+++ b/spdmlib/src/message/chunk_send.rs
@@ -54,10 +54,8 @@ impl SpdmCodec for SpdmChunkSendRequestPayload {
             .encode(bytes)
             .map_err(|_| SPDM_STATUS_BUFFER_FULL)?; // Chunk Size
 
-        if self.large_message_size.is_some() {
-            cnt += self
-                .large_message_size
-                .unwrap()
+        if let Some(large_message_size) = self.large_message_size {
+            cnt += large_message_size
                 .encode(bytes)
                 .map_err(|_| SPDM_STATUS_BUFFER_FULL)?; // Large Message Size
         }

--- a/spdmlib/src/message/chunk_send_test.rs
+++ b/spdmlib/src/message/chunk_send_test.rs
@@ -40,7 +40,7 @@ fn test_chunk_send_struct() {
     assert_eq!(u8_slice[4..6], [0, 0]);
     LittleEndian::write_u32(field_slice, chunk_size as u32);
     assert_eq!(u8_slice[6..10], field_slice[..]);
-    LittleEndian::write_u32(field_slice, large_message_size as u32);
+    LittleEndian::write_u32(field_slice, large_message_size);
     assert_eq!(u8_slice[10..14], field_slice[..]);
     assert_eq!(
         u8_slice[14..(14 + chunk_size)],

--- a/spdmlib/src/message/digest.rs
+++ b/spdmlib/src/message/digest.rs
@@ -227,9 +227,11 @@ mod tests {
     fn test_case1_spdm_digests_response_payload() {
         let u8_slice = &mut [0u8; 2];
         let mut writer = Writer::init(u8_slice);
-        let mut value = SpdmDigestsResponsePayload::default();
-        value.slot_mask = 0b00000000;
-        value.digests = gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER);
+        let value = SpdmDigestsResponsePayload {
+            slot_mask: 0b00000000,
+            digests: gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER),
+            ..SpdmDigestsResponsePayload::default()
+        };
 
         create_spdm_context!(context);
 
@@ -240,9 +242,11 @@ mod tests {
 
         let u8_slice = &mut [0u8; 2];
         let mut writer = Writer::init(u8_slice);
-        let mut value = SpdmDigestsResponsePayload::default();
-        value.slot_mask = 0b00011111;
-        value.digests = gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER);
+        let value = SpdmDigestsResponsePayload {
+            slot_mask: 0b00011111,
+            digests: gen_array_clone(SpdmDigestStruct::default(), SPDM_MAX_SLOT_NUMBER),
+            ..SpdmDigestsResponsePayload::default()
+        };
 
         create_spdm_context!(context);
 

--- a/spdmlib/src/message/encapsulated_test.rs
+++ b/spdmlib/src/message/encapsulated_test.rs
@@ -20,7 +20,7 @@ fn test_get_encapsulated_request_payload() {
         .unwrap();
     assert_eq!(size, 2);
 
-    let mut reader = Reader::init(&mut buffer);
+    let mut reader = Reader::init(&buffer);
     let ret = SpdmGetEncapsulatedRequestPayload::spdm_read(&mut context, &mut reader);
     assert!(ret.is_some());
 }
@@ -36,7 +36,7 @@ fn test_encapsulated_request_payload() {
     let size = encap_req.spdm_encode(&mut context, &mut writer).unwrap();
     assert_eq!(size, 2);
 
-    let mut reader = Reader::init(&mut buffer);
+    let mut reader = Reader::init(&buffer);
     let encap_req = SpdmEncapsulatedRequestPayload::spdm_read(&mut context, &mut reader).unwrap();
     assert_eq!(encap_req.request_id, 0xa);
 }
@@ -54,7 +54,7 @@ fn test_deliver_encapsulated_response_payload() {
         .unwrap();
     assert_eq!(size, 2);
 
-    let mut reader = Reader::init(&mut buffer);
+    let mut reader = Reader::init(&buffer);
     let deliver_encap_rsp =
         SpdmDeliverEncapsulatedResponsePayload::spdm_read(&mut context, &mut reader).unwrap();
     assert_eq!(deliver_encap_rsp.request_id, 0xa);
@@ -78,7 +78,7 @@ fn test_encapsulated_response_ack_payload() {
         .unwrap();
     assert_eq!(size, 6);
 
-    let mut reader = Reader::init(&mut buffer);
+    let mut reader = Reader::init(&buffer);
     let encap_rsp_ack =
         SpdmEncapsulatedResponseAckPayload::spdm_read(&mut context, &mut reader).unwrap();
     assert_eq!(encap_rsp_ack.request_id, 0xa);
@@ -107,7 +107,7 @@ fn test_encapsulated_response_ack_payload_ver11() {
         .unwrap();
     assert_eq!(size, 2);
 
-    let mut reader = Reader::init(&mut buffer);
+    let mut reader = Reader::init(&buffer);
     let encap_rsp_ack =
         SpdmEncapsulatedResponseAckPayload::spdm_read(&mut context, &mut reader).unwrap();
     assert_eq!(encap_rsp_ack.request_id, 0xa);

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -1749,7 +1749,7 @@ mod tests {
         assert!(value.spdm_encode(&mut context, &mut writer).is_ok());
         let mut reader = Reader::init(u8_slice);
         let spdm_message = SpdmMessage::spdm_read(&mut context, &mut reader);
-        assert_eq!(spdm_message.is_none(), true);
+        assert!(spdm_message.is_none());
     }
 
     #[test]

--- a/spdmlib/src/message/version.rs
+++ b/spdmlib/src/message/version.rs
@@ -176,7 +176,7 @@ mod tests {
         assert!(value.encode(&mut writer).is_err());
         let mut reader = Reader::init(u8_slice);
         let spdmversionstruct = SpdmVersionStruct::read(&mut reader);
-        assert_eq!(spdmversionstruct.is_none(), true);
+        assert!(spdmversionstruct.is_none());
     }
     #[test]
     fn test_case0_spdm_version_response_payload() {

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -29,8 +29,6 @@ mod tests {
     }
 
     fn kem_roundtrip(algo: SpdmKemAlgo) {
-        use spdmlib::crypto::{SpdmKemCipherTextExchange, SpdmKemEncapKeyExchange};
-
         // Generate key pair (responder side)
         let (encap_key_struct, decap_exchange) =
             (kem_impl::DEFAULT_DECAP.generate_key_pair_cb)(algo).expect("generate_key_pair failed");
@@ -97,8 +95,10 @@ mod tests {
         let written = key_pair.sign(message, &mut sig_buf).expect("sign failed");
 
         // Build SpdmSignatureStruct
-        let mut sig_struct = SpdmSignatureStruct::default();
-        sig_struct.data_size = written as u16;
+        let mut sig_struct = SpdmSignatureStruct {
+            data_size: written as u16,
+            ..SpdmSignatureStruct::default()
+        };
         sig_struct.data[..written].copy_from_slice(&sig_buf[..written]);
 
         // Verify using our callback

--- a/spdmlib_crypto_mbedtls/src/aead_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/aead_impl.rs
@@ -177,7 +177,7 @@ mod test {
     }
 
     fn from_hex(hex_str: &str) -> Result<Vec<u8>, String> {
-        if hex_str.len() % 2 != 0 {
+        if !hex_str.len().is_multiple_of(2) {
             return Err(String::from(
                 "Hex string does not have an even number of digits",
             ));
@@ -193,7 +193,7 @@ mod test {
     }
 
     fn from_hex_to_aead_key(hex_str: &str) -> Result<SpdmAeadKeyStruct, String> {
-        if hex_str.len() % 2 != 0 || hex_str.len() > SPDM_MAX_AEAD_KEY_SIZE * 2 {
+        if !hex_str.len().is_multiple_of(2) || hex_str.len() > SPDM_MAX_AEAD_KEY_SIZE * 2 {
             return Err(String::from(
                 "Hex string does not have an even number of digits",
             ));
@@ -212,7 +212,7 @@ mod test {
     }
 
     fn from_hex_to_aead_iv(hex_str: &str) -> Result<SpdmAeadIvStruct, String> {
-        if hex_str.len() % 2 != 0 || hex_str.len() > SPDM_MAX_AEAD_IV_SIZE * 2 {
+        if !hex_str.len().is_multiple_of(2) || hex_str.len() > SPDM_MAX_AEAD_IV_SIZE * 2 {
             return Err(String::from(
                 "Hex string does not have an even number of digits",
             ));

--- a/spdmlib_crypto_mbedtls/src/dhe_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/dhe_impl.rs
@@ -139,7 +139,6 @@ fn test_case0_dhe() {
 }
 #[test]
 fn test_case1_dhe() {
-    for dhe_algo in [SpdmDheAlgo::empty()].iter() {
-        assert_eq!(generate_key_pair(*dhe_algo).is_none(), true);
-    }
+    let dhe_algo = SpdmDheAlgo::empty();
+    assert!(generate_key_pair(dhe_algo).is_none());
 }

--- a/spdmlib_crypto_mbedtls/src/hkdf_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hkdf_impl.rs
@@ -94,14 +94,7 @@ mod tests {
         let out_size = 64;
         let hkdf_expand = hkdf_expand(base_hash_algo, &prk, info, out_size);
 
-        match hkdf_expand {
-            Some(_) => {
-                assert!(true)
-            }
-            None => {
-                assert!(false)
-            }
-        }
+        assert!(hkdf_expand.is_some(), "hkdf_expand should succeed");
     }
     #[test]
     fn test_case1_hkdf_expand() {
@@ -116,15 +109,11 @@ mod tests {
         let out_size = 64;
         let hkdf_expand = hkdf_expand(base_hash_algo, &prk, info, out_size);
 
-        match hkdf_expand {
-            Some(_) => {
-                // when bash_hash_algo is empty
-                // hkdf_expand will failed and return None.
-                assert!(false)
-            }
-            None => {
-                assert!(true)
-            }
-        }
+        // when base_hash_algo is empty
+        // hkdf_expand will fail and return None.
+        assert!(
+            hkdf_expand.is_none(),
+            "hkdf_expand should fail with empty base_hash_algo"
+        );
     }
 }

--- a/test/cavp_acvts_test/src/main.rs
+++ b/test/cavp_acvts_test/src/main.rs
@@ -67,9 +67,9 @@ fn handle_input_json(input_json: String) -> io::Result<String> {
             continue;
         }
         let acv_version = value["acvVersion"].as_str();
-        if acv_version.is_some() {
+        if let Some(acv_version) = acv_version {
             output.push(serde_json::json!({
-                "acvVersion": acv_version.unwrap()
+                "acvVersion": acv_version
             }));
             continue;
         }
@@ -224,9 +224,9 @@ fn algorithm_sha2(test_groups: &Vec<Value>, algo_str: &str) -> Vec<Value> {
                     let len = content_length / 8;
                     assert_eq!(msg.as_slice().len(), len as usize);
 
-                    let mut ctx = hash::hash_ctx_init(algo).unwrap();
+                    let ctx = hash::hash_ctx_init(algo).unwrap();
                     for _ in 0..repeat {
-                        hash::hash_ctx_update(&mut ctx, msg.as_slice()).unwrap();
+                        hash::hash_ctx_update(&ctx, msg.as_slice()).unwrap();
                     }
                     let md = hash::hash_ctx_finalize(ctx).unwrap();
 
@@ -305,6 +305,7 @@ fn algorithm_hmac_sha2(test_groups: &Vec<Value>, algo_str: &str) -> Vec<Value> {
     results
 }
 
+#[allow(clippy::too_many_arguments)]
 fn ecdsa_verify(
     tc_id: u64,
     curve: &str,
@@ -629,7 +630,7 @@ fn handle_algorithm_ecdhe(test_groups: &Vec<Value>) -> Vec<Value> {
                             }
                         })
                         .is_ok();
-                    if ret == false {
+                    if !ret {
                         passed = false;
                     }
 
@@ -652,8 +653,10 @@ fn handle_algorithm_ecdhe(test_groups: &Vec<Value>) -> Vec<Value> {
                     let pub_x = from_hex(ephemeral_public_server_x).unwrap();
                     let pub_y = from_hex(ephemeral_public_server_y).unwrap();
 
-                    let mut public_key = SpdmDheExchangeStruct::default();
-                    public_key.data_size = (pub_x.len() + pub_y.len()) as u16;
+                    let mut public_key = SpdmDheExchangeStruct {
+                        data_size: (pub_x.len() + pub_y.len()) as u16,
+                        ..SpdmDheExchangeStruct::default()
+                    };
                     public_key.data[0..pub_x.len()].copy_from_slice(pub_x.as_slice());
                     public_key.data[pub_x.len()..pub_x.len() + pub_y.len()]
                         .copy_from_slice(pub_y.as_slice());
@@ -735,7 +738,7 @@ fn handle_algorithm_rsa(test_groups: &Vec<Value>) -> Vec<Value> {
 }
 
 fn from_hex(hex_str: &str) -> Result<Vec<u8>, String> {
-    if hex_str.len() % 2 != 0 {
+    if !hex_str.len().is_multiple_of(2) {
         return Err(String::from(
             "Hex string does not have an even number of digits",
         ));

--- a/test/spdmlib-test/src/requester_tests/finish_req.rs
+++ b/test/spdmlib-test/src/requester_tests/finish_req.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "hashed-transcript-data")]
 extern crate alloc;
 #[cfg(feature = "hashed-transcript-data")]
+#[allow(unused_imports)]
 use {
     crate::common::device_io::{FakeSpdmDeviceIo, FakeSpdmDeviceIoReceve, SharedBuffer},
     crate::common::secret_callback::*,
@@ -368,7 +369,7 @@ fn test_case1_send_receive_spdm_finish() {
             .send_receive_spdm_finish(None, 4294901758)
             .await
             .is_ok();
-        assert_eq!(status, false);
+        assert!(!status);
 
         for session in requester.common.session.iter() {
             assert_eq!(

--- a/test/spdmlib-test/src/requester_tests/get_certificate_req.rs
+++ b/test/spdmlib-test/src/requester_tests/get_certificate_req.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "hashed-transcript-data")]
 extern crate alloc;
 #[cfg(feature = "hashed-transcript-data")]
+#[allow(unused_imports)]
 use {
     crate::common::device_io::{FakeSpdmDeviceIo, FakeSpdmDeviceIoReceve, SharedBuffer},
     crate::common::secret_callback::*,

--- a/test/spdmlib-test/src/requester_tests/get_measurements_req.rs
+++ b/test/spdmlib-test/src/requester_tests/get_measurements_req.rs
@@ -257,14 +257,14 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
                 v.extend_from_slice(&[0xFF; 32]); // Nonce
                 v.extend_from_slice(&[0x10, 0x00]); // OpaqueDataLength
                 v.extend_from_slice(&[0x02; 16]); // OpaqueData
                 v.extend_from_slice(&[0x00; 8]); // RequesterContext
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(5),
         },
         Tc {
@@ -273,7 +273,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::SpdmMeasurementQueryTotalNumber,
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x01, 0x00, 0x01, 0x37, 0x00, 0x00];
                 v.extend_from_slice(fixed_block); // MeasurementRecordData
                 v.extend_from_slice(&[0xFF; 32]);
@@ -281,7 +281,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Err(SPDM_STATUS_INVALID_MSG_FIELD),
         },
         Tc {
@@ -290,7 +290,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::Unknown(0x05),
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x01, 0x00, 0x01, 0x37, 0x00, 0x00];
                 v.extend_from_slice(fixed_block);
                 v.extend_from_slice(&[0xFF; 32]);
@@ -298,7 +298,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(1), // should expect Err?
         },
         Tc {
@@ -307,7 +307,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::Unknown(0x05),
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x00, 0x00, 0x02, 0x6E, 0x00, 0x00];
                 v.extend_from_slice(fixed_block);
                 v.extend_from_slice(fixed_block);
@@ -316,7 +316,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Err(SPDM_STATUS_INVALID_MSG_FIELD),
         },
         Tc {
@@ -325,7 +325,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::Unknown(0xFF),
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x01, 0x00, 0x01, 0x37, 0x00, 0x00];
                 v.extend_from_slice(fixed_block);
                 v.extend_from_slice(&[0xFF; 32]);
@@ -333,7 +333,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(1),
         },
         Tc {
@@ -342,7 +342,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x01, 0x00, 0x01, 0x37, 0x00, 0x00];
                 v.extend_from_slice(fixed_block);
                 v.extend_from_slice(&[0xFF; 32]);
@@ -350,7 +350,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(1),
         },
         Tc {
@@ -359,14 +359,14 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::RAW_BIT_STREAM_REQUESTED,
             operation: SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
                 v.extend_from_slice(&[0xFF; 32]);
                 v.extend_from_slice(&[0x10, 0x00]);
                 v.extend_from_slice(&[0x02; 16]);
                 v.extend_from_slice(&[0x00; 8]);
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(0),
         },
         Tc {
@@ -375,7 +375,7 @@ fn test_handle_spdm_measurement_record_response() {
             attributes: SpdmMeasurementAttributes::SIGNATURE_REQUESTED,
             operation: SpdmMeasurementOperation::SpdmMeasurementRequestAll,
             requester_context: SpdmMeasurementContextStruct::default(),
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x00, 0x00, 0x02, 0x6E, 0x00, 0x00];
                 v.extend_from_slice(fixed_block);
                 v.extend_from_slice(fixed_block);
@@ -385,7 +385,7 @@ fn test_handle_spdm_measurement_record_response() {
                 v.extend_from_slice(&[0x00; 8]);
                 v.extend_from_slice(&[0xFF; 96]); // Signature
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Err(SPDM_STATUS_INVALID_MSG_FIELD),
         },
         Tc {
@@ -396,14 +396,14 @@ fn test_handle_spdm_measurement_record_response() {
             requester_context: SpdmMeasurementContextStruct {
                 data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
             },
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
                 v.extend_from_slice(&[0xFF; 32]); // Nonce
                 v.extend_from_slice(&[0x10, 0x00]); // OpaqueDataLength
                 v.extend_from_slice(&[0x02; 16]); // OpaqueData
                 v.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]); // RequesterContext
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Ok(5),
         },
         Tc {
@@ -414,14 +414,14 @@ fn test_handle_spdm_measurement_record_response() {
             requester_context: SpdmMeasurementContextStruct {
                 data: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
             },
-            receive_buffer: (|| -> Box<[u8]> {
+            receive_buffer: {
                 let mut v = vec![0x13, 0x60, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00];
                 v.extend_from_slice(&[0xFF; 32]); // Nonce
                 v.extend_from_slice(&[0x10, 0x00]); // OpaqueDataLength
                 v.extend_from_slice(&[0x02; 16]); // OpaqueData
                 v.extend_from_slice(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x09]); // Mismatched RequesterContext
                 v.into_boxed_slice()
-            })(),
+            },
             expected_result: Err(SPDM_STATUS_INVALID_MSG_FIELD),
         },
     ];
@@ -471,7 +471,7 @@ fn test_handle_spdm_measurement_record_response() {
                 &mut content_changed,
                 &mut spdm_measurement_record_structure,
                 &send_buffer,
-                &*tc.receive_buffer,
+                &tc.receive_buffer,
                 &mut transcript_meas,
             );
             assert!(
@@ -672,8 +672,10 @@ fn test_case1_send_receive_spdm_measurement() {
         message_l1l2
             .append_message(&transcript_meas.as_ref()[..transcript_meas_len - 96])
             .unwrap();
-        let mut spdm_signature_struct = SpdmSignatureStruct::default();
-        spdm_signature_struct.data_size = 96;
+        let mut spdm_signature_struct = SpdmSignatureStruct {
+            data_size: 96,
+            ..SpdmSignatureStruct::default()
+        };
         spdm_signature_struct.data[..96]
             .copy_from_slice(&transcript_meas.as_ref()[transcript_meas_len - 96..]);
         let message_l1l2_hash =
@@ -693,11 +695,11 @@ fn test_case1_send_receive_spdm_measurement() {
             .append_message(message_l1l2_hash.as_ref())
             .unwrap();
 
-        let cert_chain_data = &requester.common.peer_info.peer_cert_chain[0 as usize]
+        let cert_chain_data = &requester.common.peer_info.peer_cert_chain[0_usize]
             .as_ref()
             .unwrap()
             .data[(4usize + requester.common.get_hash_size() as usize)
-            ..(requester.common.peer_info.peer_cert_chain[0 as usize]
+            ..(requester.common.peer_info.peer_cert_chain[0_usize]
                 .as_ref()
                 .unwrap()
                 .data_size as usize)];
@@ -912,8 +914,10 @@ fn test_case3_send_receive_spdm_measurement() {
                 message_l1l2
                     .append_message(&transcript_meas.as_ref()[..transcript_meas_len - 96])
                     .unwrap();
-                let mut spdm_signature_struct = SpdmSignatureStruct::default();
-                spdm_signature_struct.data_size = 96;
+                let mut spdm_signature_struct = SpdmSignatureStruct {
+                    data_size: 96,
+                    ..SpdmSignatureStruct::default()
+                };
                 spdm_signature_struct.data[..96]
                     .copy_from_slice(&transcript_meas.as_ref()[transcript_meas_len - 96..]);
                 let message_l1l2_hash = crypto::hash::hash_all(
@@ -935,11 +939,11 @@ fn test_case3_send_receive_spdm_measurement() {
                     .append_message(message_l1l2_hash.as_ref())
                     .unwrap();
 
-                let cert_chain_data = &requester.common.peer_info.peer_cert_chain[0 as usize]
+                let cert_chain_data = &requester.common.peer_info.peer_cert_chain[0_usize]
                     .as_ref()
                     .unwrap()
                     .data[(4usize + requester.common.get_hash_size() as usize)
-                    ..(requester.common.peer_info.peer_cert_chain[0 as usize]
+                    ..(requester.common.peer_info.peer_cert_chain[0_usize]
                         .as_ref()
                         .unwrap()
                         .data_size as usize)];

--- a/test/spdmlib-test/src/requester_tests/key_exchange_req.rs
+++ b/test/spdmlib-test/src/requester_tests/key_exchange_req.rs
@@ -257,7 +257,7 @@ fn test_case1_send_receive_spdm_key_exchange() {
             .send_receive_spdm_key_exchange(0, measurement_summary_hash_type)
             .await
             .is_ok();
-        assert_eq!(status, false);
+        assert!(!status);
 
         for session in requester.common.session.iter() {
             assert_eq!(

--- a/test/spdmlib-test/src/requester_tests/negotiate_algorithms_req.rs
+++ b/test/spdmlib-test/src/requester_tests/negotiate_algorithms_req.rs
@@ -150,8 +150,8 @@ fn test_case1_send_receive_spdm_algorithm() {
 
         let status = requester.send_receive_spdm_algorithm().await.is_ok();
         assert!(status);
-        assert_eq!(requester.common.negotiate_info.multi_key_conn_req, true);
-        assert_eq!(requester.common.negotiate_info.multi_key_conn_rsp, true);
+        assert!(requester.common.negotiate_info.multi_key_conn_req);
+        assert!(requester.common.negotiate_info.multi_key_conn_rsp);
         assert_eq!(
             requester.common.negotiate_info.mel_specification_sel,
             SpdmMelSpecification::DMTF_MEL_SPEC
@@ -275,8 +275,8 @@ fn test_case2_send_receive_spdm_algorithm() {
 
         let status = requester.send_receive_spdm_algorithm().await.is_ok();
         assert!(status);
-        assert_eq!(requester.common.negotiate_info.multi_key_conn_req, false);
-        assert_eq!(requester.common.negotiate_info.multi_key_conn_rsp, false);
+        assert!(!requester.common.negotiate_info.multi_key_conn_req);
+        assert!(!requester.common.negotiate_info.multi_key_conn_rsp);
         assert_eq!(
             requester.common.negotiate_info.mel_specification_sel,
             SpdmMelSpecification::empty()

--- a/test/spdmlib-test/src/requester_tests/psk_exchange_req.rs
+++ b/test/spdmlib-test/src/requester_tests/psk_exchange_req.rs
@@ -171,7 +171,7 @@ fn test_case1_send_receive_spdm_psk_exchange() {
             .send_receive_spdm_psk_exchange(measurement_summary_hash_type, Some(&psk_key))
             .await
             .is_ok();
-        assert_eq!(status, false);
+        assert!(!status);
 
         for session in requester.common.session.iter() {
             assert_eq!(

--- a/test/spdmlib-test/src/requester_tests/psk_finish_req.rs
+++ b/test/spdmlib-test/src/requester_tests/psk_finish_req.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "hashed-transcript-data")]
 extern crate alloc;
 #[cfg(feature = "hashed-transcript-data")]
+#[allow(unused_imports)]
 use {
     crate::common::crypto_callback::*,
     crate::common::device_io::{FakeSpdmDeviceIo, FakeSpdmDeviceIoReceve, SharedBuffer},
@@ -279,7 +280,7 @@ fn test_case1_send_receive_spdm_psk_finish() {
             .send_receive_spdm_psk_finish(4294901758)
             .await
             .is_ok();
-        assert_eq!(status, false);
+        assert!(!status);
 
         for session in requester.common.session.iter() {
             assert_eq!(

--- a/test/spdmlib-test/src/requester_tests/vendor_req.rs
+++ b/test/spdmlib-test/src/requester_tests/vendor_req.rs
@@ -73,7 +73,7 @@ fn test_case0_send_spdm_vendor_defined_request() {
             )
             .await
             .is_ok();
-        assert_eq!(status, false); //since vendor defined response payload is not implemented, so false is expected here.
+        assert!(!status); //since vendor defined response payload is not implemented, so false is expected here.
     };
     executor::block_on(future);
 }

--- a/test/spdmlib-test/src/responder_tests/algorithm_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/algorithm_rsp.rs
@@ -141,18 +141,12 @@ fn test_case0_handle_spdm_algorithm() {
             spdm_sturct_data.measurement_specification,
             SpdmMeasurementSpecification::DMTF
         );
-        assert_eq!(
-            spdm_sturct_data
-                .other_params_support
-                .contains(SpdmAlgoOtherParams::MULTI_KEY_CONN),
-            true
-        );
-        assert_eq!(
-            spdm_sturct_data
-                .other_params_support
-                .contains(SpdmAlgoOtherParams::OPAQUE_DATA_FMT1),
-            true
-        );
+        assert!(spdm_sturct_data
+            .other_params_support
+            .contains(SpdmAlgoOtherParams::MULTI_KEY_CONN));
+        assert!(spdm_sturct_data
+            .other_params_support
+            .contains(SpdmAlgoOtherParams::OPAQUE_DATA_FMT1));
         assert_eq!(
             spdm_sturct_data.base_asym_algo,
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
@@ -218,20 +212,14 @@ fn test_case0_handle_spdm_algorithm() {
                 payload.measurement_specification_sel,
                 SpdmMeasurementSpecification::DMTF
             );
-            assert_eq!(
-                payload
-                    .other_params_selection
-                    .contains(SpdmAlgoOtherParams::MULTI_KEY_CONN),
-                false
-            );
-            assert_eq!(
-                payload
-                    .other_params_selection
-                    .contains(SpdmAlgoOtherParams::OPAQUE_DATA_FMT1),
-                true
-            );
-            assert_eq!(context.common.negotiate_info.multi_key_conn_req, false);
-            assert_eq!(context.common.negotiate_info.multi_key_conn_rsp, true);
+            assert!(!payload
+                .other_params_selection
+                .contains(SpdmAlgoOtherParams::MULTI_KEY_CONN));
+            assert!(payload
+                .other_params_selection
+                .contains(SpdmAlgoOtherParams::OPAQUE_DATA_FMT1));
+            assert!(!context.common.negotiate_info.multi_key_conn_req);
+            assert!(context.common.negotiate_info.multi_key_conn_rsp);
             assert_eq!(
                 payload.measurement_hash_algo,
                 SpdmMeasurementHashAlgo::TPM_ALG_SHA_384

--- a/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
@@ -156,7 +156,10 @@ pub fn construct_certificate_positive() -> (Vec<TestSpdmMessage>, Vec<TestSpdmMe
     let spdm_certificate_chain_len = spdm_certificate_chain.as_ref().len();
 
     const PORTION_LENGTH: usize = 0x200;
-    let count = (spdm_certificate_chain.as_ref().len() + PORTION_LENGTH - 1) / PORTION_LENGTH;
+    let count = spdm_certificate_chain
+        .as_ref()
+        .len()
+        .div_ceil(PORTION_LENGTH);
     for index in 0..count {
         let offset = index * PORTION_LENGTH;
         let remainder_length = spdm_certificate_chain_len - offset;

--- a/test/spdmlib-test/src/responder_tests/challenge_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/challenge_rsp.rs
@@ -226,7 +226,10 @@ fn test_case1_handle_spdm_challenge() {
     let spdm_certificate_chain_len = spdm_certificate_chain.as_ref().len();
 
     const PORTION_LENGTH: usize = 0x200;
-    let count = (spdm_certificate_chain.as_ref().len() + PORTION_LENGTH - 1) / PORTION_LENGTH;
+    let count = spdm_certificate_chain
+        .as_ref()
+        .len()
+        .div_ceil(PORTION_LENGTH);
     for index in 0..count {
         let offset = index * PORTION_LENGTH;
         let remainder_length = spdm_certificate_chain_len - offset;

--- a/test/spdmlib-test/src/responder_tests/digest_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/digest_rsp.rs
@@ -116,7 +116,10 @@ fn test_case1_handle_spdm_digest() {
     let spdm_certificate_chain_len = spdm_certificate_chain.as_ref().len();
 
     const PORTION_LENGTH: usize = 0x200;
-    let count = (spdm_certificate_chain.as_ref().len() + PORTION_LENGTH - 1) / PORTION_LENGTH;
+    let count = spdm_certificate_chain
+        .as_ref()
+        .len()
+        .div_ceil(PORTION_LENGTH);
     for index in 0..count {
         let offset = index * PORTION_LENGTH;
         let remainder_length = spdm_certificate_chain_len - offset;

--- a/test/spdmlib-test/src/responder_tests/encap_get_certificate.rs
+++ b/test/spdmlib-test/src/responder_tests/encap_get_certificate.rs
@@ -165,6 +165,6 @@ fn test_handle_encap_response_certificate() {
         .as_mut()
         .unwrap()
         .data_size;
-    assert_eq!(offset, 0x400 as u32);
+    assert_eq!(offset, 0x400_u32);
     assert_eq!(context.common.encap_context.encap_cert_size, offset + 0x400);
 }

--- a/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/vendor_rsp.rs
@@ -74,6 +74,6 @@ fn test_case0_handle_spdm_vendor_defined_request() {
             b'd'
         );
     } else {
-        assert!(false, "Not expected result!");
+        panic!("Not expected result!");
     }
 }

--- a/test/spdmlib-test/src/responder_tests/version_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/version_rsp.rs
@@ -113,7 +113,7 @@ pub fn construct_version_positive() -> (TestSpdmMessage, TestSpdmMessage) {
         u8::from(SpdmVersion::default()) as u16,
         MAX_SPDM_VERSION_COUNT,
     );
-    for (_, v) in config_info.spdm_version.iter().flatten().enumerate() {
+    for v in config_info.spdm_version.iter().flatten() {
         version_number_entry[version_number_entry_count] = (u8::from(*v) as u16) << 8;
         version_number_entry_count += 1;
     }

--- a/test/spdmlib-test/src/test_client_server.rs
+++ b/test/spdmlib-test/src/test_client_server.rs
@@ -71,20 +71,20 @@ fn intergration_client_server() {
         );
 
         let mut transcript_vca = None;
-        assert!(!requester_context
+        assert!(requester_context
             .init_connection(&mut transcript_vca)
             .await
-            .is_err());
+            .is_ok());
 
-        assert!(!requester_context
+        assert!(requester_context
             .send_receive_spdm_digest(None)
             .await
-            .is_err());
+            .is_ok());
 
-        assert!(!requester_context
+        assert!(requester_context
             .send_receive_spdm_certificate(None, 0)
             .await
-            .is_err());
+            .is_ok());
 
         #[cfg(feature = "mut-auth")]
         {

--- a/test/spdmlib-test/src/test_library_codec.rs
+++ b/test/spdmlib-test/src/test_library_codec.rs
@@ -426,26 +426,34 @@ fn test_spdm_provision_info_codec() {
 #[test]
 fn test_spdm_provision_info_codec_with_populated_data() {
     // Test with populated certificate data (populate first few slots only to stay within buffer limits)
-    let mut cert_data_1 = SpdmCertChainData::default();
-    cert_data_1.data_size = 50;
+    let mut cert_data_1 = SpdmCertChainData {
+        data_size: 50,
+        ..SpdmCertChainData::default()
+    };
     for i in 0..50 {
         cert_data_1.data[i] = (i % 256) as u8;
     }
 
-    let mut cert_data_2 = SpdmCertChainData::default();
-    cert_data_2.data_size = 60;
+    let mut cert_data_2 = SpdmCertChainData {
+        data_size: 60,
+        ..SpdmCertChainData::default()
+    };
     for i in 0..60 {
         cert_data_2.data[i] = ((i * 2) % 256) as u8;
     }
 
-    let mut peer_root_cert_1 = SpdmCertChainData::default();
-    peer_root_cert_1.data_size = 40;
+    let mut peer_root_cert_1 = SpdmCertChainData {
+        data_size: 40,
+        ..SpdmCertChainData::default()
+    };
     for i in 0..40 {
         peer_root_cert_1.data[i] = ((i * 3) % 256) as u8;
     }
 
-    let mut peer_root_cert_2 = SpdmCertChainData::default();
-    peer_root_cert_2.data_size = 35;
+    let mut peer_root_cert_2 = SpdmCertChainData {
+        data_size: 35,
+        ..SpdmCertChainData::default()
+    };
     for i in 0..35 {
         peer_root_cert_2.data[i] = ((i * 4) % 256) as u8;
     }
@@ -656,8 +664,10 @@ fn test_spdm_peer_info_codec_with_populated_data() {
     // Test with all populated certificate chains (smaller sizes to fit in buffers)
     let mut cert_chain_templates = Vec::new();
     for slot in 0..SPDM_MAX_SLOT_NUMBER {
-        let mut cert_chain = SpdmCertChainBuffer::default();
-        cert_chain.data_size = 80 + (slot as u32 * 10); // Smaller sizes to fit
+        let mut cert_chain = SpdmCertChainBuffer {
+            data_size: 80 + (slot as u32 * 10),
+            ..SpdmCertChainBuffer::default()
+        }; // Smaller sizes to fit
         for i in 0..cert_chain.data_size {
             cert_chain.data[i as usize] = ((i + slot as u32 * 3) % 256) as u8;
         }
@@ -693,14 +703,14 @@ fn test_spdm_peer_info_codec_with_populated_data() {
 
     let original = SpdmPeerInfo {
         peer_cert_chain: [
-            Some(cert_chain_templates[0].clone()),
-            Some(cert_chain_templates[1].clone()),
-            Some(cert_chain_templates[2].clone()),
-            Some(cert_chain_templates[3].clone()),
-            Some(cert_chain_templates[4].clone()),
-            Some(cert_chain_templates[5].clone()),
-            Some(cert_chain_templates[6].clone()),
-            Some(cert_chain_templates[7].clone()),
+            Some(cert_chain_templates[0]),
+            Some(cert_chain_templates[1]),
+            Some(cert_chain_templates[2]),
+            Some(cert_chain_templates[3]),
+            Some(cert_chain_templates[4]),
+            Some(cert_chain_templates[5]),
+            Some(cert_chain_templates[6]),
+            Some(cert_chain_templates[7]),
         ],
         peer_cert_chain_temp: None,
         peer_supported_slot_mask: 0xFF,   // All slots supported
@@ -1083,16 +1093,13 @@ fn test_spdm_negotiate_info_comprehensive() {
     for (i, original) in test_cases.iter().enumerate() {
         let mut buffer = [0u8; 4096];
         let mut writer = Writer::init(&mut buffer);
-        let encoded_size = original.encode(&mut writer).expect(&format!(
-            "Failed to encode SpdmNegotiateInfo test case {}",
-            i
-        ));
+        let encoded_size = original
+            .encode(&mut writer)
+            .unwrap_or_else(|_| panic!("Failed to encode SpdmNegotiateInfo test case {}", i));
 
         let mut reader = Reader::init(&buffer[..encoded_size]);
-        let decoded = SpdmNegotiateInfo::read(&mut reader).expect(&format!(
-            "Failed to decode SpdmNegotiateInfo test case {}",
-            i
-        ));
+        let decoded = SpdmNegotiateInfo::read(&mut reader)
+            .unwrap_or_else(|| panic!("Failed to decode SpdmNegotiateInfo test case {}", i));
 
         assert_eq!(*original, decoded, "Mismatch in test case {}", i);
     }


### PR DESCRIPTION
Fix all cargo clippy warnings across the workspace, covering all feature combinations and build targets.

## Changes by crate

### codec
- Replace `assert_eq!(x, true/false)` with `assert!(x)`/`assert!(!x)`

### mctp_transport
- Gate `alloc::boxed::Box` import with `cfg(not(feature = "is_sync"))`

### pcidoe_transport
- Gate `alloc::boxed::Box` import with `cfg(not(feature = "is_sync"))`
- Replace `assert_eq!(x, true/false)` with `assert!(x)`/`assert!(!x)`

### spdmlib
- Allow `clippy::duplicate_mod` for intentional shared test module pattern
- Use struct initializers instead of field reassignment after `Default::default()`
- Derive `Default` for `SpdmChunkStatus` with `#[default]` attribute
- Replace `if is_some()/unwrap()` with `if let Some()`
- Remove unnecessary `&mut` references and casts
- Use `.is_multiple_of()` instead of manual modulo checks
- Replace `assert_eq!(x, true/false)` with `assert!(x)`/`assert!(!x)`
- Remove `assert!(true/false)`, replace with `panic!()` or remove
- Use iterators instead of needless range loops
- Eliminate single-element loops
- Use `unwrap_or_else` instead of `expect` with `format!`
- Prefix unused variable with underscore
- Simplify boolean expressions

### spdmlib_crypto_aws_lc
- Remove unused trait imports
- Use struct initializer instead of field reassignment after `Default::default()`

### spdmlib_crypto_mbedtls
- Use `.is_multiple_of()` instead of manual modulo checks
- Eliminate single-element loop and use `assert!` instead of `assert_eq!` with bool
- Replace `assert!(true/false)` in match arms with `assert!(is_some/is_none)`

### test/cavp_acvts_test
- Replace `if is_some()/unwrap()` with `if let Some()`
- Use struct initializer instead of field reassignment after `Default::default()`
- Allow `clippy::too_many_arguments` for test helper function

### test/spdmlib-test
- Use struct initializer instead of field reassignment after `Default::default()`
- Replace `assert!(false)` with `panic!()`
- Replace `assert_eq!(x, true/false)` with `assert!(x)`/`assert!(!x)`
- Add `#[allow(unused_imports)]` for feature-gated import blocks
- Use `.div_ceil()` instead of manual ceiling division
- Remove unnecessary `.enumerate()` when index is discarded

## Test coverage
Verified clean with `cargo clippy --tests` across all feature combinations:
- Default features (spdm-ring, hashed-transcript-data, std)
- All spdmlib features (mut-auth, chunk-cap, fips, downcast, mandatory-mut-auth)
- async-executor, async-tokio, is_sync
- spdm-ring, spdm-aws-lc crypto backends
- no_std target (x86_64-unknown-none)
- Without hashed-transcript-data

Only remaining warnings are from 3rd-party `ring` crate (11 lifetime syntax warnings).