### PR TITLE
feat(spdm_x509): enable and test PQC (ML-DSA) certificate chain mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,7 @@ name = "spdm_x509"
 version = "0.1.0"
 dependencies = [
  "base64ct",
+ "conquer-once",
  "const-oid",
  "der",
  "hex",
@@ -1926,10 +1927,10 @@ dependencies = [
 name = "spdmlib_crypto_mbedtls"
 version = "0.1.0"
 dependencies = [
- "der",
  "lazy_static",
  "mbedtls",
  "mbedtls-sys-auto",
+ "spdm_x509",
  "spdmlib",
  "spin 0.9.8",
  "zeroize",

--- a/README.md
+++ b/README.md
@@ -252,25 +252,40 @@ cargo build -p spdm-requester-emu -p spdm-responder-emu --no-default-features --
 
 **Run PQC self-test (spdm-rs requester vs spdm-rs responder):**
 
-Currently PQC is supported in raw public key mode (RFC 7250). Set the following environment variables to enable PQC:
+PQC is supported in both certificate chain mode (the default) and raw public
+key mode (RFC 7250). Certificate chain validation of ML-DSA certificates is
+provided by the `spdm_x509` library together with the aws-lc-rs backend (the
+`spdm-aws-lc` feature), which recognizes the ML-DSA OIDs and verifies ML-DSA
+certificate signatures.
+
+*Certificate chain mode (default):* set the following environment variables to
+enable PQC:
 
 ```
 export SPDM_CONFIG="etc/pqc_config.json"
 export SPDMRS_USE_PQC=true
-export SPDMRS_USE_RAW_PUB_KEY=true
 ```
 
 Open one command window and run the responder:
 ```
-SPDM_CONFIG="etc/pqc_config.json" SPDMRS_USE_PQC=true SPDMRS_USE_RAW_PUB_KEY=true cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
+SPDM_CONFIG="etc/pqc_config.json" SPDMRS_USE_PQC=true cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
 ```
 
 Open another command window and run the requester:
 ```
+SPDM_CONFIG="etc/pqc_config.json" SPDMRS_USE_PQC=true cargo run -p spdm-requester-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
+```
+
+*Raw public key mode (RFC 7250):* additionally set `SPDMRS_USE_RAW_PUB_KEY=true`
+on both peers:
+```
+SPDM_CONFIG="etc/pqc_config.json" SPDMRS_USE_PQC=true SPDMRS_USE_RAW_PUB_KEY=true cargo run -p spdm-responder-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
+```
+```
 SPDM_CONFIG="etc/pqc_config.json" SPDMRS_USE_PQC=true SPDMRS_USE_RAW_PUB_KEY=true cargo run -p spdm-requester-emu --no-default-features --features "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
 ```
 
-This exercises the full SPDM handshake with ML-DSA-87 for signature and ML-KEM-1024 for key exchange, including: GET_VERSION, GET_CAPABILITIES, NEGOTIATE_ALGORITHMS, CHALLENGE, GET_MEASUREMENTS, KEY_EXCHANGE, FINISH, HEARTBEAT, KEY_UPDATE, GET_MEASUREMENTS (in-session), END_SESSION, PSK_EXCHANGE, PSK_FINISH, and END_SESSION.
+This exercises the full SPDM handshake with ML-DSA-87 for signature and ML-KEM-1024 for key exchange, including: GET_VERSION, GET_CAPABILITIES, NEGOTIATE_ALGORITHMS, GET_DIGESTS, GET_CERTIFICATE, CHALLENGE, GET_MEASUREMENTS, KEY_EXCHANGE, FINISH, HEARTBEAT, KEY_UPDATE, GET_MEASUREMENTS (in-session), END_SESSION, PSK_EXCHANGE, PSK_FINISH, and END_SESSION. (GET_DIGESTS/GET_CERTIFICATE are exchanged in certificate chain mode; they are skipped in raw public key mode.)
 
 **Environment variables:**
 
@@ -278,9 +293,7 @@ This exercises the full SPDM handshake with ML-DSA-87 for signature and ML-KEM-1
 |---|---|
 | `SPDM_CONFIG` | Set to `"etc/pqc_config.json"` for PQC builds (larger buffers for ML-DSA signatures and cert chains) |
 | `SPDMRS_USE_PQC` | Set to `true` to enable PQC-only mode (ML-DSA-87 + ML-KEM-1024) |
-| `SPDMRS_USE_RAW_PUB_KEY` | Set to `true` to use raw public key (RFC 7250) instead of certificate chain |
-
-**Note:** PQC certificate chain mode is not yet supported because the ring/webpki library does not recognize ML-DSA OIDs. Raw public key mode must be used for PQC testing.
+| `SPDMRS_USE_RAW_PUB_KEY` | Set to `true` to use raw public key (RFC 7250) instead of the default certificate chain |
 
 ### Cross test with [spdm_emu](https://github.com/DMTF/spdm-emu)
 Open one command windows in workspace and run:

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -126,6 +126,9 @@ RUN_REQUESTER_CHUNK_CAP_FEATURES="${RUN_REQUESTER_FEATURES},chunk-cap"
 RUN_RESPONDER_CHUNK_CAP_FEATURES="${RUN_RESPONDER_FEATURES},chunk-cap"
 RUN_REQUESTER_PQC_FEATURES="${RUN_REQUESTER_FEATURES},spdm-aws-lc,chunk-cap"
 RUN_RESPONDER_PQC_FEATURES="${RUN_RESPONDER_FEATURES},spdm-aws-lc,chunk-cap"
+RUN_REQUESTER_PQC_MUTAUTH_FEATURES="${RUN_REQUESTER_PQC_FEATURES},mut-auth"
+RUN_RESPONDER_PQC_MUTAUTH_FEATURES="${RUN_RESPONDER_PQC_FEATURES},mut-auth"
+RUN_RESPONDER_PQC_MANDATORY_MUTAUTH_FEATURES="${RUN_RESPONDER_PQC_FEATURES},mandatory-mut-auth"
 
 
 run_with_spdm_emu() {
@@ -210,6 +213,16 @@ run_basic_test() {
     echo_command cargo test -p spdm_x509 -- --test-threads=1
     echo_command cargo test -p spdm_x509 --no-default-features -- --test-threads=1
     echo "Running basic spdm_x509 tests finished..."
+
+    # ML-DSA (FIPS 204) certificate-chain verification unit tests. These build
+    # the aws-lc-rs backend, so they run only where that toolchain is available
+    # (the spdm-aws-lc CI job). Covers the happy path (all ML-DSA variants
+    # validate) and fail paths (tampered signature / intermediate rejected).
+    if [[ "${RUN_REQUESTER_FEATURES}" == *"spdm-aws-lc"* ]]; then
+        echo "Running ML-DSA certificate-chain tests (spdmlib_crypto_aws_lc)..."
+        echo_command cargo test -p spdmlib_crypto_aws_lc -- --test-threads=1
+        echo "Running ML-DSA certificate-chain tests finished..."
+    fi
 
     echo "Running spdmlib-test..."
     pushd test/spdmlib-test
@@ -300,7 +313,7 @@ run_rust_spdm_emu_raw_pub_key() {
     cleanup
 }
 
-run_rust_spdm_emu_pqc() {
+run_rust_spdm_emu_pqc_raw_pub_key() {
     echo "Running requester and responder with PQC (ML-DSA + ML-KEM)..."
     echo_command export SPDM_CONFIG="etc/pqc_config.json"
     # Force build.rs to regenerate config.rs with PQC buffer sizes.
@@ -314,6 +327,152 @@ run_rust_spdm_emu_pqc() {
     echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_FEATURES"
     unset SPDMRS_USE_PQC
     unset SPDMRS_USE_RAW_PUB_KEY
+    echo_command unset SPDM_CONFIG
+    cleanup
+}
+
+run_rust_spdm_emu_pqc_cert_chain() {
+    echo "Running requester and responder with PQC (ML-DSA + ML-KEM) certificate chain..."
+    echo_command export SPDM_CONFIG="etc/pqc_config.json"
+    # Force build.rs to regenerate config.rs with PQC buffer sizes.
+    # build.rs writes to spdmlib/src/config.rs (a shared source file),
+    # which may have been overwritten by prior non-PQC test builds.
+    rm -f spdmlib/src/config.rs
+    export SPDMRS_USE_PQC=true
+    # NOTE: SPDMRS_USE_RAW_PUB_KEY is intentionally NOT set, so ML-DSA
+    # certificate chains are exchanged and validated (GET_DIGESTS /
+    # GET_CERTIFICATE + chain verification), exercising the ML-DSA
+    # certificate-signature path in spdm_x509 via the aws-lc backend.
+    echo_command cargo run -p spdm-responder-emu --no-default-features --features="$RUN_RESPONDER_PQC_FEATURES" &
+    sleep 20
+    echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_FEATURES"
+    unset SPDMRS_USE_PQC
+    echo_command unset SPDM_CONFIG
+    cleanup
+}
+
+run_rust_spdm_emu_pqc_mut_auth() {
+    echo "Running requester and responder with PQC (ML-DSA + ML-KEM) mutual authentication..."
+    echo_command export SPDM_CONFIG="etc/pqc_config.json"
+    # Force build.rs to regenerate config.rs with PQC buffer sizes.
+    rm -f spdmlib/src/config.rs
+    export SPDMRS_USE_PQC=true
+    # Mutual auth requires certificate chains on both sides (raw public key not
+    # set). The Responder advertises MUT_AUTH_CAP and drives the encapsulated
+    # GET_DIGESTS/GET_CERTIFICATE flow to fetch and verify the Requester's
+    # ML-DSA certificate chain; the Requester's FINISH carries an ML-DSA
+    # signature the Responder verifies. Exercises ML-DSA cert verification on
+    # BOTH peers (leaf + encapsulated requester cert) via spdm_x509 + aws-lc.
+    echo_command cargo run -p spdm-responder-emu --no-default-features --features="$RUN_RESPONDER_PQC_MUTAUTH_FEATURES" &
+    sleep 20
+    echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_MUTAUTH_FEATURES"
+    unset SPDMRS_USE_PQC
+    echo_command unset SPDM_CONFIG
+    cleanup
+}
+
+run_rust_spdm_emu_pqc_mandatory_mut_auth() {
+    echo "Running requester and responder with PQC (ML-DSA + ML-KEM) mandatory mutual authentication..."
+    echo_command export SPDM_CONFIG="etc/pqc_config.json"
+    rm -f spdmlib/src/config.rs
+    export SPDMRS_USE_PQC=true
+    # Responder mandates mutual auth; Requester advertises mut-auth. Same
+    # ML-DSA verification on both peers as run_rust_spdm_emu_pqc_mut_auth, but
+    # the Responder refuses the connection unless the Requester is mut-auth
+    # capable.
+    echo_command cargo run -p spdm-responder-emu --no-default-features --features="$RUN_RESPONDER_PQC_MANDATORY_MUTAUTH_FEATURES" &
+    sleep 20
+    echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_MUTAUTH_FEATURES"
+    unset SPDMRS_USE_PQC
+    echo_command unset SPDM_CONFIG
+    cleanup
+}
+
+run_with_spdm_emu_pqc_cert_chain() {
+    echo "Running cross test with spdm-emu PQC (ML-DSA + ML-KEM) certificate chain..."
+    echo_command export SPDM_CONFIG="etc/pqc_config.json"
+    # Force build.rs to regenerate config.rs with PQC buffer sizes.
+    rm -f spdmlib/src/config.rs
+
+    # --- spdm-rs Requester <-> spdm-emu (libspdm) Responder ---
+    pushd test_key
+    chmod +x ./spdm_responder_emu
+    # spdm-emu binaries are dynamically linked against a custom OpenSSL
+    # (libcrypto.so.3) with PQC/ML-DSA support, shipped in test_key/.
+    export LD_LIBRARY_PATH=$(pwd):${LD_LIBRARY_PATH:-}
+    # CERT_CAP (not PUB_KEY_ID) so the Responder serves an ML-DSA certificate
+    # chain; the spdm-rs Requester retrieves and validates it.
+    echo_command ./spdm_responder_emu --trans PCI_DOE --cap CACHE,CERT,CHAL,MEAS_SIG,MEAS_FRESH,ENCRYPT,MAC,KEY_EX,ENCAP,HBEAT,KEY_UPD,HANDSHAKE_IN_CLEAR,CHUNK --mut_auth NO --pqc_asym ML_DSA_87 --kem ML_KEM_1024 --pqc_first TRUE &
+    popd
+    sleep 5
+    export SPDMRS_USE_PQC=true
+    # SPDMRS_USE_RAW_PUB_KEY intentionally unset -> certificate chain mode.
+    echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_FEATURES"
+    unset SPDMRS_USE_PQC
+    cleanup
+
+    # --- spdm-rs Responder <-> spdm-emu (libspdm) Requester ---
+    export SPDMRS_USE_PQC=true
+    echo_command cargo run -p spdm-responder-emu --no-default-features --features="$RUN_RESPONDER_PQC_FEATURES" &
+    sleep 20
+    pushd test_key
+    chmod +x ./spdm_requester_emu
+    export LD_LIBRARY_PATH=$(pwd):${LD_LIBRARY_PATH:-}
+    # CERT (not PUB_KEY_ID) + DIGEST,CERT in exe_conn so the libspdm Requester
+    # fetches and validates the spdm-rs Responder's ML-DSA certificate chain.
+    # CERT_CAP is required: the spdm-rs Responder rejects a Requester that
+    # advertises CHAL_CAP without CERT_CAP or PUB_KEY_ID_CAP (DSP0274).
+    # LARGE_RESP is required: at SPDM 1.4 the libspdm Requester issues the large
+    # GET_CERTIFICATE format, which the spdm-rs Responder only accepts when
+    # LARGE_RESP_CAP is negotiated on both peers.
+    echo_command ./spdm_requester_emu --trans PCI_DOE --cap CERT,CHAL,ENCRYPT,MAC,KEY_EX,ENCAP,HBEAT,KEY_UPD,CHUNK,LARGE_RESP --mut_auth NO --pqc_asym ML_DSA_87 --kem ML_KEM_1024 --pqc_first TRUE --exe_conn DIGEST,CERT,CHAL,MEAS --exe_session KEY_EX,KEY_UPDATE,HEARTBEAT,MEAS
+    popd
+    unset SPDMRS_USE_PQC
+    unset LD_LIBRARY_PATH
+    echo_command unset SPDM_CONFIG
+    cleanup
+}
+
+run_with_spdm_emu_pqc_mut_auth() {
+    echo "Running cross test with spdm-emu PQC (ML-DSA + ML-KEM) mutual authentication..."
+    echo_command export SPDM_CONFIG="etc/pqc_config.json"
+    rm -f spdmlib/src/config.rs
+
+    # --- spdm-rs Requester <-> spdm-emu (libspdm) Responder ---
+    # The libspdm Responder requests mutual auth (--mut_auth DIGESTS) and
+    # accepts an ML-DSA Requester signing algorithm (--req_pqc_asym ML_DSA_87);
+    # the spdm-rs Requester serves and signs with its ML-DSA cert chain.
+    pushd test_key
+    chmod +x ./spdm_responder_emu
+    export LD_LIBRARY_PATH=$(pwd):${LD_LIBRARY_PATH:-}
+    echo_command ./spdm_responder_emu --trans PCI_DOE --cap CACHE,CERT,CHAL,MEAS_SIG,MEAS_FRESH,ENCRYPT,MAC,KEY_EX,ENCAP,HBEAT,KEY_UPD,HANDSHAKE_IN_CLEAR,CHUNK --mut_auth DIGESTS --basic_mut_auth NO --pqc_asym ML_DSA_87 --req_pqc_asym ML_DSA_87 --kem ML_KEM_1024 --pqc_first TRUE &
+    popd
+    sleep 5
+    export SPDMRS_USE_PQC=true
+    echo_command cargo run -p spdm-requester-emu --no-default-features --features="$RUN_REQUESTER_PQC_MUTAUTH_FEATURES"
+    unset SPDMRS_USE_PQC
+    cleanup
+
+    # --- spdm-rs Responder <-> spdm-emu (libspdm) Requester ---
+    # The spdm-rs Responder requests mutual auth; the libspdm Requester serves
+    # and signs with its ML-DSA cert chain (--req_pqc_asym ML_DSA_87), and
+    # fetches the Responder's ML-DSA chain (DIGEST,CERT in exe_conn).
+    export SPDMRS_USE_PQC=true
+    echo_command cargo run -p spdm-responder-emu --no-default-features --features="$RUN_RESPONDER_PQC_MUTAUTH_FEATURES" &
+    sleep 20
+    pushd test_key
+    chmod +x ./spdm_requester_emu
+    export LD_LIBRARY_PATH=$(pwd):${LD_LIBRARY_PATH:-}
+    # LARGE_RESP is required: at SPDM 1.4 the libspdm Requester issues the large
+    # GET_CERTIFICATE format, which the spdm-rs Responder only accepts when
+    # LARGE_RESP_CAP is negotiated on both peers.
+    # MUT_AUTH is required in --cap: the spdm-rs Responder (built with mut-auth)
+    # asserts MutAuthRequested in KEY_EXCHANGE_RSP, which the libspdm Requester
+    # only accepts (and reciprocates) when it also negotiated MUT_AUTH_CAP.
+    echo_command ./spdm_requester_emu --trans PCI_DOE --cap CERT,CHAL,ENCRYPT,MAC,KEY_EX,MUT_AUTH,ENCAP,HBEAT,KEY_UPD,CHUNK,LARGE_RESP --mut_auth DIGESTS --basic_mut_auth NO --pqc_asym ML_DSA_87 --req_pqc_asym ML_DSA_87 --kem ML_KEM_1024 --pqc_first TRUE --exe_conn DIGEST,CERT,CHAL,MEAS --exe_session KEY_EX,KEY_UPDATE,HEARTBEAT,MEAS
+    popd
+    unset SPDMRS_USE_PQC
+    unset LD_LIBRARY_PATH
     echo_command unset SPDM_CONFIG
     cleanup
 }
@@ -340,8 +499,8 @@ run_with_spdm_emu_raw_pub_key() {
     unset SPDMRS_USE_RAW_PUB_KEY
 }
 
-run_with_spdm_emu_pqc() {
-    echo "Running cross test with spdm-emu PQC (ML-DSA + ML-KEM)..."
+run_with_spdm_emu_pqc_raw_pub_key() {
+    echo "Running cross test with spdm-emu PQC (ML-DSA + ML-KEM) raw public key..."
     echo_command export SPDM_CONFIG="etc/pqc_config.json"
     # Force build.rs to regenerate config.rs with PQC buffer sizes.
     # build.rs writes to spdmlib/src/config.rs (a shared source file),
@@ -384,7 +543,10 @@ run() {
     run_rust_spdm_emu_raw_pub_key
     run_rust_spdm_emu_mut_auth
     run_rust_spdm_emu_mandatory_mut_auth
-    run_rust_spdm_emu_pqc
+    run_rust_spdm_emu_pqc_raw_pub_key
+    run_rust_spdm_emu_pqc_cert_chain
+    run_rust_spdm_emu_pqc_mut_auth
+    run_rust_spdm_emu_pqc_mandatory_mut_auth
 }
 
 CHECK_OPTION=false
@@ -442,7 +604,9 @@ main() {
             run_with_spdm_emu_raw_pub_key
             run_with_spdm_emu_mut_auth
             run_with_spdm_emu_mandatory_mut_auth
-            run_with_spdm_emu_pqc
+            run_with_spdm_emu_pqc_raw_pub_key
+            run_with_spdm_emu_pqc_cert_chain
+            run_with_spdm_emu_pqc_mut_auth
         fi
     fi
 }

--- a/spdmlib/src/crypto/spdm_x509/Cargo.toml
+++ b/spdmlib/src/crypto/spdm_x509/Cargo.toml
@@ -25,6 +25,9 @@ pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] 
 # base64ct 1.7+ may require edition2024; allow patch updates within 1.6.x
 base64ct = "~1.6"
 
+# Safe no_std one-time global for the pluggable PQC (ML-DSA) verifier hook
+conquer-once = { version = "0.3.2", default-features = false }
+
 # Logging
 log = { version = "0.4", default-features = false }
 
@@ -38,7 +41,7 @@ serde_json = "1.0"
 default = ["ring-backend"]
 ring-backend = ["ring", "untrusted"]
 mbedtls-backend = []
-std = ["der/std", "ring?/std", "log/std"]
+std = ["der/std", "ring?/std", "log/std", "conquer-once/std"]
 alloc = ["der/alloc"]
 
 [lib]

--- a/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
@@ -47,6 +47,12 @@ pub enum SignatureAlgorithm {
     RsaPssSha512,
     /// EdDSA Ed25519 (hash is built-in to the algorithm)
     Ed25519,
+    /// ML-DSA-44 (NIST FIPS 204, hash/context handled by the algorithm)
+    MlDsa44,
+    /// ML-DSA-65 (NIST FIPS 204, hash/context handled by the algorithm)
+    MlDsa65,
+    /// ML-DSA-87 (NIST FIPS 204, hash/context handled by the algorithm)
+    MlDsa87,
 }
 
 impl SignatureAlgorithm {
@@ -73,6 +79,14 @@ impl SignatureAlgorithm {
             ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.13");
         const RSA_PSS: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
         const ED25519_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
+
+        // NIST FIPS 204 ML-DSA (2.16.840.1.101.3.4.3.{17,18,19})
+        const ML_DSA_44_OID: ObjectIdentifier =
+            ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.17");
+        const ML_DSA_65_OID: ObjectIdentifier =
+            ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.18");
+        const ML_DSA_87_OID: ObjectIdentifier =
+            ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.19");
 
         const SECP256R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
         const SECP384R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.132.0.34");
@@ -105,6 +119,9 @@ impl SignatureAlgorithm {
             RSA_WITH_SHA512 => Ok(SignatureAlgorithm::RsaPkcs1Sha512),
             RSA_PSS => Self::parse_rsa_pss_params(params),
             ED25519_OID => Ok(SignatureAlgorithm::Ed25519),
+            ML_DSA_44_OID => Ok(SignatureAlgorithm::MlDsa44),
+            ML_DSA_65_OID => Ok(SignatureAlgorithm::MlDsa65),
+            ML_DSA_87_OID => Ok(SignatureAlgorithm::MlDsa87),
             _ => Err(Error::unsupported_algorithm(alloc::format!(
                 "OID: {}", sig_oid
             ))),
@@ -232,6 +249,76 @@ pub trait CryptoBackend {
     ) -> Result<()>;
 }
 
+// =============================================================================
+// Post-Quantum (PQC) verifier hook
+//
+// The built-in crypto backends (ring, mbedtls) cannot verify post-quantum
+// (e.g. ML-DSA / FIPS 204) signatures.  Rather than pulling a PQC crypto
+// dependency into this crate, we expose a runtime-registered verification
+// hook.  A downstream crate that links a PQC-capable backend (e.g.
+// `spdmlib_crypto_aws_lc` over aws-lc-rs) registers a verifier once at startup
+// via [`register_pqc_verifier`], and every backend's `verify_signature`
+// transparently dispatches PQC signatures to it.  This keeps SPDM
+// certificate-chain validation backend-agnostic while enabling PQC certificate
+// chains (DSP0274 1.4).
+// =============================================================================
+
+/// A registered PQC signature-verification callback.
+///
+/// # Arguments
+/// * `algorithm`  - the PQC signature algorithm (e.g.
+///   [`SignatureAlgorithm::MlDsa44`] / `MlDsa65` / `MlDsa87`)
+/// * `tbs_data`   - the TBSCertificate bytes that were signed
+/// * `signature`  - the raw PQC signature bytes
+/// * `public_key` - the signer's public key, either the raw public key or a
+///   DER-encoded SubjectPublicKeyInfo (the callback must accept both)
+pub type PqcVerifyFn = fn(
+    algorithm: SignatureAlgorithm,
+    tbs_data: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<()>;
+
+static PQC_VERIFIER: conquer_once::spin::OnceCell<PqcVerifyFn> =
+    conquer_once::spin::OnceCell::uninit();
+
+/// Register the global PQC signature-verification callback.
+///
+/// Returns `true` if this call installed the verifier, `false` if one was
+/// already registered (the first registration wins, mirroring the rest of the
+/// spdm-rs crypto registration model).
+pub fn register_pqc_verifier(verifier: PqcVerifyFn) -> bool {
+    PQC_VERIFIER.try_init_once(|| verifier).is_ok()
+}
+
+/// Dispatch a PQC signature verification to the registered hook.
+///
+/// Returns an "unsupported algorithm" error if no verifier has been
+/// registered, so that PQC certificate chains fail closed when the PQC
+/// backend is absent.
+pub(crate) fn verify_pqc_signature(
+    algorithm: SignatureAlgorithm,
+    tbs_data: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<()> {
+    match PQC_VERIFIER.try_get() {
+        Ok(verifier) => verifier(algorithm, tbs_data, signature, public_key),
+        Err(_) => Err(Error::unsupported_algorithm(
+            "PQC signature verification requires a registered PQC verifier",
+        )),
+    }
+}
+
+/// Returns `true` if the given algorithm is a post-quantum signature algorithm
+/// handled by the PQC verifier hook rather than a built-in crypto backend.
+pub(crate) fn is_pqc(algorithm: SignatureAlgorithm) -> bool {
+    matches!(
+        algorithm,
+        SignatureAlgorithm::MlDsa44 | SignatureAlgorithm::MlDsa65 | SignatureAlgorithm::MlDsa87
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -339,6 +426,53 @@ mod tests {
             SignatureAlgorithm::from_oid(&oid).unwrap(),
             SignatureAlgorithm::Ed25519
         );
+    }
+
+    // ── from_oid_with_params: ML-DSA (FIPS 204) ──
+
+    #[test]
+    fn test_ml_dsa_44_oid() {
+        let oid = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.17");
+        assert_eq!(
+            SignatureAlgorithm::from_oid(&oid).unwrap(),
+            SignatureAlgorithm::MlDsa44
+        );
+    }
+
+    #[test]
+    fn test_ml_dsa_65_oid() {
+        let oid = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.18");
+        assert_eq!(
+            SignatureAlgorithm::from_oid(&oid).unwrap(),
+            SignatureAlgorithm::MlDsa65
+        );
+    }
+
+    #[test]
+    fn test_ml_dsa_87_oid() {
+        let oid = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.19");
+        assert_eq!(
+            SignatureAlgorithm::from_oid(&oid).unwrap(),
+            SignatureAlgorithm::MlDsa87
+        );
+    }
+
+    #[test]
+    fn test_is_pqc() {
+        assert!(super::is_pqc(SignatureAlgorithm::MlDsa44));
+        assert!(super::is_pqc(SignatureAlgorithm::MlDsa65));
+        assert!(super::is_pqc(SignatureAlgorithm::MlDsa87));
+        assert!(!super::is_pqc(SignatureAlgorithm::Ed25519));
+        assert!(!super::is_pqc(SignatureAlgorithm::EcdsaP256Sha256));
+    }
+
+    #[test]
+    fn test_pqc_verify_without_registered_hook_errors() {
+        // With no PQC verifier registered, PQC signature verification must fail
+        // closed rather than silently pass.
+        let result =
+            super::verify_pqc_signature(SignatureAlgorithm::MlDsa87, b"tbs", b"sig", b"pubkey");
+        assert!(result.is_err());
     }
 
     // ── from_oid_with_params: unknown OID ──

--- a/spdmlib/src/crypto/spdm_x509/src/crypto_backend/ring.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/crypto_backend/ring.rs
@@ -33,6 +33,16 @@ impl CryptoBackend for RingBackend {
             SignatureAlgorithm::RsaPssSha384 => &signature::RSA_PSS_2048_8192_SHA384,
             SignatureAlgorithm::RsaPssSha512 => &signature::RSA_PSS_2048_8192_SHA512,
             SignatureAlgorithm::Ed25519 => &signature::ED25519,
+            // ML-DSA (FIPS 204) is not supported by ring.  These are dispatched
+            // to the registered PQC verifier hook by `Validator::verify_signature`
+            // and never reach this backend; reject defensively if they do.
+            SignatureAlgorithm::MlDsa44
+            | SignatureAlgorithm::MlDsa65
+            | SignatureAlgorithm::MlDsa87 => {
+                return Err(Error::unsupported_algorithm(
+                    "ML-DSA is not supported by the ring backend",
+                ));
+            }
         };
 
         let pk = UnparsedPublicKey::new(ring_algo, public_key);

--- a/spdmlib/src/crypto/spdm_x509/src/x509/oids.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/oids.rs
@@ -137,6 +137,24 @@ pub const ED25519: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112"
 pub const ED448: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.113");
 
 // =============================================================================
+// Post-Quantum Asymmetric Algorithm OIDs (NIST FIPS 204 ML-DSA)
+//
+// These OIDs are used both as the SubjectPublicKeyInfo algorithm OID and as
+// the certificate signatureAlgorithm OID for ML-DSA (Module-Lattice-Based
+// Digital Signature Algorithm) certificates.  They live under the NIST
+// arc 2.16.840.1.101.3.4.3.{17,18,19}.
+// =============================================================================
+
+/// ML-DSA-44 - 2.16.840.1.101.3.4.3.17
+pub const ML_DSA_44: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.17");
+
+/// ML-DSA-65 - 2.16.840.1.101.3.4.3.18
+pub const ML_DSA_65: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.18");
+
+/// ML-DSA-87 - 2.16.840.1.101.3.4.3.19
+pub const ML_DSA_87: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.16.840.1.101.3.4.3.19");
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 

--- a/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
@@ -273,10 +273,23 @@ impl<B: CryptoBackend> Validator<B> {
             public_key_bytes.len()
         );
 
-        match self
-            .backend
-            .verify_signature(sig_algo, &tbs_bytes, signature, public_key_bytes)
-        {
+        // Post-quantum (e.g. ML-DSA / FIPS 204) signatures cannot be verified
+        // by the classical crypto backends (ring / mbedtls).  Dispatch them to
+        // the runtime registered PQC verifier hook so that PQC certificate
+        // chains (DSP0274 1.4) validate through the same code path.
+        let verify_result = if crate::crypto_backend::is_pqc(sig_algo) {
+            crate::crypto_backend::verify_pqc_signature(
+                sig_algo,
+                &tbs_bytes,
+                signature,
+                public_key_bytes,
+            )
+        } else {
+            self.backend
+                .verify_signature(sig_algo, &tbs_bytes, signature, public_key_bytes)
+        };
+
+        match verify_result {
             Ok(_) => {
                 log::trace!("verify_signature: SUCCESS");
                 Ok(())

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -10,6 +10,11 @@ spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false
 aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", features = ["unstable"] }
 log = { version = "0.4", default-features = false }
 
+[dev-dependencies]
+# Enable the ring backend + std so the ML-DSA cert-chain tests can drive
+# spdm_x509's classical chain validation and read test-key DER files.
+spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["ring-backend", "std"] }
+
 [features]
 default = []
 hashed-transcript-data = ["spdmlib/hashed-transcript-data"]

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod kem_impl;
 pub mod pqc_asym_sign_impl;
 pub mod pqc_asym_verify_impl;
+pub mod pqc_cert_verify_impl;
 
 #[cfg(test)]
 mod tests {

--- a/spdmlib_crypto_aws_lc/src/pqc_cert_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_cert_verify_impl.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! ML-DSA (FIPS 204) certificate-signature verifier for spdm_x509.
+//!
+//! `spdm_x509` verifies X.509 certificate chains through a backend-agnostic
+//! [`CryptoBackend`], but the classical backends (ring / mbedtls) cannot verify
+//! ML-DSA signatures.  To support PQC certificate chains (DSP0274 1.4) we
+//! register an ML-DSA verifier with `spdm_x509` at startup; the chain walker
+//! and the root self-signature check then dispatch ML-DSA signatures here.
+//!
+//! Unlike SPDM message signing (which mixes in the SPDM signing context
+//! string), X.509 certificate signatures are produced over the raw
+//! TBSCertificate with an empty ML-DSA context, so we use aws-lc-rs's
+//! `UnparsedPublicKey::verify` directly.
+
+use aws_lc_rs::signature::UnparsedPublicKey;
+use aws_lc_rs::unstable::signature::{ML_DSA_44, ML_DSA_65, ML_DSA_87};
+use log::error;
+use spdm_x509::crypto_backend::SignatureAlgorithm;
+use spdm_x509::error::{Error, Result};
+
+/// Verify an ML-DSA certificate signature.
+///
+/// `public_key` may be either the raw FIPS 204 public key (the BIT STRING
+/// content of a SubjectPublicKeyInfo) or a DER-encoded SubjectPublicKeyInfo;
+/// aws-lc-rs's parser accepts both encodings.
+fn verify_pqc_dsa(
+    algorithm: SignatureAlgorithm,
+    tbs_data: &[u8],
+    signature: &[u8],
+    public_key: &[u8],
+) -> Result<()> {
+    let verification_algo: &'static _ = match algorithm {
+        SignatureAlgorithm::MlDsa44 => &ML_DSA_44,
+        SignatureAlgorithm::MlDsa65 => &ML_DSA_65,
+        SignatureAlgorithm::MlDsa87 => &ML_DSA_87,
+        _ => {
+            return Err(Error::unsupported_algorithm(
+                "pqc_cert_verify: not an ML-DSA algorithm",
+            ));
+        }
+    };
+
+    let public_key = UnparsedPublicKey::new(verification_algo, public_key);
+    public_key.verify(tbs_data, signature).map_err(|_| {
+        error!("ML-DSA certificate signature verification failed");
+        Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
+    })
+}
+
+/// Register the ML-DSA certificate verifier with `spdm_x509`.
+///
+/// Idempotent: the first registration wins (mirroring the spdm-rs crypto
+/// registration model).  Call once at startup, before any PQC certificate
+/// chain is validated.
+pub fn register() -> bool {
+    spdm_x509::crypto_backend::register_pqc_verifier(verify_pqc_dsa)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key_path(relative: &str) -> std::string::String {
+        std::format!("{}/../test_key/{}", env!("CARGO_MANIFEST_DIR"), relative)
+    }
+
+    /// Load an SPDM certificate chain (concatenated DER: root || inter || leaf).
+    fn load_chain(dir: &str) -> std::vec::Vec<u8> {
+        std::fs::read(test_key_path(&std::format!(
+            "{}/bundle_responder.certchain.der",
+            dir
+        )))
+        .unwrap_or_else(|e| panic!("read {} chain: {}", dir, e))
+    }
+
+    /// Happy path: with the ML-DSA verifier registered, spdm_x509 validates a
+    /// real ML-DSA certificate chain (root self-signature + intermediate +
+    /// leaf) end to end — this is the certificate-chain path exercised by the
+    /// SPDM handshake in cert-chain mode.
+    #[test]
+    fn test_ml_dsa_cert_chain_happy_path() {
+        register();
+        for dir in ["mldsa44", "mldsa65", "mldsa87"] {
+            let chain = load_chain(dir);
+            let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+            assert!(
+                result.is_ok(),
+                "{} ML-DSA chain should validate: {:?}",
+                dir,
+                result.err()
+            );
+        }
+    }
+
+    /// Fail path: a single flipped byte inside the leaf certificate's ML-DSA
+    /// signature must cause chain validation to fail — proving the verifier
+    /// actually checks the signature rather than accepting unconditionally.
+    #[test]
+    fn test_ml_dsa_cert_chain_tampered_signature_rejected() {
+        register();
+        let mut chain = load_chain("mldsa87");
+
+        // The leaf certificate is last in the SPDM chain; its ML-DSA signature
+        // is at the very end of the buffer.  Flip a byte well inside it.
+        let len = chain.len();
+        chain[len - 16] ^= 0xFF;
+
+        let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+        assert!(
+            result.is_err(),
+            "tampered ML-DSA leaf signature must be rejected"
+        );
+    }
+
+    /// Fail path: tampering with the intermediate certificate's TBS content
+    /// (which is signed by the root) must be rejected during the chain walk.
+    #[test]
+    fn test_ml_dsa_cert_chain_tampered_intermediate_rejected() {
+        register();
+        let mut chain = load_chain("mldsa87");
+
+        // Corrupt a byte in the first cert (root) region's later portion, which
+        // falls inside the root's signature over its own TBS. Any interior flip
+        // that changes signed bytes or a signature must break validation.
+        // Use an offset comfortably past the header but before the leaf.
+        chain[1380] ^= 0xFF;
+
+        let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+        assert!(
+            result.is_err(),
+            "tampered certificate in ML-DSA chain must be rejected"
+        );
+    }
+}

--- a/spdmlib_crypto_mbedtls/Cargo.toml
+++ b/spdmlib_crypto_mbedtls/Cargo.toml
@@ -6,12 +6,16 @@ license = "Apache-2.0 or MIT"
 
 [dependencies]
 spdmlib = { path = "../spdmlib", default-features = false}
+# spdm_x509 provides ML-DSA (FIPS 204) aware certificate-chain validation via
+# its ring-backed validator plus the runtime PQC verifier hook. Delegate to it
+# (as the ring cert operation does) so PQC certificate chains work with the
+# mbedtls backend too. ring-backend matches how spdmlib already builds spdm_x509.
+spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["ring-backend"] }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.9.8"
 zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 mbedtls = { version = "0.9.1", default-features = false, features = ["no_std_deps", "rdrand"]}
 mbedtls-sys-auto = { version = "2.28.0", default-features = false }
-der = { version = "0.7.7", default-features = false }
 
 [features]
 default = ["hashed-transcript-data", "std"]

--- a/spdmlib_crypto_mbedtls/src/cert_operation_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/cert_operation_impl.rs
@@ -1,104 +1,67 @@
-// Copyright (c) 2023 Intel Corporation
+// Copyright (c) 2023, 2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use mbedtls::x509::Certificate;
 use spdmlib::crypto::SpdmCertOperation;
 use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_CERT};
 
-use der::{Reader, SliceReader};
+// =============================================================================
+// spdm_x509 implementation
+//
+// The certificate-chain operations delegate to the spdm_x509 library (the same
+// path the ring backend uses) rather than to the mbedtls C X.509 verifier. This
+// gives the mbedtls backend ML-DSA (FIPS 204) aware chain validation: spdm_x509
+// parses the chain itself and dispatches classical (RSA/ECC) signatures to its
+// ring backend and post-quantum signatures to the registered PQC verifier hook.
+// mbedtls cannot verify ML-DSA certificate signatures, so delegating here is
+// what lets PQC certificate chains work with the mbedtls backend.
+// =============================================================================
 
 pub static DEFAULT: SpdmCertOperation = SpdmCertOperation {
-    get_cert_from_cert_chain_cb: get_cert_from_cert_chain,
-    verify_cert_chain_cb: verify_cert_chain,
+    get_cert_from_cert_chain_cb: get_cert_from_cert_chain_x509,
+    verify_cert_chain_cb: verify_cert_chain_x509,
 };
 
-fn get_cert_from_cert_chain(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)> {
-    let mut offset = 0usize;
-    let mut this_index = 0isize;
-    let cert_chain_size = cert_chain.len();
-    loop {
-        if cert_chain[offset..].len() < 4 || offset > cert_chain.len() {
-            return Err(SPDM_STATUS_INVALID_CERT);
-        }
-        if cert_chain[offset] != 0x30 || cert_chain[offset + 1] != 0x82 {
-            return Err(SPDM_STATUS_INVALID_CERT);
-        }
-        let this_cert_len =
-            ((cert_chain[offset + 2] as usize) << 8) + (cert_chain[offset + 3] as usize) + 4;
-        if this_cert_len > cert_chain_size - offset {
-            return Err(SPDM_STATUS_INVALID_CERT);
-        }
-        if this_index == index {
-            // return the this one
-            return Ok((offset, offset + this_cert_len));
-        }
-        this_index += 1;
-        if (offset + this_cert_len == cert_chain_size) && (index == -1) {
-            // return the last one
-            return Ok((offset, offset + this_cert_len));
-        }
-        offset += this_cert_len;
-    }
+fn get_cert_from_cert_chain_x509(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)> {
+    spdm_x509::x509::chain::get_cert_from_cert_chain(cert_chain, index)
+        .map_err(|_| SPDM_STATUS_INVALID_CERT)
 }
 
-fn verify_cert_chain(
+fn verify_cert_chain_x509(
     cert_chain: &[u8],
-    _base_asym_algo: Option<u32>,
-    _base_hash_algo: Option<u32>,
+    base_asym_algo: Option<u32>,
+    base_hash_algo: Option<u32>,
 ) -> SpdmResult {
-    let mut reader = SliceReader::new(cert_chain).map_err(|_| SPDM_STATUS_INVALID_CERT)?;
-    let mut chain = mbedtls::alloc::List::new();
-    let mut ca = mbedtls::alloc::List::new();
-
-    loop {
-        let res = reader.tlv_bytes();
-        if res.is_err() {
-            break;
-        }
-        let cert = Certificate::from_der(res.unwrap()).map_err(|_| SPDM_STATUS_INVALID_CERT)?;
-        if ca.is_empty() {
-            ca.push(cert);
-        } else {
-            chain.push(cert);
-        }
-    }
-    if chain.is_empty() && ca.is_empty() {
-        return Err(SPDM_STATUS_INVALID_CERT);
-    }
-    if chain.is_empty() {
-        chain.append(ca.clone())
-    }
-    Certificate::verify(&chain, &ca, None, None).map_err(|_| SPDM_STATUS_INVALID_CERT)
+    spdm_x509::x509::chain::verify_cert_chain_with_options(
+        cert_chain,
+        base_asym_algo,
+        base_hash_algo,
+    )
+    .map_err(|_| SPDM_STATUS_INVALID_CERT)
 }
 
-#[test]
-fn test_certificate() {
-    let cert_chain =
-        include_bytes!("../../test_key/rsa3072_Expiration/bundle_requester.certchain.der");
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let mut reader = SliceReader::new(cert_chain).unwrap();
-    let mut chain = mbedtls::alloc::List::new();
-    let mut ca = mbedtls::alloc::List::new();
-    loop {
-        let res = reader.tlv_bytes();
-        if res.is_err() {
-            break;
-        }
-        let res = res.unwrap();
-        let cert = Certificate::from_der(res).unwrap();
-        if ca.is_empty() {
-            ca.push(cert);
-        } else {
-            chain.push(cert);
-        }
-    }
-    if chain.is_empty() && ca.is_empty() {
-        panic!("SPDM_STATUS_INVALID_CERT")
-    }
-    if chain.is_empty() {
-        chain.append(ca.clone())
+    #[test]
+    fn test_verify_cert_chain_rsa3072() {
+        let cert_chain =
+            &include_bytes!("../../test_key/rsa3072/bundle_responder.certchain.der")[..];
+        assert!(verify_cert_chain_x509(cert_chain, None, None).is_ok());
     }
 
-    Certificate::verify(&chain, &ca, None, None).unwrap();
+    #[test]
+    fn test_verify_cert_chain_ecp384() {
+        let cert_chain =
+            &include_bytes!("../../test_key/ecp384/bundle_responder.certchain.der")[..];
+        assert!(verify_cert_chain_x509(cert_chain, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_get_cert_from_cert_chain_leaf() {
+        let cert_chain =
+            &include_bytes!("../../test_key/ecp384/bundle_responder.certchain.der")[..];
+        assert!(get_cert_from_cert_chain_x509(cert_chain, -1).is_ok());
+    }
 }

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -269,4 +269,8 @@ pub fn register_pqc_crypto_callbacks() {
     );
     spdmlib::crypto::kem_decap::register(spdmlib_crypto_aws_lc::kem_impl::DEFAULT_DECAP.clone());
     spdmlib::crypto::kem_encap::register(spdmlib_crypto_aws_lc::kem_impl::DEFAULT_ENCAP.clone());
+    // Enable ML-DSA (FIPS 204) certificate-chain verification in spdm_x509 so
+    // PQC certificate chain mode (DSP0274 1.4) can be used, not just raw
+    // public key mode.
+    spdmlib_crypto_aws_lc::pqc_cert_verify_impl::register();
 }

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -179,6 +179,16 @@ async fn test_spdm(
         } else {
             SpdmPqcAsymAlgo::empty()
         },
+        // PQC Requester signing algorithm (used for mutual authentication).
+        // Advertised in PQC mode so that, when MUT_AUTH_CAP is negotiated, the
+        // ALGORITHMS exchange can select an ML-DSA ReqAsym algorithm; without a
+        // negotiated (classical or PQC) ReqAsym the response is rejected per
+        // DSP0274. Harmless when mut-auth is off (mirrors req_asym_algo).
+        pqc_req_asym_algo: if use_pqc {
+            SpdmPqcReqAsymAlgo::ALG_MLDSA_87
+        } else {
+            SpdmPqcReqAsymAlgo::empty()
+        },
         kem_algo: if use_pqc {
             SpdmKemAlgo::ALG_MLKEM_1024
         } else {
@@ -756,6 +766,13 @@ async fn test_idekm_tdisp(
         req_capabilities
     };
 
+    // IDE_KM and TDISP are algorithm-agnostic: they run as SPDM
+    // vendor-defined messages over an already-established secure session, so
+    // they work over a PQC (ML-DSA + ML-KEM) session just as over a classical
+    // one. Mirror test_spdm's PQC algorithm/cert selection so this secondary
+    // test can run against a PQC peer.
+    let use_pqc = use_pqc();
+
     let config_info = common::SpdmConfigInfo {
         spdm_version: [
             Some(SpdmVersion::SpdmVersion10),
@@ -767,21 +784,45 @@ async fn test_idekm_tdisp(
         req_capabilities,
         req_ct_exponent: 0,
         measurement_specification: SpdmMeasurementSpecification::DMTF,
-        base_asym_algo: if use_ecdsa() {
+        base_asym_algo: if use_pqc {
+            SpdmBaseAsymAlgo::empty()
+        } else if use_ecdsa() {
             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
         },
         base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
-        dhe_algo: SpdmDheAlgo::SECP_384_R1,
+        dhe_algo: if use_pqc {
+            SpdmDheAlgo::empty()
+        } else {
+            SpdmDheAlgo::SECP_384_R1
+        },
         aead_algo: SpdmAeadAlgo::AES_256_GCM,
-        req_asym_algo: if req_use_ecdsa() {
+        req_asym_algo: if use_pqc {
+            SpdmReqAsymAlgo::empty()
+        } else if req_use_ecdsa() {
             SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
         } else {
             SpdmReqAsymAlgo::TPM_ALG_RSASSA_3072
         },
         key_schedule_algo: SpdmKeyScheduleAlgo::SPDM_KEY_SCHEDULE,
         other_params_support: SpdmAlgoOtherParams::OPAQUE_DATA_FMT1,
+        pqc_asym_algo: if use_pqc {
+            SpdmPqcAsymAlgo::ALG_MLDSA_87
+        } else {
+            SpdmPqcAsymAlgo::empty()
+        },
+        // PQC Requester signing algorithm (mutual auth); mirrors test_spdm.
+        pqc_req_asym_algo: if use_pqc {
+            SpdmPqcReqAsymAlgo::ALG_MLDSA_87
+        } else {
+            SpdmPqcReqAsymAlgo::empty()
+        },
+        kem_algo: if use_pqc {
+            SpdmKemAlgo::ALG_MLKEM_1024
+        } else {
+            SpdmKemAlgo::empty()
+        },
         data_transfer_size: config::SPDM_DATA_TRANSFER_SIZE as u32,
         max_spdm_msg_size: config::MAX_SPDM_MSG_SIZE as u32,
         secure_spdm_version: [
@@ -796,19 +837,25 @@ async fn test_idekm_tdisp(
         ..Default::default()
     };
 
-    let ca_file_path = if use_ecdsa() {
+    let ca_file_path = if use_pqc {
+        "test_key/mldsa87/ca.cert.der"
+    } else if use_ecdsa() {
         "test_key/ecp384/ca.cert.der"
     } else {
         "test_key/rsa3072/ca.cert.der"
     };
     let ca_cert = std::fs::read(ca_file_path).expect("unable to read ca cert!");
-    let inter_file_path = if use_ecdsa() {
+    let inter_file_path = if use_pqc {
+        "test_key/mldsa87/inter.cert.der"
+    } else if use_ecdsa() {
         "test_key/ecp384/inter.cert.der"
     } else {
         "test_key/rsa3072/inter.cert.der"
     };
     let inter_cert = std::fs::read(inter_file_path).expect("unable to read inter cert!");
-    let leaf_file_path = if use_ecdsa() {
+    let leaf_file_path = if use_pqc {
+        "test_key/mldsa87/end_responder.cert.der"
+    } else if use_ecdsa() {
         "test_key/ecp384/end_responder.cert.der"
     } else {
         "test_key/rsa3072/end_responder.cert.der"

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -352,6 +352,16 @@ async fn handle_message(
         } else {
             SpdmPqcAsymAlgo::empty()
         },
+        // PQC Requester signing algorithm (used for mutual authentication).
+        // Advertised in PQC mode so that, when MUT_AUTH_CAP is negotiated, the
+        // ALGORITHMS exchange can select an ML-DSA ReqAsym algorithm; without a
+        // negotiated (classical or PQC) ReqAsym the response is rejected per
+        // DSP0274. Harmless when mut-auth is off (mirrors req_asym_algo).
+        pqc_req_asym_algo: if use_pqc {
+            SpdmPqcReqAsymAlgo::ALG_MLDSA_87
+        } else {
+            SpdmPqcReqAsymAlgo::empty()
+        },
         kem_algo: if use_pqc {
             SpdmKemAlgo::ALG_MLKEM_1024
         } else {


### PR DESCRIPTION
Recognize ML-DSA (FIPS 204) OIDs in spdm_x509 and dispatch cert-chain signature verification to a runtime-registered PQC hook backed by aws-lc-rs, enabling PQC certificate chains and mutual auth (not just raw public key). Add unit, integration, and libspdm cross tests; update README.


Assisted-by: Claude Code:claude-opus-4-8