### PR TITLE
deps(aws-lc): bump aws-lc-rs to v1.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.3"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -164,12 +164,13 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.43.0"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1414,6 +1415,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"


### PR DESCRIPTION
Update the vendored aws-lc-rs submodule from v1.16.2 to v1.17.3, which advances the underlying AWS-LC C library:

- aws-lc-sys:      0.39.0 -> 0.43.0 (aws-lc v1.71.0 -> v5.2.0)
- aws-lc-fips-sys: 0.13.13 -> 0.13.16 (AWS-LC-FIPS-3.3.0 -> 3.3.0-6)
- aws-lc-rs crate: 1.16.2 -> 1.17.3

The aws-lc crypto backend (spdmlib_crypto_aws_lc) builds against the upgraded library. Cargo.lock is updated accordingly, including the new pkg-config transitive dependency introduced by aws-lc-rs system-lib auto-detection.

Assisted-by: GitHub Copilot:claude-opus-4-8