### PR TITLE
fix(spdmlib): zeroize session secrets on RequestResynch error

### DIFF
--- a/spdmlib/src/requester/handle_error_response_req.rs
+++ b/spdmlib/src/requester/handle_error_response_req.rs
@@ -4,7 +4,6 @@
 
 use codec::{Codec, Reader};
 
-use crate::common::session::SpdmSessionState;
 use crate::error::{
     SpdmResult, SpdmStatus, SPDM_STATUS_BUSY_PEER, SPDM_STATUS_ERROR_PEER,
     SPDM_STATUS_INVALID_MSG_FIELD, SPDM_STATUS_INVALID_PARAMETER, SPDM_STATUS_INVALID_STATE_PEER,
@@ -32,7 +31,7 @@ impl RequesterContext {
                 } else {
                     return Err(SPDM_STATUS_INVALID_PARAMETER);
                 };
-                session.set_session_state(SpdmSessionState::SpdmSessionNotStarted);
+                session.teardown();
             }
             Err(SPDM_STATUS_INVALID_STATE_PEER)
         } else {


### PR DESCRIPTION
The SpdmErrorRequestResynch handler only called
set_session_state(SpdmSessionNotStarted) — a one-line setter that flips the state enum but leaves AES-GCM keys, HKDF secrets, salts, and finished_key live in the SpdmSession slot.

Replace with session.teardown() which calls set_default() and triggers ZeroizeOnDrop on all secret fields, matching the SpdmErrorDecryptError handler.