### PR TITLE
feat(aws-lc): standalone aws-lc-rs crypto backend (classical + PQC)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,14 @@ jobs:
           - runs-on: ubuntu-latest
             run_requester_features: "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
             run_responder_features: "spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
+          # mbedtls + aws-lc overlay: mbedtls for classical, aws-lc for PQC.
+          - runs-on: ubuntu-latest
+            run_requester_features: "spdm-mbedtls,hashed-transcript-data,async-executor,spdm-aws-lc"
+            run_responder_features: "spdm-mbedtls,hashed-transcript-data,async-executor,spdm-aws-lc"
+          # Standalone aws-lc: aws-lc-rs alone (no ring, no mbedtls), std-only.
+          - runs-on: ubuntu-latest
+            run_requester_features: "spdm-aws-lc,hashed-transcript-data,async-executor"
+            run_responder_features: "spdm-aws-lc,hashed-transcript-data,async-executor"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.runs-on }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,9 +1918,12 @@ name = "spdmlib_crypto_aws_lc"
 version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
+ "bytes",
+ "lazy_static",
  "log",
  "spdm_x509",
  "spdmlib",
+ "spin 0.9.8",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,20 @@ The following list shows the supported combinations for both spdm-requester-emu 
 | spdm-mbedtls,hashed-transcript-data,is_sync        | mbedtls       | Yes                            | sync                   | use mbedtls as crypto library with hashed-transcript-data enabled, sync version.                                |
 | spdm-mbedtls,hashed-transcript-data,async-executor | mbedtls       | Yes                            | executor async runtime | use mbedtls as crypto library with hashed-transcript-data enabled, async version, use executor as async runtime |
 | spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc | ring+aws-lc-rs | Yes                    | executor async runtime | use ring + aws-lc-rs for PQC (ML-DSA, ML-KEM) with hashed-transcript-data enabled, async version               |
+| spdm-mbedtls,hashed-transcript-data,async-executor,spdm-aws-lc | mbedtls+aws-lc-rs | Yes                 | executor async runtime | use mbedtls + aws-lc-rs for PQC (ML-DSA, ML-KEM) with hashed-transcript-data enabled, async version            |
+| spdm-aws-lc,hashed-transcript-data,async-executor  | aws-lc-rs (standalone) | Yes            | executor async runtime | aws-lc-rs alone (no spdm-ring/spdm-mbedtls) for BOTH classical and PQC — no ring, no mbedtls linked. std-only.  |
+
+Notes on `spdm-aws-lc`:
+* Combined with a classical backend (`spdm-ring` or `spdm-mbedtls`),
+  `spdm-aws-lc` is a **PQC overlay**: it supplies only the post-quantum
+  algorithms (ML-DSA, ML-KEM) on top of that backend, which still provides the
+  traditional algorithms (hash, HMAC, AEAD, ECDHE, RSA/ECDSA, HKDF, cert chain).
+* On its own — `spdm-aws-lc` with neither `spdm-ring` nor `spdm-mbedtls` — it is
+  the **standalone** backend: aws-lc-rs supplies *both* classical and PQC crypto,
+  with no ring and no mbedtls linked (`cargo tree -i ring` reports ring absent).
+  This mode is **std-only** — aws-lc-rs cannot serve the `no_std`
+  (`x86_64-unknown-none`) target, so ring/mbedtls remain the backends for
+  embedded/UEFI builds.
 
 
 For example, run the emulator with spdm-ring enabled and without hashed-transcript-data enabled, and use executor as async runtime. 

--- a/idekm/Cargo.toml
+++ b/idekm/Cargo.toml
@@ -16,10 +16,15 @@ license = "Apache-2.0 or MIT"
 [dependencies]
 codec = { path = "../codec" }
 zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
-spdmlib = { path = "../spdmlib", default-features = false, features = ["spdm-ring"]}
+spdmlib = { path = "../spdmlib", default-features = false }
 conquer-once = { version = "0.3.2", default-features = false }
 maybe-async = "0.2.7"
 
 [features]
+# spdm-ring is the default backend so `cargo build`/`cargo test` on this crate
+# alone keeps working. Dependents that select a different backend (e.g. the
+# standalone aws-lc emu) set default-features = false to avoid linking ring.
+default = ["spdm-ring"]
+spdm-ring = ["spdmlib/spdm-ring"]
 is_sync = ["spdmlib/is_sync", "maybe-async/is_sync"]
-std = []
+std = ["spdmlib/std"]

--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -115,6 +115,14 @@ build() {
     echo "Building spdm-responder-emu with PQC (spdm-aws-lc)..."
     echo_command cargo build -p spdm-responder-emu --no-default-features --features="spdm-ring,hashed-transcript-data,async-executor,spdm-aws-lc"
     echo_command unset SPDM_CONFIG
+
+    # Standalone aws-lc backend (no ring, no mbedtls): aws-lc-rs supplies both
+    # classical and PQC crypto. std-only. Compile-checked here on every build.
+    echo "Building spdm-requester-emu with standalone aws-lc (spdm-aws-lc, no ring/mbedtls)..."
+    echo_command cargo build -p spdm-requester-emu --no-default-features --features="spdm-aws-lc,hashed-transcript-data,async-executor"
+
+    echo "Building spdm-responder-emu with standalone aws-lc (spdm-aws-lc, no ring/mbedtls)..."
+    echo_command cargo build -p spdm-responder-emu --no-default-features --features="spdm-aws-lc,hashed-transcript-data,async-executor"
 }
 
 RUN_REQUESTER_FEATURES=${RUN_REQUESTER_FEATURES:-spdm-ring,hashed-transcript-data,async-executor}
@@ -537,6 +545,11 @@ run_with_spdm_emu_pqc_raw_pub_key() {
 }
 
 run() {
+    # Every crypto config — spdm-ring, spdm-mbedtls, spdm-ring+spdm-aws-lc,
+    # spdm-mbedtls+spdm-aws-lc, and standalone spdm-aws-lc (no ring/mbedtls) —
+    # runs the same matrix below. aws-lc is a full backend, so the standalone row
+    # exercises the classical passes too; the *_pqc_* passes append spdm-aws-lc
+    # and only do real work once PQC is negotiated.
     run_basic_test
     run_rust_spdm_emu
     run_rust_spdm_emu_supported_algs

--- a/spdmlib/Cargo.toml
+++ b/spdmlib/Cargo.toml
@@ -20,7 +20,7 @@ conquer-once = { version = "0.3.2", default-features = false }
 lazy_static = { version = "1.0", features = ["spin_no_std"], optional = true }
 ring = { version = "0.17.14", default-features = false, features = ["alloc", "less-safe-getrandom-custom-or-rdrand"], optional = true }
 untrusted = { version = "0.9.0", optional = true }
-spdm_x509 = { path = "src/crypto/spdm_x509", default-features = false, features = ["ring-backend"] }
+spdm_x509 = { path = "src/crypto/spdm_x509", default-features = false }
 zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 maybe-async = "0.2.7"
 futures = { version = "0.3", default-features = false }

--- a/spdmlib/src/crypto/mod.rs
+++ b/spdmlib/src/crypto/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2021-2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
@@ -30,24 +30,23 @@ use conquer_once::spin::OnceCell;
 
 /// Check if a certificate is a root certificate (self-signed).
 ///
-/// A self-signed certificate must be both self-issued (issuer == subject)
-/// and have a valid self-signature (RFC 5280).
+/// A self-signed root must be self-issued (issuer == subject) and have a valid
+/// self-signature (RFC 5280).
+///
+/// The root's self-signature is verified cryptographically by the registered
+/// `cert_operation::verify_cert_chain`, which runs before this function in the
+/// GET_CERTIFICATE / ENCAP_GET_CERTIFICATE flow: the X.509 chain walk verifies
+/// the root (last cert) against its own public key using the *active* crypto
+/// backend (ring, mbedtls, or aws-lc). This function therefore only checks the
+/// self-issued property here, avoiding a second, backend-hardcoded signature
+/// check — which is what lets a post-quantum backend (aws-lc, verifying ML-DSA)
+/// validate an ML-DSA root without a separate ring-only re-verification.
 pub fn is_root_certificate(cert_der: &[u8]) -> SpdmResult {
     let cert = spdm_x509::Certificate::from_der(cert_der).map_err(|_| SPDM_STATUS_INVALID_CERT)?;
 
-    // Check self-issued: issuer == subject
+    // Check self-issued: issuer == subject.
     if cert.tbs_certificate.issuer != cert.tbs_certificate.subject {
         return Err(SPDM_STATUS_INVALID_CERT);
-    }
-
-    // Verify self-signature using the cert's own public key
-    #[cfg(feature = "spdm-ring")]
-    {
-        let validator =
-            spdm_x509::x509::validator::Validator::<spdm_x509::crypto_backend::RingBackend>::new();
-        validator
-            .verify_signature(&cert, &cert)
-            .map_err(|_| SPDM_STATUS_INVALID_CERT)?;
     }
 
     Ok(())
@@ -105,10 +104,10 @@ pub fn check_leaf_certificate(cert_der: &[u8], is_alias_cert: bool) -> SpdmResul
     } else {
         spdm_x509::x509::spdm_validator::SpdmCertificateModel::GenericCert
     };
-    let validator = spdm_x509::x509::spdm_validator::SpdmValidator::<
-        spdm_x509::crypto_backend::RingBackend,
-    >::new();
-    if validator.validate_hardware_identity(&cert, model).is_err() {
+    // Hardware-identity validation inspects only extension bytes (no crypto), so
+    // use the backend-free helper — this keeps check_leaf_certificate independent
+    // of any specific crypto backend (ring/mbedtls/aws-lc).
+    if spdm_x509::x509::spdm_validator::validate_hardware_identity(&cert, model).is_err() {
         log::error!(
             "Leaf certificate hardware identity check failed for model {:?}",
             model

--- a/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
@@ -310,13 +310,23 @@ pub(crate) fn verify_pqc_signature(
     }
 }
 
-/// Returns `true` if the given algorithm is a post-quantum signature algorithm
-/// handled by the PQC verifier hook rather than a built-in crypto backend.
+/// Returns `true` if the given algorithm is a post-quantum signature algorithm.
 pub(crate) fn is_pqc(algorithm: SignatureAlgorithm) -> bool {
     matches!(
         algorithm,
         SignatureAlgorithm::MlDsa44 | SignatureAlgorithm::MlDsa65 | SignatureAlgorithm::MlDsa87
     )
+}
+
+/// Returns `true` if a runtime PQC verifier hook has been registered.
+///
+/// When a PQC-capable `CryptoBackend` (e.g. the aws-lc backend, which verifies
+/// ML-DSA itself) is in use, no hook is registered and PQC signatures are
+/// dispatched to the backend directly — the runtime hook is only used when a
+/// classical backend (ring/mbedtls) that cannot do ML-DSA is paired with a
+/// separately-registered PQC verifier.
+pub(crate) fn pqc_verifier_registered() -> bool {
+    PQC_VERIFIER.try_get().is_ok()
 }
 
 #[cfg(test)]

--- a/spdmlib/src/crypto/spdm_x509/src/x509/spdm_validator.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/spdm_validator.rs
@@ -436,123 +436,9 @@ impl<B: crate::crypto_backend::CryptoBackend> SpdmValidator<B> {
         cert: &Certificate,
         model: SpdmCertificateModel,
     ) -> Result<()> {
-        // Check if the certificate has the SPDM extension
-        let spdm_ext = match find_extension(cert, &oids::SPDM_EXTENSION) {
-            Some(ext) => ext,
-            None => {
-                // If DeviceCert, SPDM extension should be present
-                if model == SpdmCertificateModel::DeviceCert {
-                    return Err(Error::ExtensionError(
-                        ExtensionError::MissingRequiredExtension(alloc::string::String::from(
-                            "DeviceCert requires SPDM extension with Hardware Identity",
-                        )),
-                    ));
-                }
-                return Ok(());
-            }
-        };
-
-        // Parse the SPDM extension to look for Hardware Identity OID
-        // The extension value is a SEQUENCE of OIDs
-        let has_hw_identity = self.check_hardware_identity_in_extension(&spdm_ext.extn_value)?;
-
-        // Apply validation rules based on certificate model
-        match model {
-            SpdmCertificateModel::DeviceCert => {
-                if !has_hw_identity {
-                    return Err(Error::ExtensionError(
-                        ExtensionError::MissingRequiredExtension(alloc::string::String::from(
-                            "DeviceCert MUST contain Hardware Identity OID",
-                        )),
-                    ));
-                }
-            }
-            SpdmCertificateModel::AliasCert => {
-                if has_hw_identity {
-                    return Err(Error::ExtensionError(ExtensionError::InvalidValue(
-                        alloc::string::String::from(
-                            "AliasCert MUST NOT contain Hardware Identity OID",
-                        ),
-                    )));
-                }
-            }
-            SpdmCertificateModel::GenericCert => {
-                // No specific requirement for GenericCert
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Check if Hardware Identity OID is present in SPDM extension.
-    ///
-    /// The SPDM extension value is an OCTET STRING containing a DER-encoded
-    /// SEQUENCE OF ObjectIdentifier.  We parse this properly with the `der`
-    /// crate instead of doing a raw byte-pattern search (which could
-    /// false-positive on arbitrary DER content).
-    fn check_hardware_identity_in_extension(
-        &self,
-        extn_value: &der::asn1::OctetString,
-    ) -> Result<bool> {
-        use const_oid::ObjectIdentifier;
-        use der::{Decode, Header, Reader, SliceReader, Tag};
-
-        let bytes = extn_value.as_bytes();
-
-        let mut reader = SliceReader::new(bytes).map_err(|e| {
-            Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
-                alloc::format!("Invalid SPDM extension encoding: {:?}", e),
-            ))
-        })?;
-
-        // Read the outer SEQUENCE header
-        let header = Header::decode(&mut reader).map_err(|e| {
-            Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
-                alloc::format!("Invalid SPDM extension SEQUENCE header: {:?}", e),
-            ))
-        })?;
-
-        if header.tag != Tag::Sequence {
-            return Err(Error::ExtensionError(
-                crate::error::ExtensionError::InvalidEncoding(alloc::format!(
-                    "Expected SEQUENCE in SPDM extension, got {:?}",
-                    header.tag
-                )),
-            ));
-        }
-
-        // Iterate over elements within the SEQUENCE.
-        // Each element may be a bare OID or a SEQUENCE { OID, ... }.
-        let mut found = false;
-        reader
-            .read_nested(header.length, |seq_reader| {
-                while !seq_reader.is_finished() {
-                    let tag = seq_reader.peek_tag()?;
-                    let oid = if tag == Tag::Sequence {
-                        let hdr = Header::decode(seq_reader)?;
-                        seq_reader.read_nested(hdr.length, |inner| {
-                            let id = ObjectIdentifier::decode(inner)?;
-                            while !inner.is_finished() {
-                                let _: der::Any = Decode::decode(inner)?;
-                            }
-                            Ok(id)
-                        })?
-                    } else {
-                        ObjectIdentifier::decode(seq_reader)?
-                    };
-                    if oid == oids::HARDWARE_IDENTITY {
-                        found = true;
-                    }
-                }
-                Ok(())
-            })
-            .map_err(|e| {
-                Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
-                    alloc::format!("Failed to parse SPDM extension OIDs: {:?}", e),
-                ))
-            })?;
-
-        Ok(found)
+        // Hardware-identity validation is a pure extension-byte inspection with no
+        // cryptographic operation, so delegate to the backend-free free function.
+        validate_hardware_identity(cert, model)
     }
 
     /// Validate Basic Constraints per SPDM certificate model
@@ -669,6 +555,125 @@ impl<B: crate::crypto_backend::CryptoBackend> SpdmValidator<B> {
 
         Ok(())
     }
+}
+
+// =============================================================================
+// Backend-free helpers
+//
+// SPDM hardware-identity validation inspects only X.509 extension bytes and
+// performs no cryptographic operation, so it does not need a `CryptoBackend`.
+// Exposing it as a free function lets callers (e.g. spdmlib's
+// check_leaf_certificate) validate the DeviceCert/AliasCert HW-identity rules
+// without instantiating `SpdmValidator<B>` for a specific backend — which is
+// what allows a build with no classical backend (standalone aws-lc) to compile
+// without referencing `RingBackend`.
+// =============================================================================
+
+/// Validate the SPDM Hardware Identity OID rules for a certificate model
+/// (DSP0274 Section 10.6.1.4), without requiring a crypto backend.
+///
+/// - **DeviceCert**: the SPDM extension with the Hardware Identity OID MUST be present.
+/// - **AliasCert**: the Hardware Identity OID MUST NOT be present.
+/// - **GenericCert**: no requirement.
+pub fn validate_hardware_identity(cert: &Certificate, model: SpdmCertificateModel) -> Result<()> {
+    let spdm_ext = match find_extension(cert, &oids::SPDM_EXTENSION) {
+        Some(ext) => ext,
+        None => {
+            if model == SpdmCertificateModel::DeviceCert {
+                return Err(Error::ExtensionError(
+                    ExtensionError::MissingRequiredExtension(alloc::string::String::from(
+                        "DeviceCert requires SPDM extension with Hardware Identity",
+                    )),
+                ));
+            }
+            return Ok(());
+        }
+    };
+
+    let has_hw_identity = check_hardware_identity_in_extension(&spdm_ext.extn_value)?;
+
+    match model {
+        SpdmCertificateModel::DeviceCert => {
+            if !has_hw_identity {
+                return Err(Error::ExtensionError(
+                    ExtensionError::MissingRequiredExtension(alloc::string::String::from(
+                        "DeviceCert MUST contain Hardware Identity OID",
+                    )),
+                ));
+            }
+        }
+        SpdmCertificateModel::AliasCert => {
+            if has_hw_identity {
+                return Err(Error::ExtensionError(ExtensionError::InvalidValue(
+                    alloc::string::String::from("AliasCert MUST NOT contain Hardware Identity OID"),
+                )));
+            }
+        }
+        SpdmCertificateModel::GenericCert => {}
+    }
+
+    Ok(())
+}
+
+/// Returns `true` if the SPDM extension OCTET STRING (a DER SEQUENCE OF OID)
+/// contains the Hardware Identity OID.
+fn check_hardware_identity_in_extension(extn_value: &der::asn1::OctetString) -> Result<bool> {
+    use const_oid::ObjectIdentifier;
+    use der::{Decode, Header, Reader, SliceReader, Tag};
+
+    let bytes = extn_value.as_bytes();
+
+    let mut reader = SliceReader::new(bytes).map_err(|e| {
+        Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
+            alloc::format!("Invalid SPDM extension encoding: {:?}", e),
+        ))
+    })?;
+
+    let header = Header::decode(&mut reader).map_err(|e| {
+        Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
+            alloc::format!("Invalid SPDM extension SEQUENCE header: {:?}", e),
+        ))
+    })?;
+
+    if header.tag != Tag::Sequence {
+        return Err(Error::ExtensionError(
+            crate::error::ExtensionError::InvalidEncoding(alloc::format!(
+                "Expected SEQUENCE in SPDM extension, got {:?}",
+                header.tag
+            )),
+        ));
+    }
+
+    let mut found = false;
+    reader
+        .read_nested(header.length, |seq_reader| {
+            while !seq_reader.is_finished() {
+                let tag = seq_reader.peek_tag()?;
+                let oid = if tag == Tag::Sequence {
+                    let hdr = Header::decode(seq_reader)?;
+                    seq_reader.read_nested(hdr.length, |inner| {
+                        let id = ObjectIdentifier::decode(inner)?;
+                        while !inner.is_finished() {
+                            let _: der::Any = Decode::decode(inner)?;
+                        }
+                        Ok(id)
+                    })?
+                } else {
+                    ObjectIdentifier::decode(seq_reader)?
+                };
+                if oid == oids::HARDWARE_IDENTITY {
+                    found = true;
+                }
+            }
+            Ok(())
+        })
+        .map_err(|e| {
+            Error::ExtensionError(crate::error::ExtensionError::InvalidEncoding(
+                alloc::format!("Failed to parse SPDM extension OIDs: {:?}", e),
+            ))
+        })?;
+
+    Ok(found)
 }
 
 #[cfg(all(test, feature = "ring-backend"))]

--- a/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
@@ -273,11 +273,15 @@ impl<B: CryptoBackend> Validator<B> {
             public_key_bytes.len()
         );
 
-        // Post-quantum (e.g. ML-DSA / FIPS 204) signatures cannot be verified
-        // by the classical crypto backends (ring / mbedtls).  Dispatch them to
-        // the runtime registered PQC verifier hook so that PQC certificate
-        // chains (DSP0274 1.4) validate through the same code path.
-        let verify_result = if crate::crypto_backend::is_pqc(sig_algo) {
+        // Post-quantum (e.g. ML-DSA / FIPS 204) signatures cannot be verified by
+        // the classical crypto backends (ring / mbedtls). When such a backend is
+        // paired with a separately-registered PQC verifier hook, dispatch ML-DSA
+        // to the hook. When the active backend can verify ML-DSA itself (e.g. the
+        // aws-lc backend), no hook is registered and the signature — PQC or
+        // classical — goes straight to the backend.
+        let verify_result = if crate::crypto_backend::is_pqc(sig_algo)
+            && crate::crypto_backend::pqc_verifier_registered()
+        {
             crate::crypto_backend::verify_pqc_signature(
                 sig_algo,
                 &tbs_bytes,

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -9,10 +9,15 @@ spdmlib = { path = "../spdmlib", default-features = false }
 spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false }
 aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", features = ["unstable"] }
 log = { version = "0.4", default-features = false }
+# For the streaming hash-context handle table (hashed-transcript-data).
+lazy_static = { version = "1.0", features = ["spin_no_std"] }
+spin = "0.9.8"
+# For building SpdmDheExchangeStruct via its From<BytesMut> impl.
+bytes = { version = "1", default-features = false }
 
 [dev-dependencies]
-# Enable the ring backend + std so the ML-DSA cert-chain tests can drive
-# spdm_x509's classical chain validation and read test-key DER files.
+# Enable the ring backend + std so the cert-chain tests can read test-key DER
+# files and exercise the full validator.
 spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["ring-backend", "std"] }
 
 [features]

--- a/spdmlib_crypto_aws_lc/src/aead_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/aead_impl.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! AEAD (AES-128/256-GCM, ChaCha20-Poly1305) via aws-lc-rs, for the standalone
+//! aws-lc backend. Mirrors the ring backend's structure.
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+use log::error;
+use spdmlib::crypto::SpdmAead;
+use spdmlib::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
+use spdmlib::protocol::{SpdmAeadAlgo, SpdmAeadIvStruct, SpdmAeadKeyStruct};
+
+pub static DEFAULT: SpdmAead = SpdmAead {
+    encrypt_cb: encrypt,
+    decrypt_cb: decrypt,
+};
+
+fn encrypt(
+    aead_algo: SpdmAeadAlgo,
+    key: &SpdmAeadKeyStruct,
+    iv: &SpdmAeadIvStruct,
+    aad: &[u8],
+    plain_text: &[u8],
+    tag: &mut [u8],
+    cipher_text: &mut [u8],
+) -> SpdmResult<(usize, usize)> {
+    if key.data_size != aead_algo.get_key_size() {
+        error!("key len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    if iv.data_size != aead_algo.get_iv_size() {
+        error!("iv len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    let tag_size = tag.len();
+    if tag_size != aead_algo.get_tag_size() as usize {
+        error!("tag len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    let plain_text_size = plain_text.len();
+    if cipher_text.len() != plain_text_size {
+        error!("cipher_text len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+
+    let mut d = [0u8; aws_lc_rs::aead::NONCE_LEN];
+    d.copy_from_slice(&iv.data[..aws_lc_rs::aead::NONCE_LEN]);
+    let nonce = aws_lc_rs::aead::Nonce::assume_unique_for_key(d);
+
+    cipher_text.copy_from_slice(plain_text);
+    let mut s_key: aws_lc_rs::aead::SealingKey<OneNonceSequence> = make_key(aead_algo, key, nonce)?;
+    match s_key.seal_in_place_separate_tag(aws_lc_rs::aead::Aad::from(aad), cipher_text) {
+        Ok(t) => {
+            tag.copy_from_slice(t.as_ref());
+            Ok((plain_text_size, tag_size))
+        }
+        Err(_) => Err(SPDM_STATUS_CRYPTO_ERROR),
+    }
+}
+
+fn decrypt(
+    aead_algo: SpdmAeadAlgo,
+    key: &SpdmAeadKeyStruct,
+    iv: &SpdmAeadIvStruct,
+    aad: &[u8],
+    cipher_text: &[u8],
+    tag: &[u8],
+    plain_text: &mut [u8],
+) -> SpdmResult<usize> {
+    if key.data_size != aead_algo.get_key_size() {
+        error!("key len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    if iv.data_size != aead_algo.get_iv_size() {
+        error!("iv len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    let tag_size = tag.len();
+    if tag_size != aead_algo.get_tag_size() as usize {
+        error!("tag len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+    let cipher_text_size = cipher_text.len();
+    if plain_text.len() != cipher_text_size {
+        error!("plain_text len invalid");
+        return Err(SPDM_STATUS_CRYPTO_ERROR);
+    }
+
+    let mut d = [0u8; aws_lc_rs::aead::NONCE_LEN];
+    d.copy_from_slice(&iv.data[..aws_lc_rs::aead::NONCE_LEN]);
+    let nonce = aws_lc_rs::aead::Nonce::assume_unique_for_key(d);
+
+    let mut in_out: Vec<u8> = Vec::with_capacity(cipher_text_size + tag_size);
+    in_out.extend_from_slice(cipher_text);
+    in_out.extend_from_slice(tag);
+
+    let mut o_key: aws_lc_rs::aead::OpeningKey<OneNonceSequence> = make_key(aead_algo, key, nonce)?;
+    match o_key.open_in_place(aws_lc_rs::aead::Aad::from(aad), &mut in_out) {
+        Ok(out) => {
+            plain_text.copy_from_slice(&out[..cipher_text_size]);
+            Ok(cipher_text_size)
+        }
+        Err(_) => Err(SPDM_STATUS_CRYPTO_ERROR),
+    }
+}
+
+fn make_key<K: aws_lc_rs::aead::BoundKey<OneNonceSequence>>(
+    aead_algo: SpdmAeadAlgo,
+    key: &SpdmAeadKeyStruct,
+    nonce: aws_lc_rs::aead::Nonce,
+) -> SpdmResult<K> {
+    let algorithm = match aead_algo {
+        SpdmAeadAlgo::AES_128_GCM => &aws_lc_rs::aead::AES_128_GCM,
+        SpdmAeadAlgo::AES_256_GCM => &aws_lc_rs::aead::AES_256_GCM,
+        SpdmAeadAlgo::CHACHA20_POLY1305 => &aws_lc_rs::aead::CHACHA20_POLY1305,
+        _ => return Err(SPDM_STATUS_CRYPTO_ERROR),
+    };
+    let unbound = aws_lc_rs::aead::UnboundKey::new(algorithm, key.as_ref())
+        .map_err(|_| SPDM_STATUS_CRYPTO_ERROR)?;
+    Ok(K::new(unbound, OneNonceSequence::new(nonce)))
+}
+
+struct OneNonceSequence(Option<aws_lc_rs::aead::Nonce>);
+
+impl OneNonceSequence {
+    fn new(nonce: aws_lc_rs::aead::Nonce) -> Self {
+        Self(Some(nonce))
+    }
+}
+
+impl aws_lc_rs::aead::NonceSequence for OneNonceSequence {
+    fn advance(&mut self) -> Result<aws_lc_rs::aead::Nonce, aws_lc_rs::error::Unspecified> {
+        self.0.take().ok_or(aws_lc_rs::error::Unspecified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aead_roundtrip_aes256() {
+        let aead = SpdmAeadAlgo::AES_256_GCM;
+        let key = SpdmAeadKeyStruct::from(&[0x11u8; 32][..]);
+        let iv = SpdmAeadIvStruct::from(&[0x22u8; 12][..]);
+        let plain = b"spdm-rs aws-lc aead test payload";
+        let mut cipher = alloc::vec![0u8; plain.len()];
+        let mut tag = [0u8; 16];
+        let (pl, tl) = encrypt(aead, &key, &iv, b"aad", plain, &mut tag, &mut cipher).unwrap();
+        assert_eq!(pl, plain.len());
+        assert_eq!(tl, 16);
+        let mut dec = alloc::vec![0u8; cipher.len()];
+        let dl = decrypt(aead, &key, &iv, b"aad", &cipher, &tag, &mut dec).unwrap();
+        assert_eq!(dl, plain.len());
+        assert_eq!(&dec[..], &plain[..]);
+        // Tampered AAD must fail.
+        assert!(decrypt(aead, &key, &iv, b"bad", &cipher, &tag, &mut dec).is_err());
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/asym_verify_impl.rs
@@ -1,0 +1,426 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+// Traditional (RSA/ECDSA) SPDM message-signature verification via aws-lc-rs,
+// for the standalone aws-lc backend. Ported from the ring backend; aws-lc-rs
+// exposes a ring-compatible signature API.
+
+use aws_lc_rs::signature::{self, UnparsedPublicKey};
+use log::error;
+use spdmlib::crypto::SpdmAsymVerify;
+use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_CERT, SPDM_STATUS_VERIF_FAIL};
+use spdmlib::protocol::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmDer, SpdmSignatureStruct};
+
+// Parse DER length field. Returns (bytes_consumed_for_length, value)
+fn parse_der_length(input: &[u8]) -> Option<(usize, usize)> {
+    if input.is_empty() {
+        return None;
+    }
+    let first = input[0] as usize;
+    if (first & 0x80) == 0 {
+        // short form
+        return Some((1, first));
+    }
+    let num = first & 0x7f;
+    if input.len() < 1 + num {
+        return None;
+    }
+    let mut val: usize = 0;
+    for i in 0..num {
+        val = (val << 8) | (input[1 + i] as usize);
+    }
+    Some((1 + num, val))
+}
+
+// Extract the BIT STRING payload (skipping the unused-bits byte) from a SubjectPublicKeyInfo
+// or any DER blob containing a BIT STRING. Returns the slice containing the raw public key
+// (for uncompressed EC points this will start with 0x04 followed by X||Y).
+pub(crate) fn extract_spki_pubkey(spki: &[u8]) -> Option<&[u8]> {
+    let mut i = 0usize;
+    while i < spki.len() {
+        // look for BIT STRING tag (0x03)
+        if spki[i] == 0x03 {
+            // parse length starting at i+1
+            if let Some((len_of_len, content_len)) = parse_der_length(&spki[i + 1..]) {
+                let content_start = i + 1 + len_of_len;
+                if content_start + content_len <= spki.len() && content_len >= 1 {
+                    // first byte of BIT STRING is number of unused bits
+                    let unused = spki[content_start];
+                    if unused <= 7 {
+                        let key_start = content_start + 1;
+                        let key_len = content_len - 1;
+                        if key_start + key_len <= spki.len() {
+                            return Some(&spki[key_start..(key_start + key_len)]);
+                        }
+                    }
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+pub static DEFAULT: SpdmAsymVerify = SpdmAsymVerify {
+    verify_cb: asym_verify,
+};
+
+fn asym_verify(
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    der: SpdmDer,
+    data: &[u8],
+    signature: &SpdmSignatureStruct,
+) -> SpdmResult {
+    if signature.data_size != base_asym_algo.get_sig_size() {
+        return Err(SPDM_STATUS_VERIF_FAIL);
+    }
+
+    match der {
+        SpdmDer::SpdmDerPubKeyRfc7250(raw_pub_key) => {
+            // Extract the public key bytes from an RFC7250 SubjectPublicKeyInfo DER
+            let pub_key = match extract_spki_pubkey(raw_pub_key) {
+                Some(pk) => pk,
+                None => return Err(SPDM_STATUS_VERIF_FAIL),
+            };
+
+            // RFC7250 uses FIXED signature format (not ASN.1 DER) for ECDSA
+            match base_asym_algo {
+                SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384 => {
+                    // RFC7250 uses FIXED format. Ring only supports matching curve+hash:
+                    // P256+SHA256 and P384+SHA384. Cross-combinations only exist in ASN1 format.
+                    let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+                        ) => &signature::ECDSA_P256_SHA256_FIXED,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+                        ) => &signature::ECDSA_P384_SHA384_FIXED,
+                        _ => {
+                            // Unsupported combination for RFC7250
+                            return Err(SPDM_STATUS_VERIF_FAIL);
+                        }
+                    };
+                    let pk = UnparsedPublicKey::new(sign_algorithm, pub_key);
+                    pk.verify(data, &signature.data[..signature.data_size as usize])
+                        .map_err(|_| SPDM_STATUS_VERIF_FAIL)
+                }
+                SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048
+                | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072
+                | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096
+                | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048
+                | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
+                | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096 => {
+                    let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
+                        ) => &signature::RSA_PKCS1_2048_8192_SHA256,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
+                        ) => &signature::RSA_PSS_2048_8192_SHA256,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
+                        ) => &signature::RSA_PKCS1_2048_8192_SHA384,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
+                        ) => &signature::RSA_PSS_2048_8192_SHA384,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
+                        ) => &signature::RSA_PKCS1_2048_8192_SHA512,
+                        (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072,
+                        )
+                        | (
+                            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                            SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
+                        ) => &signature::RSA_PSS_2048_8192_SHA512,
+                        _ => {
+                            return Err(SPDM_STATUS_VERIF_FAIL);
+                        }
+                    };
+                    let pk = UnparsedPublicKey::new(sign_algorithm, pub_key);
+                    pk.verify(data, &signature.data[..signature.data_size as usize])
+                        .map_err(|_| SPDM_STATUS_VERIF_FAIL)
+                }
+                _ => Err(SPDM_STATUS_VERIF_FAIL),
+            }
+        }
+        SpdmDer::SpdmDerCertChain(public_cert_der) => asym_verify_with_spdm_x509(
+            base_hash_algo,
+            base_asym_algo,
+            public_cert_der,
+            data,
+            signature,
+        ),
+    }
+}
+
+// =============================================================================
+// spdm_x509 implementation
+// =============================================================================
+
+fn asym_verify_with_spdm_x509(
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    public_cert_der: &[u8],
+    data: &[u8],
+    signature: &SpdmSignatureStruct,
+) -> SpdmResult {
+    // Get the leaf certificate using spdm_x509
+    let (leaf_begin, leaf_end) =
+        spdm_x509::x509::chain::get_cert_from_cert_chain(public_cert_der, -1).map_err(|e| {
+            error!("Failed to get leaf cert: {:?}", e);
+            SPDM_STATUS_INVALID_CERT
+        })?;
+
+    let leaf_cert_der = &public_cert_der[leaf_begin..leaf_end];
+
+    // Parse the certificate using spdm_x509 to get the public key
+    let cert = spdm_x509::Certificate::from_der(leaf_cert_der).map_err(|e| {
+        error!("Failed to parse certificate: {:?}", e);
+        SPDM_STATUS_INVALID_CERT
+    })?;
+
+    let pub_key_info = &cert.tbs_certificate.subject_public_key_info;
+    let pub_key_bytes = pub_key_info.subject_public_key.raw_bytes();
+
+    match base_asym_algo {
+        SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+        | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384 => {
+            // For ECDSA, we need to convert the signature from FIXED format to ASN.1 DER format
+            // Ring verifies ECDSA signatures in ASN.1 DER format
+
+            // Convert signature to DER format
+            let mut der_signature = [0u8; spdmlib::protocol::ECDSA_ECC_NIST_P384_SIG_SIZE + 8];
+            let der_sign_size = ecc_signature_bin_to_der(signature.as_ref(), &mut der_signature)?;
+
+            // Select the appropriate algorithm (ASN.1 versions, not FIXED)
+            let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                (
+                    SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                    SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+                ) => &signature::ECDSA_P256_SHA256_ASN1,
+                (
+                    SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                    SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+                ) => &signature::ECDSA_P256_SHA384_ASN1,
+                (
+                    SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+                    SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+                ) => &signature::ECDSA_P384_SHA256_ASN1,
+                (
+                    SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+                    SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+                ) => &signature::ECDSA_P384_SHA384_ASN1,
+                _ => {
+                    error!(
+                        "Unsupported ECDSA combination: hash={:?}, asym={:?}",
+                        base_hash_algo, base_asym_algo
+                    );
+                    return Err(SPDM_STATUS_VERIF_FAIL);
+                }
+            };
+
+            let pk = UnparsedPublicKey::new(sign_algorithm, pub_key_bytes);
+            match pk.verify(data, &der_signature[..der_sign_size]) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("ECDSA signature verification failed: {:?}", e);
+                    Err(SPDM_STATUS_VERIF_FAIL)
+                }
+            }
+        }
+        SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048
+        | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072
+        | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096
+        | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048
+        | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
+        | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096 => {
+            // For RSA, use ring signature verification
+            let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+                    &signature::RSA_PKCS1_2048_8192_SHA256
+                }
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+                    &signature::RSA_PSS_2048_8192_SHA256
+                }
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+                    &signature::RSA_PKCS1_2048_8192_SHA384
+                }
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+                    &signature::RSA_PSS_2048_8192_SHA384
+                }
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+                    &signature::RSA_PKCS1_2048_8192_SHA512
+                }
+                (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+                | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+                    &signature::RSA_PSS_2048_8192_SHA512
+                }
+                _ => {
+                    error!(
+                        "Unsupported RSA combination: hash={:?}, asym={:?}",
+                        base_hash_algo, base_asym_algo
+                    );
+                    return Err(SPDM_STATUS_VERIF_FAIL);
+                }
+            };
+
+            let pk = UnparsedPublicKey::new(sign_algorithm, pub_key_bytes);
+            match pk.verify(data, &signature.data[..signature.data_size as usize]) {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    error!("RSA signature verification failed: {:?}", e);
+                    Err(SPDM_STATUS_VERIF_FAIL)
+                }
+            }
+        }
+        _ => {
+            error!("Unsupported algorithm: {:?}", base_asym_algo);
+            Err(SPDM_STATUS_VERIF_FAIL)
+        }
+    }
+}
+
+// add ASN.1 for the ECDSA binary signature
+fn ecc_signature_bin_to_der(signature: &[u8], der_signature: &mut [u8]) -> SpdmResult<usize> {
+    let sign_size = signature.len();
+    assert!(
+        // prevent API misuse
+        sign_size == spdmlib::protocol::ECDSA_ECC_NIST_P256_SIG_SIZE
+            || sign_size == spdmlib::protocol::ECDSA_ECC_NIST_P384_SIG_SIZE
+    );
+    let half_size = sign_size / 2;
+
+    let mut r_index = half_size;
+    for (i, item) in signature.iter().enumerate().take(half_size) {
+        if *item != 0 {
+            r_index = i;
+            break;
+        }
+    }
+    let r_size = half_size - r_index;
+    let r = &signature[r_index..half_size];
+
+    let mut s_index = half_size;
+    for i in 0..half_size {
+        if signature[i + half_size] != 0 {
+            s_index = i;
+            break;
+        }
+    }
+    let s_size = half_size - s_index;
+    let s = &signature[half_size + s_index..sign_size];
+    if r_size == 0 || s_size == 0 {
+        return Ok(0);
+    }
+
+    let der_r_size = if r[0] < 0x80 { r_size } else { r_size + 1 };
+    let der_s_size = if s[0] < 0x80 { s_size } else { s_size + 1 };
+    // der_sign_size includes: 0x30 _ 0x02 _ [der_r_size] 0x02 _ [der_s_size]
+    let der_sign_size = der_r_size + der_s_size + 6;
+
+    if der_signature.len() < der_sign_size {
+        error!("der_signature too small");
+        return Err(SPDM_STATUS_VERIF_FAIL);
+    }
+
+    if der_r_size > u8::MAX as usize
+        || der_s_size > u8::MAX as usize
+        || der_sign_size > u8::MAX as usize
+    {
+        error!("size check fails!");
+        return Err(SPDM_STATUS_VERIF_FAIL);
+    }
+
+    der_signature[0] = 0x30u8;
+    der_signature[1] = (der_sign_size - 2) as u8;
+    der_signature[2] = 0x02u8;
+    der_signature[3] = der_r_size as u8;
+    if r[0] < 0x80 {
+        der_signature[4..(4 + r_size)].copy_from_slice(r);
+    } else {
+        der_signature[4] = 0u8;
+        der_signature[5..(5 + r_size)].copy_from_slice(r);
+    }
+    der_signature[4 + der_r_size] = 0x02u8;
+    der_signature[5 + der_r_size] = der_s_size as u8;
+
+    if s[0] < 0x80 {
+        der_signature[(6 + der_r_size)..(6 + der_r_size + s_size)].copy_from_slice(s);
+    } else {
+        der_signature[6 + der_r_size] = 0u8;
+        der_signature[(7 + der_r_size)..(7 + der_r_size + s_size)].copy_from_slice(s);
+    }
+
+    Ok(der_sign_size)
+}
+// NOTE: The ring backend's unit tests for this module rely on a `public_cert.der`
+// test asset local to that crate. The aws-lc classical asym_verify path is
+// exercised end-to-end by the emulator interaction test (standalone aws-lc) and
+// by the cert-chain tests in `cert_operation_impl`.

--- a/spdmlib_crypto_aws_lc/src/cert_operation_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/cert_operation_impl.rs
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! Certificate-chain operations for the standalone aws-lc backend.
+//!
+//! Provides an `AwsLcBackend` implementing spdm_x509's `CryptoBackend` trait
+//! that verifies BOTH traditional (RSA/ECDSA/Ed25519) AND post-quantum
+//! (ML-DSA, FIPS 204) certificate signatures via aws-lc-rs. Because a single
+//! backend now covers ML-DSA, the runtime PQC verifier hook
+//! (`register_pqc_verifier`) is unnecessary on this path — cert-chain
+//! validation goes through the normal `CryptoBackend::verify_signature`.
+
+use aws_lc_rs::signature::{self, UnparsedPublicKey};
+use spdm_x509::crypto_backend::{CryptoBackend, SignatureAlgorithm};
+use spdm_x509::error::{Error, Result};
+use spdmlib::crypto::SpdmCertOperation;
+use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_CERT};
+
+/// aws-lc-rs implementation of spdm_x509's `CryptoBackend` — classical + ML-DSA.
+#[derive(Clone, Copy)]
+pub struct AwsLcBackend;
+
+impl CryptoBackend for AwsLcBackend {
+    fn verify_signature(
+        &self,
+        algorithm: SignatureAlgorithm,
+        tbs_data: &[u8],
+        signature: &[u8],
+        public_key: &[u8],
+    ) -> Result<()> {
+        // ML-DSA: aws-lc-rs accepts a raw or SPKI-DER public key; empty context
+        // for X.509 certificate signatures.
+        use aws_lc_rs::unstable::signature::{ML_DSA_44, ML_DSA_65, ML_DSA_87};
+
+        let classical: &dyn signature::VerificationAlgorithm = match algorithm {
+            SignatureAlgorithm::EcdsaP256Sha256 => &signature::ECDSA_P256_SHA256_ASN1,
+            SignatureAlgorithm::EcdsaP256Sha384 => &signature::ECDSA_P256_SHA384_ASN1,
+            SignatureAlgorithm::EcdsaP384Sha256 => &signature::ECDSA_P384_SHA256_ASN1,
+            SignatureAlgorithm::EcdsaP384Sha384 => &signature::ECDSA_P384_SHA384_ASN1,
+            SignatureAlgorithm::RsaPkcs1Sha256 => &signature::RSA_PKCS1_2048_8192_SHA256,
+            SignatureAlgorithm::RsaPkcs1Sha384 => &signature::RSA_PKCS1_2048_8192_SHA384,
+            SignatureAlgorithm::RsaPkcs1Sha512 => &signature::RSA_PKCS1_2048_8192_SHA512,
+            SignatureAlgorithm::RsaPssSha256 => &signature::RSA_PSS_2048_8192_SHA256,
+            SignatureAlgorithm::RsaPssSha384 => &signature::RSA_PSS_2048_8192_SHA384,
+            SignatureAlgorithm::RsaPssSha512 => &signature::RSA_PSS_2048_8192_SHA512,
+            SignatureAlgorithm::Ed25519 => &signature::ED25519,
+            SignatureAlgorithm::MlDsa44
+            | SignatureAlgorithm::MlDsa65
+            | SignatureAlgorithm::MlDsa87 => {
+                let algo = match algorithm {
+                    SignatureAlgorithm::MlDsa44 => &ML_DSA_44,
+                    SignatureAlgorithm::MlDsa65 => &ML_DSA_65,
+                    SignatureAlgorithm::MlDsa87 => &ML_DSA_87,
+                    _ => unreachable!(),
+                };
+                let pk = UnparsedPublicKey::new(algo, public_key);
+                return pk.verify(tbs_data, signature).map_err(|_| {
+                    Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
+                });
+            }
+        };
+
+        let pk = UnparsedPublicKey::new(classical, public_key);
+        pk.verify(tbs_data, signature).map_err(|_| {
+            Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
+        })
+    }
+}
+
+pub static DEFAULT: SpdmCertOperation = SpdmCertOperation {
+    get_cert_from_cert_chain_cb: get_cert_from_cert_chain,
+    verify_cert_chain_cb: verify_cert_chain,
+};
+
+fn get_cert_from_cert_chain(cert_chain: &[u8], index: isize) -> SpdmResult<(usize, usize)> {
+    spdm_x509::x509::chain::get_cert_from_cert_chain(cert_chain, index)
+        .map_err(|_| SPDM_STATUS_INVALID_CERT)
+}
+
+fn verify_cert_chain(
+    cert_chain: &[u8],
+    base_asym_algo: Option<u32>,
+    base_hash_algo: Option<u32>,
+) -> SpdmResult {
+    spdm_x509::x509::chain::verify_cert_chain_with_backend(
+        cert_chain,
+        AwsLcBackend,
+        base_asym_algo,
+        base_hash_algo,
+    )
+    .map_err(|_| SPDM_STATUS_INVALID_CERT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_cert_chain_ecp384() {
+        let chain = &include_bytes!("../../test_key/ecp384/bundle_responder.certchain.der")[..];
+        assert!(verify_cert_chain(chain, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_verify_cert_chain_rsa3072() {
+        let chain = &include_bytes!("../../test_key/rsa3072/bundle_responder.certchain.der")[..];
+        assert!(verify_cert_chain(chain, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_verify_cert_chain_mldsa87() {
+        let chain = &include_bytes!("../../test_key/mldsa87/bundle_responder.certchain.der")[..];
+        assert!(verify_cert_chain(chain, None, None).is_ok());
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/dhe_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/dhe_impl.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! ECDHE (P-256, P-384) via aws-lc-rs, for the standalone aws-lc backend.
+//!
+//! Uses aws-lc-rs's non-ephemeral `agreement::PrivateKey`, which (unlike
+//! `EphemeralPrivateKey`) can export its raw big-endian private scalar and be
+//! re-imported from it. This gives the same checkpoint/resume support as the
+//! ring backend: `export_private_key` returns the raw scalar and
+//! `import_private_key_cb` reconstructs the key from it.
+
+extern crate alloc;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use aws_lc_rs::agreement::{self, PrivateKey, UnparsedPublicKey};
+use aws_lc_rs::encoding::{AsBigEndian, EcPrivateKeyBin};
+use spdmlib::crypto::{SpdmDhe, SpdmDheKeyExchange};
+use spdmlib::protocol::{SpdmDheAlgo, SpdmDheExchangeStruct, SpdmSharedSecretFinalKeyStruct};
+
+pub static DEFAULT: SpdmDhe = SpdmDhe {
+    generate_key_pair_cb: generate_key_pair,
+    import_private_key_cb: Some(import_private_key),
+};
+
+fn algo_of(dhe_algo: SpdmDheAlgo) -> Option<&'static agreement::Algorithm> {
+    match dhe_algo {
+        SpdmDheAlgo::SECP_256_R1 => Some(&agreement::ECDH_P256),
+        SpdmDheAlgo::SECP_384_R1 => Some(&agreement::ECDH_P384),
+        _ => None,
+    }
+}
+
+fn generate_key_pair(
+    dhe_algo: SpdmDheAlgo,
+) -> Option<(SpdmDheExchangeStruct, Box<dyn SpdmDheKeyExchange + Send>)> {
+    let alg = algo_of(dhe_algo)?;
+    let private_key = PrivateKey::generate(alg).ok()?;
+    exchange_from_private_key(alg, private_key)
+}
+
+fn import_private_key(
+    dhe_algo: SpdmDheAlgo,
+    private_key_bytes: &[u8],
+) -> Option<Box<dyn SpdmDheKeyExchange + Send>> {
+    let alg = algo_of(dhe_algo)?;
+    // Raw big-endian fixed-length scalar, same encoding produced by
+    // `export_private_key` below (and by the ring backend).
+    let private_key = PrivateKey::from_private_key(alg, private_key_bytes).ok()?;
+    let (_pub, exchange) = exchange_from_private_key(alg, private_key)?;
+    Some(exchange)
+}
+
+/// Build the SPDM exchange struct (raw X||Y public point) and the key-exchange
+/// object from a private key.
+fn exchange_from_private_key(
+    alg: &'static agreement::Algorithm,
+    private_key: PrivateKey,
+) -> Option<(SpdmDheExchangeStruct, Box<dyn SpdmDheKeyExchange + Send>)> {
+    let public_key = private_key.compute_public_key().ok()?;
+    // SPDM carries the raw X||Y (strip the leading 0x04 uncompressed-point tag).
+    let public_key_xy = public_key.as_ref()[1..].to_vec();
+
+    let exchange: Box<dyn SpdmDheKeyExchange + Send> = Box::new(SpdmDheKeyExchangeAwsLc {
+        alg,
+        private_key: Some(private_key),
+    });
+    let exch_struct = SpdmDheExchangeStruct::from(bytes::BytesMut::from(&public_key_xy[..]));
+    Some((exch_struct, exchange))
+}
+
+struct SpdmDheKeyExchangeAwsLc {
+    alg: &'static agreement::Algorithm,
+    private_key: Option<PrivateKey>,
+}
+
+impl SpdmDheKeyExchange for SpdmDheKeyExchangeAwsLc {
+    fn compute_final_key(
+        mut self: Box<Self>,
+        peer_pub_key: &SpdmDheExchangeStruct,
+    ) -> Option<SpdmSharedSecretFinalKeyStruct> {
+        let private_key = self.private_key.take()?;
+
+        // Reconstruct the uncompressed point: 0x04 || X || Y.
+        let mut pubkey = Vec::with_capacity(1 + peer_pub_key.data_size as usize);
+        pubkey.push(0x04u8);
+        pubkey.extend_from_slice(&peer_pub_key.data[..peer_pub_key.data_size as usize]);
+        let peer_public_key = UnparsedPublicKey::new(self.alg, pubkey);
+
+        let mut final_key: Vec<u8> = Vec::new();
+        let res = agreement::agree(
+            &private_key,
+            &peer_public_key,
+            aws_lc_rs::error::Unspecified,
+            |key_material| {
+                final_key.extend_from_slice(key_material);
+                Ok(())
+            },
+        );
+        match res {
+            Ok(()) => Some(SpdmSharedSecretFinalKeyStruct::from(final_key.as_slice())),
+            Err(_) => None,
+        }
+    }
+
+    fn export_private_key(&self) -> Option<Vec<u8>> {
+        let private_key = self.private_key.as_ref()?;
+        let bin: EcPrivateKeyBin = private_key.as_be_bytes().ok()?;
+        Some(bin.as_ref().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(dhe_algo: SpdmDheAlgo) {
+        // Two parties generate key pairs and must agree on the same secret.
+        let (a_pub, a_ex) = generate_key_pair(dhe_algo).unwrap();
+        let (b_pub, b_ex) = generate_key_pair(dhe_algo).unwrap();
+        let a_secret = a_ex.compute_final_key(&b_pub).unwrap();
+        let b_secret = b_ex.compute_final_key(&a_pub).unwrap();
+        assert_eq!(a_secret.data_size, b_secret.data_size);
+        assert_eq!(
+            &a_secret.data[..a_secret.data_size as usize],
+            &b_secret.data[..b_secret.data_size as usize]
+        );
+    }
+
+    #[test]
+    fn test_dhe_p256() {
+        roundtrip(SpdmDheAlgo::SECP_256_R1);
+    }
+
+    #[test]
+    fn test_dhe_p384() {
+        roundtrip(SpdmDheAlgo::SECP_384_R1);
+    }
+
+    /// Exported private key bytes must re-import and reproduce the same agreed
+    /// secret — the checkpoint/resume property.
+    fn export_import_roundtrip(dhe_algo: SpdmDheAlgo) {
+        let (_a_pub, a_ex) = generate_key_pair(dhe_algo).unwrap();
+        let exported = a_ex.export_private_key().expect("export supported");
+
+        // Original A and re-imported A agree with the same peer B; because the
+        // imported key is byte-identical, both must yield the same secret.
+        let a_imported = import_private_key(dhe_algo, &exported).unwrap();
+        let (b_pub, _b_ex) = generate_key_pair(dhe_algo).unwrap();
+
+        let secret_orig = a_ex.compute_final_key(&b_pub).unwrap();
+        let secret_imported = a_imported.compute_final_key(&b_pub).unwrap();
+
+        assert_eq!(
+            &secret_orig.data[..secret_orig.data_size as usize],
+            &secret_imported.data[..secret_imported.data_size as usize],
+            "imported key must reproduce the same shared secret"
+        );
+    }
+
+    #[test]
+    fn test_dhe_export_import_p256() {
+        export_import_roundtrip(SpdmDheAlgo::SECP_256_R1);
+    }
+
+    #[test]
+    fn test_dhe_export_import_p384() {
+        export_import_roundtrip(SpdmDheAlgo::SECP_384_R1);
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/hash_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hash_impl.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! SHA-256/384/512 hashing via aws-lc-rs, for the standalone aws-lc backend.
+
+extern crate alloc;
+
+use spdmlib::crypto::SpdmHash;
+use spdmlib::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
+
+#[cfg(not(feature = "hashed-transcript-data"))]
+pub static DEFAULT: SpdmHash = SpdmHash {
+    hash_all_cb: hash_all,
+};
+#[cfg(feature = "hashed-transcript-data")]
+pub static DEFAULT: SpdmHash = SpdmHash {
+    hash_all_cb: hash_all,
+    hash_ctx_init_cb: hash_ext::hash_ctx_init,
+    hash_ctx_update_cb: hash_ext::hash_ctx_update,
+    hash_ctx_finalize_cb: hash_ext::hash_ctx_finalize,
+    hash_ctx_dup_cb: hash_ext::hash_ctx_dup,
+    hash_ctx_serialize_cb: hash_ext::hash_ctx_serialize,
+    hash_ctx_deserialize_cb: hash_ext::hash_ctx_deserialize,
+};
+
+fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestStruct> {
+    let algorithm = match base_hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => &aws_lc_rs::digest::SHA256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => &aws_lc_rs::digest::SHA384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => &aws_lc_rs::digest::SHA512,
+        _ => return None,
+    };
+    let digest_value = aws_lc_rs::digest::digest(algorithm, data);
+    Some(SpdmDigestStruct::from(digest_value.as_ref()))
+}
+
+#[cfg(feature = "hashed-transcript-data")]
+mod hash_ext {
+    use super::*;
+    use alloc::boxed::Box;
+    use alloc::collections::BTreeMap;
+    use lazy_static::lazy_static;
+    use spdmlib::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
+    use spin::Mutex;
+
+    pub type HashCtxConcrete = aws_lc_rs::digest::Context;
+
+    lazy_static! {
+        static ref HASH_CTX_TABLE: Mutex<BTreeMap<usize, Box<HashCtxConcrete>>> =
+            Mutex::new(BTreeMap::new());
+    }
+
+    pub fn hash_ctx_init(base_hash_algo: SpdmBaseHashAlgo) -> Option<usize> {
+        let algorithm = match base_hash_algo {
+            SpdmBaseHashAlgo::TPM_ALG_SHA_256 => &aws_lc_rs::digest::SHA256,
+            SpdmBaseHashAlgo::TPM_ALG_SHA_384 => &aws_lc_rs::digest::SHA384,
+            SpdmBaseHashAlgo::TPM_ALG_SHA_512 => &aws_lc_rs::digest::SHA512,
+            _ => return None,
+        };
+        let ctx = Box::new(HashCtxConcrete::new(algorithm));
+        Some(insert_to_table(ctx))
+    }
+
+    pub fn hash_ctx_update(handle: usize, data: &[u8]) -> SpdmResult {
+        let mut table = HASH_CTX_TABLE.lock();
+        let ctx = table.get_mut(&handle).ok_or(SPDM_STATUS_CRYPTO_ERROR)?;
+        ctx.update(data);
+        Ok(())
+    }
+
+    pub fn hash_ctx_finalize(handle: usize) -> Option<SpdmDigestStruct> {
+        let ctx = HASH_CTX_TABLE.lock().remove(&handle)?;
+        let digest_value = ctx.finish();
+        Some(SpdmDigestStruct::from(digest_value.as_ref()))
+    }
+
+    pub fn hash_ctx_dup(handle: usize) -> Option<usize> {
+        let ctx_new = {
+            let table = HASH_CTX_TABLE.lock();
+            let ctx = table.get(&handle)?;
+            ctx.clone()
+        };
+        Some(insert_to_table(ctx_new))
+    }
+
+    fn insert_to_table(value: Box<HashCtxConcrete>) -> usize {
+        let handle_ptr: *const HashCtxConcrete = &*value;
+        let handle = handle_ptr as usize;
+        HASH_CTX_TABLE.lock().insert(handle, value);
+        handle
+    }
+
+    // aws-lc-rs digest::Context does not expose serialize/deserialize of the
+    // in-progress state, so checkpoint/resume of a hash context is unsupported
+    // on this backend. These return None; callers that need transcript
+    // checkpointing must use a backend that supports it.
+    pub fn hash_ctx_serialize(_handle: usize) -> Option<alloc::vec::Vec<u8>> {
+        None
+    }
+
+    pub fn hash_ctx_deserialize(_bytes: &[u8]) -> Option<usize> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_all_sha256() {
+        let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_256, &[0u8; 32]).unwrap();
+        assert_eq!(d.data_size, 32);
+    }
+
+    #[test]
+    fn test_hash_all_sha384() {
+        let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_384, &[0u8; 48]).unwrap();
+        assert_eq!(d.data_size, 48);
+    }
+
+    #[test]
+    fn test_hash_all_sha512() {
+        let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_512, &[0u8; 64]).unwrap();
+        assert_eq!(d.data_size, 64);
+    }
+
+    #[test]
+    fn test_hash_all_invalid() {
+        assert!(hash_all(SpdmBaseHashAlgo::empty(), &[0u8; 32]).is_none());
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/hkdf_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hkdf_impl.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! HKDF-SHA-256/384/512 via aws-lc-rs, for the standalone aws-lc backend.
+
+use spdmlib::crypto::SpdmHkdf;
+#[cfg(test)]
+use spdmlib::protocol::SpdmDigestStruct;
+use spdmlib::protocol::{
+    SpdmBaseHashAlgo, SpdmHkdfInputKeyingMaterial, SpdmHkdfOutputKeyingMaterial,
+    SpdmHkdfPseudoRandomKey, SPDM_MAX_HKDF_OKM_SIZE,
+};
+
+pub static DEFAULT: SpdmHkdf = SpdmHkdf {
+    hkdf_extract_cb: hkdf_extract,
+    hkdf_expand_cb: hkdf_expand,
+};
+
+fn hkdf_extract(
+    hash_algo: SpdmBaseHashAlgo,
+    salt: &[u8],
+    ikm: &SpdmHkdfInputKeyingMaterial,
+) -> Option<SpdmHkdfPseudoRandomKey> {
+    // HKDF-Extract(salt, IKM) == HMAC(salt, IKM); use HMAC to produce the PRK,
+    // matching the ring backend's behavior.
+    let algorithm = match hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
+        _ => return None,
+    };
+    let s_key = aws_lc_rs::hmac::Key::new(algorithm, salt);
+    let tag = aws_lc_rs::hmac::sign(&s_key, ikm.as_ref());
+    Some(SpdmHkdfPseudoRandomKey::from(tag.as_ref()))
+}
+
+fn hkdf_expand(
+    hash_algo: SpdmBaseHashAlgo,
+    prk: &SpdmHkdfPseudoRandomKey,
+    info: &[u8],
+    out_size: u16,
+) -> Option<SpdmHkdfOutputKeyingMaterial> {
+    if out_size as usize > SPDM_MAX_HKDF_OKM_SIZE {
+        return None;
+    }
+    let algo = match hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hkdf::HKDF_SHA256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hkdf::HKDF_SHA384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hkdf::HKDF_SHA512,
+        _ => return None,
+    };
+    if prk.data_size as usize != algo.hmac_algorithm().digest_algorithm().output_len() {
+        return None;
+    }
+    let prk = aws_lc_rs::hkdf::Prk::new_less_safe(algo, prk.as_ref());
+    let mut ret = SpdmHkdfOutputKeyingMaterial::default();
+    let res = prk
+        .expand(&[info], SpdmCryptoHkdfKeyLen::new(out_size))
+        .and_then(|okm| {
+            ret.data_size = out_size;
+            okm.fill(&mut ret.data[..out_size as usize])
+        });
+    match res {
+        Ok(_) => Some(ret),
+        Err(_) => None,
+    }
+}
+
+struct SpdmCryptoHkdfKeyLen {
+    out_size: usize,
+}
+impl SpdmCryptoHkdfKeyLen {
+    pub fn new(len: u16) -> Self {
+        SpdmCryptoHkdfKeyLen {
+            out_size: len as usize,
+        }
+    }
+}
+impl aws_lc_rs::hkdf::KeyType for SpdmCryptoHkdfKeyLen {
+    fn len(&self) -> usize {
+        self.out_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hkdf_extract_expand() {
+        let algo = SpdmBaseHashAlgo::TPM_ALG_SHA_384;
+        // Build an IKM from a SpdmDigestStruct (one of the enum's variants).
+        let digest = SpdmDigestStruct::from(&[0x0bu8; 48][..]);
+        let ikm = SpdmHkdfInputKeyingMaterial::SpdmDigest(&digest);
+        let prk = hkdf_extract(algo, &[0u8; 48], &ikm).unwrap();
+        assert_eq!(prk.data_size, 48);
+        let okm = hkdf_expand(algo, &prk, b"info", 48).unwrap();
+        assert_eq!(okm.data_size, 48);
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/hmac_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hmac_impl.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! HMAC-SHA-256/384/512 via aws-lc-rs, for the standalone aws-lc backend.
+
+use spdmlib::crypto::SpdmHmac;
+use spdmlib::error::{SpdmResult, SPDM_STATUS_VERIF_FAIL};
+use spdmlib::protocol::{SpdmBaseHashAlgo, SpdmDigestStruct};
+
+pub static DEFAULT: SpdmHmac = SpdmHmac {
+    hmac_cb: hmac,
+    hmac_verify_cb: hmac_verify,
+};
+
+fn hmac(base_hash_algo: SpdmBaseHashAlgo, key: &[u8], data: &[u8]) -> Option<SpdmDigestStruct> {
+    let algorithm = match base_hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
+        _ => return None,
+    };
+    let s_key = aws_lc_rs::hmac::Key::new(algorithm, key);
+    let tag = aws_lc_rs::hmac::sign(&s_key, data);
+    Some(SpdmDigestStruct::from(tag.as_ref()))
+}
+
+fn hmac_verify(
+    base_hash_algo: SpdmBaseHashAlgo,
+    key: &[u8],
+    data: &[u8],
+    hmac: &SpdmDigestStruct,
+) -> SpdmResult {
+    let algorithm = match base_hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
+        _ => return Err(SPDM_STATUS_VERIF_FAIL),
+    };
+    let v_key = aws_lc_rs::hmac::Key::new(algorithm, key);
+    match aws_lc_rs::hmac::verify(&v_key, data, &hmac.data[..(hmac.data_size as usize)]) {
+        Ok(()) => Ok(()),
+        Err(_) => Err(SPDM_STATUS_VERIF_FAIL),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hmac_sign_verify_roundtrip() {
+        for algo in [
+            SpdmBaseHashAlgo::TPM_ALG_SHA_256,
+            SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+        ] {
+            let key = [0x0bu8; 20];
+            let data = b"spdm-rs aws-lc hmac test";
+            let tag = hmac(algo, &key, data).unwrap();
+            assert!(hmac_verify(algo, &key, data, &tag).is_ok());
+            // Wrong data must fail.
+            assert!(hmac_verify(algo, &key, b"other", &tag).is_err());
+        }
+    }
+}

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -2,12 +2,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-//! spdm-rs crypto backend using aws-lc-rs for PQC (ML-KEM, ML-DSA) support.
+//! spdm-rs crypto backend using aws-lc-rs.
+//!
+//! Historically this crate supplied only the post-quantum primitives (ML-KEM,
+//! ML-DSA) as an overlay on the ring/mbedtls classical backends. It now also
+//! provides the traditional primitives (hash, HMAC, AEAD, ECDHE, RSA/ECDSA
+//! verify, HKDF, rand, certificate-chain verification), so aws-lc-rs can be
+//! used as a **standalone** backend for both traditional and PQC crypto on
+//! std targets (no ring, no mbedtls). See `register_crypto_callbacks` in the
+//! emulator layer.
 
+// PQC (post-quantum) primitives.
 pub mod kem_impl;
 pub mod pqc_asym_sign_impl;
 pub mod pqc_asym_verify_impl;
 pub mod pqc_cert_verify_impl;
+
+// Traditional primitives (standalone aws-lc backend).
+pub mod aead_impl;
+pub mod asym_verify_impl;
+pub mod cert_operation_impl;
+pub mod dhe_impl;
+pub mod hash_impl;
+pub mod hkdf_impl;
+pub mod hmac_impl;
+pub mod rand_impl;
 
 #[cfg(test)]
 mod tests {

--- a/spdmlib_crypto_aws_lc/src/rand_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/rand_impl.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! CSPRNG via aws-lc-rs, for the standalone aws-lc backend.
+
+use aws_lc_rs::rand::SecureRandom;
+use spdmlib::crypto::SpdmCryptoRandom;
+use spdmlib::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
+
+pub static DEFAULT: SpdmCryptoRandom = SpdmCryptoRandom {
+    get_random_cb: get_random,
+};
+
+fn get_random(data: &mut [u8]) -> SpdmResult<usize> {
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    rng.fill(data).map_err(|_| SPDM_STATUS_CRYPTO_ERROR)?;
+    Ok(data.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_random_small() {
+        let data = &mut [0u8; 16];
+        assert!(matches!(get_random(data), Ok(16)));
+    }
+
+    #[test]
+    fn test_get_random_large() {
+        let data = &mut [0u8; 80];
+        assert!(matches!(get_random(data), Ok(80)));
+    }
+}

--- a/tdisp/Cargo.toml
+++ b/tdisp/Cargo.toml
@@ -16,11 +16,16 @@ license = "Apache-2.0 or MIT"
 [dependencies]
 codec = { path = "../codec" }
 bitflags = "1.2.1"
-spdmlib = { path = "../spdmlib", default-features = false, features = ["spdm-ring"]}
+spdmlib = { path = "../spdmlib", default-features = false }
 conquer-once = { version = "0.3.2", default-features = false }
 spin = { version = "0.9.8" }
 maybe-async = "0.2.7"
 
 [features]
+# spdm-ring is the default backend so `cargo build`/`cargo test` on this crate
+# alone keeps working. Dependents that select a different backend (e.g. the
+# standalone aws-lc emu) set default-features = false to avoid linking ring.
+default = ["spdm-ring"]
+spdm-ring = ["spdmlib/spdm-ring"]
 is_sync = ["spdmlib/is_sync", "maybe-async/is_sync"]
-std = []
+std = ["spdmlib/std"]

--- a/test/spdm-emu/Cargo.toml
+++ b/test/spdm-emu/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.13"
-ring = { version = "0.17.14" }
-untrusted = { version = "0.9.0" }
+# ring is only used for the emulator's classical secret-signing helper; optional
+# so a standalone aws-lc build (spdm-aws-lc without spdm-ring/spdm-mbedtls)
+# links no ring.
+ring = { version = "0.17.14", optional = true }
+untrusted = { version = "0.9.0", optional = true }
 codec = { path = "../../codec" }
 spdmlib = { path = "../../spdmlib", default-features = false }
 mctp_transport = { path = "../../mctp_transport" }
@@ -32,10 +35,15 @@ default = ["spdm-ring", "spdmlib/hashed-transcript-data", "async-executor"]
 mut-auth = ["spdmlib/mut-auth"]
 chunk-cap = ["spdmlib/chunk-cap"]
 mandatory-mut-auth = ["mut-auth", "spdmlib/mandatory-mut-auth"]
-spdm-ring = ["spdmlib/spdm-ring", "spdmlib/std"]
-spdm-mbedtls = ["spdmlib_crypto_mbedtls"]
-spdm-aws-lc = ["spdmlib_crypto_aws_lc", "aws-lc-rs"]
-hashed-transcript-data = ["spdmlib/hashed-transcript-data", "spdmlib_crypto_mbedtls?/hashed-transcript-data"]
+spdm-ring = ["spdmlib/spdm-ring", "spdmlib/std", "dep:ring", "dep:untrusted"]
+spdm-mbedtls = ["spdmlib_crypto_mbedtls", "dep:ring", "dep:untrusted"]
+# aws-lc-rs crypto (ML-DSA, ML-KEM, and the traditional primitives). Pulls
+# spdmlib/std because aws-lc-rs is std-only. Combined with spdm-ring or
+# spdm-mbedtls it is a PQC overlay on that classical backend; on its own (no
+# spdm-ring, no spdm-mbedtls) it is the standalone backend for BOTH classical
+# and PQC crypto, with no ring and no mbedtls linked. std-only (not for no_std).
+spdm-aws-lc = ["spdmlib_crypto_aws_lc", "aws-lc-rs", "spdmlib/std"]
+hashed-transcript-data = ["spdmlib/hashed-transcript-data", "spdmlib_crypto_mbedtls?/hashed-transcript-data", "spdmlib_crypto_aws_lc?/hashed-transcript-data"]
 async-executor = []
 async-tokio = []
 is_sync = ["spdmlib/is_sync", "maybe-async/is_sync", "mctp_transport/is_sync", "pcidoe_transport/is_sync"]

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -1,16 +1,31 @@
-// Copyright (c) 2021 Intel Corporation
+// Copyright (c) 2021-2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+// PathBuf is only used by the classical backend signing paths (which read a key
+// file); a no-backend build (cargo test --features spdmlib/spdm-ring) uses none.
+#[cfg(any(
+    feature = "spdm-ring",
+    feature = "spdm-mbedtls",
+    feature = "spdm-aws-lc"
+))]
 use std::path::PathBuf;
 
 use spdmlib::common::SpdmContext;
 use spdmlib::secret::{SpdmSecretAsymSign, SpdmSecretPqcAsymSign};
 
+use spdmlib::protocol::{SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmPqcAsymAlgo, SpdmSignatureStruct};
+// Only the classical backend paths (ring / aws-lc) use the RSA signature sizes
+// and the max signature buffer; gate them so a no-backend build (used by
+// `cargo test --features spdmlib/spdm-ring`) is warning-free.
+#[cfg(any(
+    feature = "spdm-ring",
+    feature = "spdm-mbedtls",
+    feature = "spdm-aws-lc"
+))]
 use spdmlib::protocol::{
-    SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmPqcAsymAlgo, SpdmSignatureStruct, RSAPSS_2048_SIG_SIZE,
-    RSAPSS_3072_SIG_SIZE, RSAPSS_4096_SIG_SIZE, RSASSA_2048_SIG_SIZE, RSASSA_3072_SIG_SIZE,
-    RSASSA_4096_SIG_SIZE, SPDM_MAX_ASYM_SIG_SIZE,
+    RSAPSS_2048_SIG_SIZE, RSAPSS_3072_SIG_SIZE, RSAPSS_4096_SIG_SIZE, RSASSA_2048_SIG_SIZE,
+    RSASSA_3072_SIG_SIZE, RSASSA_4096_SIG_SIZE, SPDM_MAX_ASYM_SIG_SIZE,
 };
 
 pub static SECRET_ASYM_IMPL_INSTANCE: SpdmSecretAsymSign =
@@ -20,6 +35,12 @@ pub static SECRET_PQC_ASYM_IMPL_INSTANCE: SpdmSecretPqcAsymSign = SpdmSecretPqcA
     sign_cb: pqc_asym_sign,
 };
 
+// Classical secret-signing for the emulator. Two implementations are provided:
+// a ring-based one (used by spdm-ring / spdm-mbedtls builds) and an aws-lc-based
+// one (used by a standalone spdm-aws-lc build that links no ring, i.e. spdm-aws-lc
+// without spdm-ring or spdm-mbedtls). Exactly one `asym_sign` is compiled, so
+// SECRET_ASYM_IMPL_INSTANCE resolves correctly.
+#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
 fn asym_sign(
     _spdm_context: &SpdmContext,
     base_hash_algo: SpdmBaseHashAlgo,
@@ -93,6 +114,7 @@ fn asym_sign(
     }
 }
 
+#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
 fn sign_ecdsa_asym_algo(
     algorithm: &'static ring::signature::EcdsaSigningAlgorithm,
     data: &[u8],
@@ -137,6 +159,7 @@ fn sign_ecdsa_asym_algo(
     })
 }
 
+#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
 fn sign_rsa_asym_algo(
     padding_alg: &'static dyn ring::signature::RsaEncoding,
     key_len: usize,
@@ -189,6 +212,188 @@ fn sign_rsa_asym_algo(
         data_size: key_len as u16,
         data: full_sign,
     })
+}
+
+// aws-lc-rs classical secret-signing, for a standalone aws-lc build with no ring.
+// Mirrors the ring implementation above; aws-lc-rs exposes a ring-compatible
+// signing API (EcdsaKeyPair::from_pkcs8, RsaKeyPair::from_der, .sign()).
+#[cfg(all(
+    feature = "spdm-aws-lc",
+    not(feature = "spdm-ring"),
+    not(feature = "spdm-mbedtls")
+))]
+fn asym_sign(
+    _spdm_context: &SpdmContext,
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    use aws_lc_rs::signature;
+    match (base_hash_algo, base_asym_algo) {
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256) => {
+            sign_ecdsa_asym_algo_aws_lc(&signature::ECDSA_P256_SHA256_FIXED_SIGNING, data)
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384) => {
+            sign_ecdsa_asym_algo_aws_lc(&signature::ECDSA_P384_SHA384_FIXED_SIGNING, data)
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PKCS1_SHA256,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PSS_SHA256,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PKCS1_SHA384,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PSS_SHA384,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PKCS1_SHA512,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+            sign_rsa_asym_algo_aws_lc(
+                &signature::RSA_PSS_SHA512,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        _ => panic!(),
+    }
+}
+
+#[cfg(all(
+    feature = "spdm-aws-lc",
+    not(feature = "spdm-ring"),
+    not(feature = "spdm-mbedtls")
+))]
+fn sign_ecdsa_asym_algo_aws_lc(
+    algorithm: &'static aws_lc_rs::signature::EcdsaSigningAlgorithm,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    use aws_lc_rs::signature;
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
+        PathBuf::from(env_key_path)
+    } else {
+        let crate_dir = get_test_key_directory();
+        if algorithm == &signature::ECDSA_P256_SHA256_FIXED_SIGNING {
+            crate_dir.join("test_key/ecp256/end_responder.key.p8")
+        } else if algorithm == &signature::ECDSA_P384_SHA384_FIXED_SIGNING {
+            crate_dir.join("test_key/ecp384/end_responder.key.p8")
+        } else {
+            panic!("not support")
+        }
+    };
+    let der_file = std::fs::read(&key_file_path)
+        .unwrap_or_else(|e| panic!("unable to read key from {:?}: {}", key_file_path, e));
+    let key_pair = signature::EcdsaKeyPair::from_pkcs8(algorithm, der_file.as_slice()).ok()?;
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let signature = key_pair.sign(&rng, data).ok()?;
+    let signature = signature.as_ref();
+
+    let mut full_signature: [u8; SPDM_MAX_ASYM_SIG_SIZE] = [0u8; SPDM_MAX_ASYM_SIG_SIZE];
+    full_signature[..signature.len()].copy_from_slice(signature);
+    Some(SpdmSignatureStruct {
+        data_size: signature.len() as u16,
+        data: full_signature,
+    })
+}
+
+#[cfg(all(
+    feature = "spdm-aws-lc",
+    not(feature = "spdm-ring"),
+    not(feature = "spdm-mbedtls")
+))]
+fn sign_rsa_asym_algo_aws_lc(
+    padding_alg: &'static dyn aws_lc_rs::signature::RsaEncoding,
+    key_len: usize,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    use aws_lc_rs::signature;
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
+        PathBuf::from(env_key_path)
+    } else {
+        let crate_dir = get_test_key_directory();
+        #[allow(unreachable_patterns)]
+        match key_len {
+            RSASSA_2048_SIG_SIZE | RSAPSS_2048_SIG_SIZE => {
+                crate_dir.join("test_key/rsa2048/end_responder.key.der")
+            }
+            RSASSA_3072_SIG_SIZE | RSAPSS_3072_SIG_SIZE => {
+                crate_dir.join("test_key/rsa3072/end_responder.key.der")
+            }
+            RSASSA_4096_SIG_SIZE | RSAPSS_4096_SIG_SIZE => {
+                crate_dir.join("test_key/rsa3072/end_responder.key.der")
+            }
+            _ => panic!("RSA key len not supported"),
+        }
+    };
+    let der_file = std::fs::read(&key_file_path)
+        .unwrap_or_else(|e| panic!("unable to read key from {:?}: {}", key_file_path, e));
+    let key_pair = signature::RsaKeyPair::from_der(der_file.as_slice()).ok()?;
+    if key_len != key_pair.public_modulus_len() {
+        panic!();
+    }
+    let rng = aws_lc_rs::rand::SystemRandom::new();
+    let mut full_sign = [0u8; SPDM_MAX_ASYM_SIG_SIZE];
+    key_pair
+        .sign(padding_alg, &rng, data, &mut full_sign[0..key_len])
+        .ok()?;
+    Some(SpdmSignatureStruct {
+        data_size: key_len as u16,
+        data: full_sign,
+    })
+}
+
+// Fallback used only when the emulator library is compiled with no crypto
+// backend feature at all (e.g. `cargo test --features spdmlib/spdm-ring`, which
+// enables spdmlib's backend but not spdm-emu's own spdm-ring/spdm-mbedtls/
+// spdm-aws-lc). SECRET_ASYM_IMPL_INSTANCE is unconditional, so `asym_sign` must
+// always resolve; the emu binaries always select a real backend feature.
+#[cfg(not(any(
+    feature = "spdm-ring",
+    feature = "spdm-mbedtls",
+    feature = "spdm-aws-lc"
+)))]
+fn asym_sign(
+    _spdm_context: &SpdmContext,
+    _base_hash_algo: SpdmBaseHashAlgo,
+    _base_asym_algo: SpdmBaseAsymAlgo,
+    _data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    unimplemented!("classical signing requires spdm-ring, spdm-mbedtls, or spdm-aws-lc")
 }
 
 fn pqc_asym_sign(
@@ -250,6 +455,11 @@ fn pqc_asym_sign(
     }
 }
 
+#[cfg(any(
+    feature = "spdm-ring",
+    feature = "spdm-mbedtls",
+    feature = "spdm-aws-lc"
+))]
 fn get_test_key_directory() -> PathBuf {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let crate_dir = crate_dir
@@ -262,6 +472,11 @@ fn get_test_key_directory() -> PathBuf {
 
 /// Register PQC crypto callbacks (KEM and ML-DSA verification) using aws-lc-rs.
 /// Must be called before any PQC operations.
+///
+/// This is the PQC **overlay** registration: it adds ML-KEM, ML-DSA message
+/// verification, and the ML-DSA certificate-chain hook on top of a classical
+/// backend (ring or mbedtls) that has already been registered for the
+/// traditional primitives.
 #[cfg(feature = "spdm-aws-lc")]
 pub fn register_pqc_crypto_callbacks() {
     spdmlib::crypto::pqc_asym_verify::register(
@@ -273,4 +488,40 @@ pub fn register_pqc_crypto_callbacks() {
     // PQC certificate chain mode (DSP0274 1.4) can be used, not just raw
     // public key mode.
     spdmlib_crypto_aws_lc::pqc_cert_verify_impl::register();
+}
+
+/// Register aws-lc-rs as the **standalone** crypto backend for BOTH traditional
+/// and post-quantum algorithms — no ring, no mbedtls.
+///
+/// This installs the full aws-lc primitive set (hash, HMAC, AEAD, ECDHE,
+/// RSA/ECDSA verify, HKDF, rand, certificate-chain verification) plus ML-KEM
+/// and ML-DSA. Because the aws-lc certificate backend (`AwsLcBackend`) verifies
+/// ML-DSA itself, the runtime PQC verifier hook is intentionally NOT registered
+/// here — ML-DSA certificate signatures go through the normal cert_operation
+/// path. aws-lc-rs is std-only, so this cannot be used for no_std targets.
+#[cfg(feature = "spdm-aws-lc")]
+pub fn register_aws_lc_crypto_callbacks() {
+    // Traditional primitives.
+    spdmlib::crypto::hash::register(spdmlib_crypto_aws_lc::hash_impl::DEFAULT.clone());
+    spdmlib::crypto::hmac::register(spdmlib_crypto_aws_lc::hmac_impl::DEFAULT.clone());
+    spdmlib::crypto::aead::register(spdmlib_crypto_aws_lc::aead_impl::DEFAULT.clone());
+    spdmlib::crypto::asym_verify::register(
+        spdmlib_crypto_aws_lc::asym_verify_impl::DEFAULT.clone(),
+    );
+    spdmlib::crypto::dhe::register(spdmlib_crypto_aws_lc::dhe_impl::DEFAULT.clone());
+    spdmlib::crypto::hkdf::register(spdmlib_crypto_aws_lc::hkdf_impl::DEFAULT.clone());
+    spdmlib::crypto::rand::register(spdmlib_crypto_aws_lc::rand_impl::DEFAULT.clone());
+    spdmlib::crypto::cert_operation::register(
+        spdmlib_crypto_aws_lc::cert_operation_impl::DEFAULT.clone(),
+    );
+    // Post-quantum primitives (message signatures + KEM). No PQC cert-chain
+    // verifier hook is registered: AwsLcBackend (cert_operation, above) verifies
+    // ML-DSA certificate signatures directly, and is_root_certificate() no longer
+    // performs a separate backend-hardcoded self-signature check. The standalone
+    // aws-lc path is therefore fully hook-free for ML-DSA certificate chains.
+    spdmlib::crypto::pqc_asym_verify::register(
+        spdmlib_crypto_aws_lc::pqc_asym_verify_impl::DEFAULT.clone(),
+    );
+    spdmlib::crypto::kem_decap::register(spdmlib_crypto_aws_lc::kem_impl::DEFAULT_DECAP.clone());
+    spdmlib::crypto::kem_encap::register(spdmlib_crypto_aws_lc::kem_impl::DEFAULT_ENCAP.clone());
 }

--- a/test/spdm-requester-emu/src/main.rs
+++ b/test/spdm-requester-emu/src/main.rs
@@ -1683,10 +1683,24 @@ fn emu_main_inner() {
 
     spdmlib::secret::psk::register(SECRET_PSK_IMPL_INSTANCE.clone());
 
+    // Crypto backend registration is decided entirely at compile time:
+    // - aws-lc present, no classical backend  -> aws-lc standalone (classical + PQC)
+    // - aws-lc present + a classical backend   -> classical backend, aws-lc PQC overlay
+    // - classical backend only                 -> classical backend (ring registers itself)
+    #[cfg(all(
+        feature = "spdm-aws-lc",
+        not(feature = "spdm-ring"),
+        not(feature = "spdm-mbedtls")
+    ))]
+    spdm_emu::crypto_callback::register_aws_lc_crypto_callbacks();
+
     #[cfg(feature = "spdm-mbedtls")]
     spdm_emu::crypto::crypto_mbedtls_register_handles();
 
-    #[cfg(feature = "spdm-aws-lc")]
+    #[cfg(all(
+        feature = "spdm-aws-lc",
+        any(feature = "spdm-ring", feature = "spdm-mbedtls")
+    ))]
     spdm_emu::crypto_callback::register_pqc_crypto_callbacks();
 
     let since_the_epoch = std::time::SystemTime::now()

--- a/test/spdm-responder-emu/src/main.rs
+++ b/test/spdm-responder-emu/src/main.rs
@@ -137,13 +137,27 @@ fn emu_main() {
 fn emu_main_inner() {
     new_logger_from_env().init().unwrap();
 
+    // Crypto backend registration is decided entirely at compile time:
+    // - aws-lc present, no classical backend  -> aws-lc standalone (classical + PQC)
+    // - aws-lc present + a classical backend   -> classical backend, aws-lc PQC overlay
+    // - classical backend only                 -> classical backend (ring registers itself)
+    #[cfg(all(
+        feature = "spdm-aws-lc",
+        not(feature = "spdm-ring"),
+        not(feature = "spdm-mbedtls")
+    ))]
+    spdm_emu::crypto_callback::register_aws_lc_crypto_callbacks();
+
     #[cfg(feature = "spdm-mbedtls")]
     spdm_emu::crypto::crypto_mbedtls_register_handles();
 
     spdmlib::secret::measurement::register(SECRET_MEASUREMENT_IMPL_INSTANCE.clone());
     spdmlib::secret::psk::register(SECRET_PSK_IMPL_INSTANCE.clone());
 
-    #[cfg(feature = "spdm-aws-lc")]
+    #[cfg(all(
+        feature = "spdm-aws-lc",
+        any(feature = "spdm-ring", feature = "spdm-mbedtls")
+    ))]
     spdm_emu::crypto_callback::register_pqc_crypto_callbacks();
 
     let tdisp_rsp_context = DeviceContext {


### PR DESCRIPTION
Add spdmlib_crypto_aws_lc so aws-lc-rs supplies both classical and PQC primitives standalone (no ring/mbedtls, std-only); with a classical backend it stays a PQC overlay. Backend and emulator selection is compile-time from the crypto features.


Assisted-by: Claude Code:claude-opus-4-8