### PR TITLE
fix(spdmlib/session): clear backup flags and transcript hashes on reset

### DIFF
--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -562,6 +562,10 @@ impl SpdmSession {
         self.heartbeat_period = 0;
         self.secure_spdm_version_sel = SecuredMessageVersion::default();
         self.mut_auth_requested = SpdmKeyExchangeMutAuthAttributes::empty();
+        self.responder_backup_valid = false;
+        self.requester_backup_valid = false;
+        self.th1 = SpdmDigestStruct::default();
+        self.th2 = SpdmDigestStruct::default();
     }
 
     pub fn get_session_id(&self) -> u32 {


### PR DESCRIPTION
Extend `SpdmSession::set_default()` to also reset
`responder_backup_valid`, `requester_backup_valid`, `th1`, and `th2`. Without these resets, a session struct that is recycled after teardown or reset retains values from the previous connection.
An attacker could leverage this leakage to manipulate key updates or poison transcript hashes in future SPDM sessions.