### PR TITLE
fix(spdmlib): only increment decode sequence number on success

### DIFF
--- a/spdmlib/src/common/session.rs
+++ b/spdmlib/src/common/session.rs
@@ -1263,7 +1263,7 @@ impl SpdmSession {
                         app_buffer,
                         &self.handshake_secret.request_direction,
                     );
-                    if r != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
+                    if r.is_ok() {
                         self.handshake_secret.request_direction.sequence_number += 1;
                     }
                     r
@@ -1273,7 +1273,7 @@ impl SpdmSession {
                         app_buffer,
                         &self.handshake_secret.response_direction,
                     );
-                    if r != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
+                    if r.is_ok() {
                         self.handshake_secret.response_direction.sequence_number += 1;
                     }
                     r
@@ -1286,7 +1286,7 @@ impl SpdmSession {
                         app_buffer,
                         &self.application_secret.request_direction,
                     );
-                    if r != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
+                    if r.is_ok() {
                         self.application_secret.request_direction.sequence_number += 1;
                     }
                     r
@@ -1304,13 +1304,13 @@ impl SpdmSession {
                             app_buffer,
                             &self.application_secret_backup.response_direction,
                         );
-                        if r_backup != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
+                        if r_backup.is_ok() {
                             self.application_secret_backup
                                 .response_direction
                                 .sequence_number += 1;
                         }
                         r_backup
-                    } else if r != Err(SPDM_STATUS_SEQUENCE_NUMBER_OVERFLOW) {
+                    } else if r.is_ok() {
                         self.application_secret.response_direction.sequence_number += 1;
                         r
                     } else {


### PR DESCRIPTION
decode_spdm_secured_message() incremented the sequence number on every result except SEQUENCE_NUMBER_OVERFLOW. When AEAD decryption fails (e.g. CRYPTO_ERROR from a corrupted frame), the local counter advances but the peer's counter stays unchanged, causing a permanent desynchronization cascade where all subsequent decrypts fail.

Change the condition from 'r != Err(OVERFLOW)' to 'r.is_ok()' in all six decode paths (handshake req/resp, application req/resp, backup), matching the encode side which already uses 'r.is_ok()'.