### PR TITLE
spdmlib: use saturating shift for CT exponent timeout computation

### DIFF
--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -383,7 +383,9 @@ impl RequesterContext {
         crypto_request: bool,
     ) -> SpdmResult<usize> {
         let timeout: usize = if crypto_request {
-            2 << self.common.negotiate_info.rsp_ct_exponent_sel
+            2usize
+                .checked_shl(self.common.negotiate_info.rsp_ct_exponent_sel as u32)
+                .unwrap_or(usize::MAX)
         } else {
             ST1
         };

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -481,7 +481,9 @@ impl ResponderContext {
         info!("receive_message!\n");
 
         let timeout: usize = if crypto_request {
-            2 << self.common.negotiate_info.req_ct_exponent_sel
+            2usize
+                .checked_shl(self.common.negotiate_info.req_ct_exponent_sel as u32)
+                .unwrap_or(usize::MAX)
         } else {
             ST1
         };


### PR DESCRIPTION
receive_single_message() computes 2 << rsp_ct_exponent_sel where rsp_ct_exponent_sel is a u8 from the device CAPABILITIES response. With overflow-checks=true, any exponent >= 63 on x86_64 causes a checked-shift panic.

Replace the raw shift with checked_shl(), saturating to usize::MAX on overflow.