### PR TITLE
fix(spdmlib/algorithm): validate ALGORITHMS response is subset of offer

### DIFF
--- a/spdmlib/src/message/algorithm.rs
+++ b/spdmlib/src/message/algorithm.rs
@@ -215,12 +215,18 @@ impl SpdmCodec for SpdmNegotiateAlgorithmsRequestPayload {
                         key_schedule_present = true;
                     }
                     SpdmAlg::SpdmAlgoPqcReqAsym(_) => {
+                        if context.negotiate_info.spdm_version_sel < SpdmVersion::SpdmVersion14 {
+                            return None;
+                        }
                         if pqc_req_asym_present {
                             return None;
                         }
                         pqc_req_asym_present = true;
                     }
                     SpdmAlg::SpdmAlgoKem(_) => {
+                        if context.negotiate_info.spdm_version_sel < SpdmVersion::SpdmVersion14 {
+                            return None;
+                        }
                         if kem_present {
                             return None;
                         }
@@ -657,6 +663,9 @@ impl SpdmCodec for SpdmAlgorithmsResponsePayload {
                         }
                     }
                     SpdmAlg::SpdmAlgoPqcReqAsym(v) => {
+                        if context.negotiate_info.spdm_version_sel < SpdmVersion::SpdmVersion14 {
+                            return None;
+                        }
                         if pqc_req_asym_present {
                             return None;
                         }
@@ -667,6 +676,9 @@ impl SpdmCodec for SpdmAlgorithmsResponsePayload {
                         }
                     }
                     SpdmAlg::SpdmAlgoKem(v) => {
+                        if context.negotiate_info.spdm_version_sel < SpdmVersion::SpdmVersion14 {
+                            return None;
+                        }
                         if kem_present {
                             return None;
                         }
@@ -796,7 +808,7 @@ mod tests {
             ],
         };
         create_spdm_context!(context);
-        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
 
         assert!(value.spdm_encode(&mut context, &mut writer).is_ok());
         let mut reader = Reader::init(u8_slice);
@@ -881,7 +893,7 @@ mod tests {
         };
 
         create_spdm_context!(context);
-        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
 
         assert!(value.spdm_encode(&mut context, &mut writer).is_ok());
         let mut reader = Reader::init(u8_slice);
@@ -927,6 +939,59 @@ mod tests {
         u8_slice[31] = 1;
         let mut reader = Reader::init(u8_slice);
         assert_eq!(48, reader.left());
+        let spdm_negotiate_algorithms_request_payload =
+            SpdmNegotiateAlgorithmsRequestPayload::spdm_read(&mut context, &mut reader);
+        assert!(spdm_negotiate_algorithms_request_payload.is_none());
+    }
+
+    #[test]
+    fn test_case3_spdm_negotiate_algorithms_request_payload_rejects_v13_pqc_structs() {
+        let value = SpdmNegotiateAlgorithmsRequestPayload {
+            measurement_specification: SpdmMeasurementSpecification::DMTF,
+            other_params_support: SpdmAlgoOtherParams::empty(),
+            base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+            base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+            pqc_asym_algo: SpdmPqcAsymAlgo::empty(),
+            mel_specification: SpdmMelSpecification::empty(),
+            alg_struct_count: 5,
+            alg_struct: [
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                    alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::SECP_256_R1),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeAEAD,
+                    alg_supported: SpdmAlg::SpdmAlgoAead(SpdmAeadAlgo::AES_128_GCM),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeReqAsym,
+                    alg_supported: SpdmAlg::SpdmAlgoReqAsym(
+                        SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+                    ),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeKeySchedule,
+                    alg_supported: SpdmAlg::SpdmAlgoKeySchedule(
+                        SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
+                    ),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypePqcReqAsym,
+                    alg_supported: SpdmAlg::SpdmAlgoPqcReqAsym(SpdmPqcReqAsymAlgo::ALG_MLDSA_87),
+                },
+                SpdmAlgStruct::default(),
+            ],
+        };
+
+        let u8_slice = &mut [0u8; 52];
+        let mut writer = Writer::init(u8_slice);
+
+        create_spdm_context!(context);
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
+        assert!(value.spdm_encode(&mut context, &mut writer).is_ok());
+
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        let mut reader = Reader::init(u8_slice);
         let spdm_negotiate_algorithms_request_payload =
             SpdmNegotiateAlgorithmsRequestPayload::spdm_read(&mut context, &mut reader);
         assert!(spdm_negotiate_algorithms_request_payload.is_none());
@@ -978,7 +1043,7 @@ mod tests {
         };
 
         create_spdm_context!(context);
-        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
 
         context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
         context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
@@ -1155,6 +1220,64 @@ mod tests {
         );
         assert_eq!(spdm_sturct_data.alg_struct_count, 0);
         assert_eq!(16, reader.left());
+    }
+
+    #[test]
+    fn test_case3_spdm_algorithms_response_payload_rejects_v13_pqc_structs() {
+        let value = SpdmAlgorithmsResponsePayload {
+            measurement_specification_sel: SpdmMeasurementSpecification::DMTF,
+            other_params_selection: SpdmAlgoOtherParams::OPAQUE_DATA_FMT1,
+            measurement_hash_algo: SpdmMeasurementHashAlgo::RAW_BIT_STREAM,
+            base_asym_sel: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+            base_hash_sel: SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+            pqc_asym_sel: SpdmPqcAsymAlgo::empty(),
+            mel_specification_sel: SpdmMelSpecification::empty(),
+            alg_struct_count: 5,
+            alg_struct: [
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeDHE,
+                    alg_supported: SpdmAlg::SpdmAlgoDhe(SpdmDheAlgo::SECP_256_R1),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeAEAD,
+                    alg_supported: SpdmAlg::SpdmAlgoAead(SpdmAeadAlgo::AES_128_GCM),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeReqAsym,
+                    alg_supported: SpdmAlg::SpdmAlgoReqAsym(
+                        SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+                    ),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeKeySchedule,
+                    alg_supported: SpdmAlg::SpdmAlgoKeySchedule(
+                        SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
+                    ),
+                },
+                SpdmAlgStruct {
+                    alg_type: SpdmAlgType::SpdmAlgTypeKEM,
+                    alg_supported: SpdmAlg::SpdmAlgoKem(SpdmKemAlgo::ALG_MLKEM_1024),
+                },
+                SpdmAlgStruct::default(),
+            ],
+        };
+
+        let u8_slice = &mut [0u8; 56];
+        let mut writer = Writer::init(u8_slice);
+
+        create_spdm_context!(context);
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
+        context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
+        context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;
+        context.config_info.base_asym_algo = SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048;
+        context.config_info.base_hash_algo = SpdmBaseHashAlgo::TPM_ALG_SHA_256;
+        assert!(value.spdm_encode(&mut context, &mut writer).is_ok());
+
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        let mut reader = Reader::init(u8_slice);
+        let spdm_algorithms_response_payload =
+            SpdmAlgorithmsResponsePayload::spdm_read(&mut context, &mut reader);
+        assert!(spdm_algorithms_response_payload.is_none());
     }
 }
 

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -793,7 +793,7 @@ mod tests {
             ),
         };
         create_spdm_context!(context);
-        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion11;
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
 
         let spdm_message = new_spdm_message(value, context);
         assert_eq!(
@@ -891,7 +891,7 @@ mod tests {
             }),
         };
         create_spdm_context!(context);
-        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion11;
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
 
         context.config_info.measurement_specification = SpdmMeasurementSpecification::DMTF;
         context.config_info.measurement_hash_algo = SpdmMeasurementHashAlgo::RAW_BIT_STREAM;

--- a/spdmlib/src/requester/negotiate_algorithms_req.rs
+++ b/spdmlib/src/requester/negotiate_algorithms_req.rs
@@ -235,11 +235,52 @@ impl RequesterContext {
                             if algorithms.base_hash_sel.bits() == 0 {
                                 return Err(SPDM_STATUS_NEGOTIATION_FAIL);
                             }
+                            if !self
+                                .common
+                                .config_info
+                                .base_hash_algo
+                                .contains(algorithms.base_hash_sel)
+                            {
+                                error!(
+                                    "Responder base_hash_sel {:X?} not subset of offer {:X?}\n",
+                                    algorithms.base_hash_sel.bits(),
+                                    self.common.config_info.base_hash_algo.bits()
+                                );
+                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                            }
                             self.common.negotiate_info.base_hash_sel = algorithms.base_hash_sel;
+                            if algorithms.base_asym_sel.bits() != 0
+                                && !self
+                                    .common
+                                    .config_info
+                                    .base_asym_algo
+                                    .contains(algorithms.base_asym_sel)
+                            {
+                                error!(
+                                    "Responder base_asym_sel {:X?} not subset of offer {:X?}\n",
+                                    algorithms.base_asym_sel.bits(),
+                                    self.common.config_info.base_asym_algo.bits()
+                                );
+                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                            }
                             self.common.negotiate_info.base_asym_sel = algorithms.base_asym_sel;
                             if self.common.negotiate_info.spdm_version_sel
                                 >= SpdmVersion::SpdmVersion14
                             {
+                                if algorithms.pqc_asym_sel.bits() != 0
+                                    && !self
+                                        .common
+                                        .config_info
+                                        .pqc_asym_algo
+                                        .contains(algorithms.pqc_asym_sel)
+                                {
+                                    error!(
+                                        "Responder pqc_asym_sel {:X?} not subset of offer {:X?}\n",
+                                        algorithms.pqc_asym_sel.bits(),
+                                        self.common.config_info.pqc_asym_algo.bits()
+                                    );
+                                    return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                }
                                 self.common.negotiate_info.pqc_asym_sel = algorithms.pqc_asym_sel;
                             }
                             if algorithms.base_asym_sel.bits() == 0
@@ -255,6 +296,16 @@ impl RequesterContext {
                                 match &alg.alg_supported {
                                     SpdmAlg::SpdmAlgoDhe(v) => {
                                         if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                            if v.bits() != 0
+                                                && !self.common.config_info.dhe_algo.contains(*v)
+                                            {
+                                                error!(
+                                                    "Responder DHE {:X?} not subset of offer {:X?}\n",
+                                                    v.bits(),
+                                                    self.common.config_info.dhe_algo.bits()
+                                                );
+                                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                            }
                                             self.common.negotiate_info.dhe_sel = *v;
                                         } else {
                                             error!(
@@ -266,6 +317,16 @@ impl RequesterContext {
                                     }
                                     SpdmAlg::SpdmAlgoAead(v) => {
                                         if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                            if v.bits() != 0
+                                                && !self.common.config_info.aead_algo.contains(*v)
+                                            {
+                                                error!(
+                                                    "Responder AEAD {:X?} not subset of offer {:X?}\n",
+                                                    v.bits(),
+                                                    self.common.config_info.aead_algo.bits()
+                                                );
+                                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                            }
                                             self.common.negotiate_info.aead_sel = *v;
                                         } else {
                                             error!(
@@ -277,6 +338,20 @@ impl RequesterContext {
                                     }
                                     SpdmAlg::SpdmAlgoReqAsym(v) => {
                                         if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                            if v.bits() != 0
+                                                && !self
+                                                    .common
+                                                    .config_info
+                                                    .req_asym_algo
+                                                    .contains(*v)
+                                            {
+                                                error!(
+                                                    "Responder req_asym {:X?} not subset of offer {:X?}\n",
+                                                    v.bits(),
+                                                    self.common.config_info.req_asym_algo.bits()
+                                                );
+                                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                            }
                                             self.common.negotiate_info.req_asym_sel = *v;
                                         } else {
                                             error!(
@@ -288,6 +363,20 @@ impl RequesterContext {
                                     }
                                     SpdmAlg::SpdmAlgoKeySchedule(v) => {
                                         if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                            if v.bits() != 0
+                                                && !self
+                                                    .common
+                                                    .config_info
+                                                    .key_schedule_algo
+                                                    .contains(*v)
+                                            {
+                                                error!(
+                                                    "Responder key_schedule {:X?} not subset of offer {:X?}\n",
+                                                    v.bits(),
+                                                    self.common.config_info.key_schedule_algo.bits()
+                                                );
+                                                return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                            }
                                             self.common.negotiate_info.key_schedule_sel = *v;
                                         } else {
                                             error!(
@@ -302,6 +391,20 @@ impl RequesterContext {
                                             >= SpdmVersion::SpdmVersion14
                                         {
                                             if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                                if v.bits() != 0
+                                                    && !self
+                                                        .common
+                                                        .config_info
+                                                        .pqc_req_asym_algo
+                                                        .contains(*v)
+                                                {
+                                                    error!(
+                                                        "Responder pqc_req_asym {:X?} not subset of offer {:X?}\n",
+                                                        v.bits(),
+                                                        self.common.config_info.pqc_req_asym_algo.bits()
+                                                    );
+                                                    return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                                }
                                                 self.common.negotiate_info.pqc_req_asym_sel = *v;
                                             } else {
                                                 error!(
@@ -317,6 +420,20 @@ impl RequesterContext {
                                             >= SpdmVersion::SpdmVersion14
                                         {
                                             if v.is_no_more_than_one_selected() || v.bits() == 0 {
+                                                if v.bits() != 0
+                                                    && !self
+                                                        .common
+                                                        .config_info
+                                                        .kem_algo
+                                                        .contains(*v)
+                                                {
+                                                    error!(
+                                                        "Responder KEM {:X?} not subset of offer {:X?}\n",
+                                                        v.bits(),
+                                                        self.common.config_info.kem_algo.bits()
+                                                    );
+                                                    return Err(SPDM_STATUS_NEGOTIATION_FAIL);
+                                                }
                                                 self.common.negotiate_info.kem_sel = *v;
                                             } else {
                                                 error!(

--- a/test/spdmlib-test/src/responder_tests/algorithm_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/algorithm_rsp.rs
@@ -40,7 +40,7 @@ fn test_case0_handle_spdm_algorithm() {
             provision_info,
         );
 
-        context.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        context.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
         context
             .common
             .negotiate_info
@@ -60,7 +60,7 @@ fn test_case0_handle_spdm_algorithm() {
         let spdm_message_header = &mut [0u8; 1024];
         let mut writer = Writer::init(spdm_message_header);
         let value = SpdmMessageHeader {
-            version: SpdmVersion::SpdmVersion13,
+            version: SpdmVersion::SpdmVersion14,
             request_response_code: SpdmRequestResponseCode::SpdmRequestNegotiateAlgorithms,
         };
         assert!(value.encode(&mut writer).is_ok());
@@ -125,7 +125,7 @@ fn test_case0_handle_spdm_algorithm() {
 
         let mut reader = Reader::init(u8_slice);
         let spdm_message_header = SpdmMessageHeader::read(&mut reader).unwrap();
-        assert_eq!(spdm_message_header.version, SpdmVersion::SpdmVersion13);
+        assert_eq!(spdm_message_header.version, SpdmVersion::SpdmVersion14);
         assert_eq!(
             spdm_message_header.request_response_code,
             SpdmRequestResponseCode::SpdmRequestNegotiateAlgorithms
@@ -202,7 +202,7 @@ fn test_case0_handle_spdm_algorithm() {
         let spdm_message: SpdmMessage =
             SpdmMessage::spdm_read(&mut context.common, &mut reader).unwrap();
 
-        assert_eq!(spdm_message.header.version, SpdmVersion::SpdmVersion13);
+        assert_eq!(spdm_message.header.version, SpdmVersion::SpdmVersion14);
         assert_eq!(
             spdm_message.header.request_response_code,
             SpdmRequestResponseCode::SpdmResponseAlgorithms


### PR DESCRIPTION
The NEGOTIATE_ALGORITHMS response handler accepted any algorithm the responder proposed, even if the requester never offered it. A malicious responder could force use of a weak algorithm that the requester explicitly excluded.

Add subset validation: reject the response if any selected algorithm was not in the requester's offer bitmask.