### PR TITLE
feat(emu): support SPDMRS_REJECT_REQUEST_ALL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,23 @@ export SPDMRS_USE_ECDSA=false        # controls base_asym_algo (BaseAsymAlgo)
 export SPDMRS_REQ_USE_ECDSA=false    # controls req_asym_algo (ReqBaseAsymAlg)
 ```
 
+### Reject GET_MEASUREMENTS RequestAll (simulate hardware limitation)
+
+Some devices do not support `GET_MEASUREMENTS` with `operation=0xFF` (RequestAll)
+and respond with SPDM ERROR `UnexpectedRequest` (code 0x05). To simulate this
+behavior in the responder emulator:
+
+```bash
+export SPDMRS_REJECT_REQUEST_ALL=1
+
+cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor"
+```
+
+When set, the responder sends `SpdmErrorUnexpectedRequest` for any RequestAll
+measurement request while keeping the SPDM session alive. This forces the
+requester to fall back to individual measurement collection (querying total count,
+then requesting each index separately).
+
 ### Run emulator with raw public key (PUB_KEY_ID) mode
 
 spdm-rs supports raw public key authentication per RFC 7250 (PUB_KEY_ID) as an alternative to certificate chains. In this mode, the responder uses a SubjectPublicKeyInfo DER-encoded public key instead of a full certificate chain.

--- a/spdmlib/src/responder/measurement_rsp.rs
+++ b/spdmlib/src/responder/measurement_rsp.rs
@@ -177,6 +177,15 @@ impl ResponderContext {
         let measurement_record = if get_measurements.measurement_operation
             == SpdmMeasurementOperation::SpdmMeasurementRequestAll
         {
+            // When SPDMRS_REJECT_REQUEST_ALL is set, reject RequestAll with
+            // UnexpectedRequest error (matching real silicon behavior where some
+            // devices do not support operation=0xFF). The session remains valid.
+            #[cfg(feature = "std")]
+            if std::env::var("SPDMRS_REJECT_REQUEST_ALL").is_ok() {
+                self.common.reset_message_m(session_id);
+                self.write_spdm_error(SpdmErrorCode::SpdmErrorUnexpectedRequest, 0, writer);
+                return (Ok(()), Some(writer.used_slice()));
+            }
             if let Some(meas) = secret::measurement::measurement_collection(
                 spdm_version_sel,
                 measurement_specification_sel,


### PR DESCRIPTION
This PR adds a new feature to spdm-emu.

When the SPDMRS_REJECT_REQUEST_ALL environment variable is set, the responder rejects GET_MEASUREMENTS with operation=0xFF (RequestAll) by sending SpdmErrorUnexpectedRequest and returning Ok - keeping the SPDM session alive for subsequent individual measurement requests.

The check lives in measurement_rsp.rs (the handler level) so that:
- The correct SPDM error code is sent (UnexpectedRequest = 0x05)
- The session remains valid (Ok return, no fatal error propagation)

This is introduced so downstream requesters can test-out different strategies of measurement retrieval.