### PR TITLE
fix(deps): upgrade rand from 0.8.5 to 0.9.4 to fix GHSA-cq8v-f236-94qc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,20 +1492,19 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1513,11 +1512,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]

--- a/fuzz-target/random_requester/Cargo.toml
+++ b/fuzz-target/random_requester/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8.4"
+rand = "0.9.3"
 fuzzlib = { path = "../fuzzlib" }
 futures = { version = "0.3", default-features = false }
 async-trait = "0.1.71"

--- a/fuzz-target/requester/challenge_req/Cargo.toml
+++ b/fuzz-target/requester/challenge_req/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 fuzzlib = { path = "../../fuzzlib", default-features = false }
-rand = "0.8.4"
+rand = "0.9.3"
 afl = { version = "=0.15.12", optional = true }
 futures = { version = "0.3", default-features = false }
 async-trait = "0.1.71"


### PR DESCRIPTION
The rand crate at version 0.8.5 is affected by GHSA-cq8v-f236-94qc (Rand is unsound with a custom logger using rand::rng()). The fixed versions are 0.9.3 and 0.10.1.

Upgrade the rand dependency in:
- fuzz-target/random_requester/Cargo.toml: 0.8.4 -> 0.9.3
- fuzz-target/requester/challenge_req/Cargo.toml: 0.8.4 -> 0.9.3

Cargo.lock is updated to rand 0.9.4 (latest in the 0.9 series, which is >= the fixed version 0.9.3).

Closes #365