### PR TITLE
fix(mbedtls): stop linking ring in the spdm-mbedtls backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,6 +1174,7 @@ dependencies = [
  "rs-libc",
  "serde",
  "serde_derive",
+ "yasna",
 ]
 
 [[package]]
@@ -1295,10 +1302,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1787,6 +1814,7 @@ dependencies = [
  "futures",
  "log",
  "maybe-async",
+ "mbedtls",
  "mctp_transport",
  "pcidoe_transport",
  "ring",
@@ -1853,6 +1881,7 @@ dependencies = [
  "der",
  "hex",
  "log",
+ "mbedtls",
  "pem-rfc7468",
  "ring",
  "serde",
@@ -2597,6 +2626,16 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "yasna"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
+dependencies = [
+ "bit-vec",
+ "num-bigint",
+]
 
 [[package]]
 name = "zerocopy"

--- a/spdmlib/src/crypto/spdm_x509/Cargo.toml
+++ b/spdmlib/src/crypto/spdm_x509/Cargo.toml
@@ -18,6 +18,7 @@ const-oid = { version = "0.9", default-features = false }
 # Cryptographic backends (optional)
 ring = { version = "0.17", optional = true, default-features = false, features = ["alloc"] }
 untrusted = { version = "0.9", optional = true }
+mbedtls = { version = "0.9.1", optional = true, default-features = false, features = ["no_std_deps", "rdrand"] }
 
 # PEM encoding support
 pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
@@ -40,7 +41,7 @@ serde_json = "1.0"
 [features]
 default = ["ring-backend"]
 ring-backend = ["ring", "untrusted"]
-mbedtls-backend = []
+mbedtls-backend = ["mbedtls"]
 std = ["der/std", "ring?/std", "log/std", "conquer-once/std"]
 alloc = ["der/alloc"]
 

--- a/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mbedtls.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mbedtls.rs
@@ -4,19 +4,185 @@
 
 //! mbedtls backend for signature verification.
 //!
-//! This module provides an mbedtls-based implementation of the crypto backend.
+//! This module provides an mbedtls-based implementation of the
+//! [`CryptoBackend`] trait, so `spdm_x509` can validate certificate chains
+//! without linking `ring`.
+//!
+//! `Validator::verify_signature` hands this backend the *raw* subjectPublicKey
+//! BIT STRING content of the issuer (an EC point for ECDSA, a PKCS#1
+//! `RSAPublicKey` for RSA), whereas mbedtls' `Pk::from_public_key` parses a
+//! full DER-encoded `SubjectPublicKeyInfo`.  We therefore wrap the raw key back
+//! into a `SubjectPublicKeyInfo` (using the algorithm implied by the negotiated
+//! [`SignatureAlgorithm`]) before handing it to mbedtls.
 
-use super::SignatureAlgorithm;
-use crate::error::Result;
+extern crate alloc;
 
-/// Verify a signature using mbedtls backend (stub).
-pub fn verify_signature(
-    _algorithm: SignatureAlgorithm,
-    _public_key: &[u8],
-    _message: &[u8],
-    _signature: &[u8],
-) -> Result<()> {
-    Err(crate::error::Error::unsupported_algorithm(
-        "mbedtls backend not yet implemented",
-    ))
+use super::{CryptoBackend, SignatureAlgorithm};
+use crate::error::{Error, Result};
+
+use alloc::vec::Vec;
+use const_oid::ObjectIdentifier;
+use der::asn1::BitString;
+use der::{Any, Encode};
+use mbedtls::hash::Type as MdType;
+use mbedtls::pk::{Options, Pk, RsaPadding};
+use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
+
+// Public-key algorithm OIDs (RFC 5480 / RFC 8017).
+const RSA_ENCRYPTION: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.1");
+const EC_PUBLIC_KEY: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
+// Named-curve OIDs, used as the AlgorithmIdentifier parameters for EC keys.
+const SECP256R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
+const SECP384R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.132.0.34");
+
+/// mbedtls-based cryptographic backend.
+pub struct MbedtlsBackend;
+
+impl CryptoBackend for MbedtlsBackend {
+    fn verify_signature(
+        &self,
+        algorithm: SignatureAlgorithm,
+        tbs_data: &[u8],
+        signature: &[u8],
+        public_key: &[u8],
+    ) -> Result<()> {
+        log::trace!("Verifying signature with algorithm {:?}", algorithm);
+
+        // ML-DSA (FIPS 204) is not supported by mbedtls.  These are dispatched
+        // to the registered PQC verifier hook by `Validator::verify_signature`
+        // and never reach this backend; reject defensively if they do.
+        if super::is_pqc(algorithm) {
+            return Err(Error::unsupported_algorithm(
+                "ML-DSA is not supported by the mbedtls backend",
+            ));
+        }
+
+        let md = md_type(algorithm)?;
+
+        // Rebuild a SubjectPublicKeyInfo DER around the raw public key so
+        // mbedtls can parse it.
+        let spki_der = build_spki_der(algorithm, public_key)?;
+        let mut pk = Pk::from_public_key(&spki_der).map_err(|_| {
+            Error::unsupported_algorithm("mbedtls could not parse the issuer public key")
+        })?;
+
+        // RSA-PSS must be verified with PSS padding (mbedtls defaults an RSA key
+        // to PKCS#1 v1.5).  The MGF-1 hash matches the message-digest hash for
+        // all PSS variants SPDM uses.
+        if is_rsa_pss(algorithm) {
+            pk.set_options(Options::Rsa {
+                padding: RsaPadding::Pkcs1V21 { mgf: md },
+            });
+        }
+
+        // mbedtls' pk_verify takes the message digest, not the message.
+        let digest = digest(md, tbs_data)?;
+
+        pk.verify(md, &digest, signature).map_err(|_| {
+            log::error!("Signature verification failed");
+            Error::SignatureError(crate::error::SignatureError::VerificationFailed)
+        })?;
+
+        log::trace!("Signature verification successful");
+        Ok(())
+    }
+}
+
+/// Map a [`SignatureAlgorithm`] to the mbedtls message-digest type.
+fn md_type(algorithm: SignatureAlgorithm) -> Result<MdType> {
+    match algorithm {
+        SignatureAlgorithm::EcdsaP256Sha256
+        | SignatureAlgorithm::EcdsaP384Sha256
+        | SignatureAlgorithm::RsaPkcs1Sha256
+        | SignatureAlgorithm::RsaPssSha256 => Ok(MdType::Sha256),
+        SignatureAlgorithm::EcdsaP256Sha384
+        | SignatureAlgorithm::EcdsaP384Sha384
+        | SignatureAlgorithm::RsaPkcs1Sha384
+        | SignatureAlgorithm::RsaPssSha384 => Ok(MdType::Sha384),
+        SignatureAlgorithm::RsaPkcs1Sha512 | SignatureAlgorithm::RsaPssSha512 => Ok(MdType::Sha512),
+        SignatureAlgorithm::Ed25519 => Err(Error::unsupported_algorithm(
+            "Ed25519 is not supported by the mbedtls backend",
+        )),
+        SignatureAlgorithm::MlDsa44 | SignatureAlgorithm::MlDsa65 | SignatureAlgorithm::MlDsa87 => {
+            Err(Error::unsupported_algorithm(
+                "ML-DSA is not supported by the mbedtls backend",
+            ))
+        }
+    }
+}
+
+/// Whether the algorithm is one of the RSA-PSS variants.
+fn is_rsa_pss(algorithm: SignatureAlgorithm) -> bool {
+    matches!(
+        algorithm,
+        SignatureAlgorithm::RsaPssSha256
+            | SignatureAlgorithm::RsaPssSha384
+            | SignatureAlgorithm::RsaPssSha512
+    )
+}
+
+/// Compute a one-shot digest of `data` with the given mbedtls hash type.
+fn digest(md: MdType, data: &[u8]) -> Result<Vec<u8>> {
+    // SHA-512 output (64 bytes) is the largest we use.
+    let mut out = [0u8; 64];
+    let len = mbedtls::hash::Md::hash(md, data, &mut out)
+        .map_err(|_| Error::unsupported_algorithm("mbedtls digest failed"))?;
+    Ok(out[..len].to_vec())
+}
+
+/// Wrap a raw subjectPublicKey BIT STRING back into a DER `SubjectPublicKeyInfo`
+/// so mbedtls' `Pk::from_public_key` can parse it.
+fn build_spki_der(algorithm: SignatureAlgorithm, raw_public_key: &[u8]) -> Result<Vec<u8>> {
+    let (oid, parameters) =
+        match algorithm {
+            // RSA keys carry ASN.1 NULL parameters.
+            SignatureAlgorithm::RsaPkcs1Sha256
+            | SignatureAlgorithm::RsaPkcs1Sha384
+            | SignatureAlgorithm::RsaPkcs1Sha512
+            | SignatureAlgorithm::RsaPssSha256
+            | SignatureAlgorithm::RsaPssSha384
+            | SignatureAlgorithm::RsaPssSha512 => (RSA_ENCRYPTION, Some(Any::null())),
+            // ECDSA keys carry the named-curve OID as parameters.
+            SignatureAlgorithm::EcdsaP256Sha256 | SignatureAlgorithm::EcdsaP256Sha384 => (
+                EC_PUBLIC_KEY,
+                Some(Any::encode_from(&SECP256R1).map_err(|_| {
+                    Error::unsupported_algorithm("failed to encode P-256 curve OID")
+                })?),
+            ),
+            SignatureAlgorithm::EcdsaP384Sha256 | SignatureAlgorithm::EcdsaP384Sha384 => (
+                EC_PUBLIC_KEY,
+                Some(Any::encode_from(&SECP384R1).map_err(|_| {
+                    Error::unsupported_algorithm("failed to encode P-384 curve OID")
+                })?),
+            ),
+            SignatureAlgorithm::Ed25519
+            | SignatureAlgorithm::MlDsa44
+            | SignatureAlgorithm::MlDsa65
+            | SignatureAlgorithm::MlDsa87 => {
+                return Err(Error::unsupported_algorithm(
+                    "unsupported public-key algorithm for the mbedtls backend",
+                ));
+            }
+        };
+
+    let subject_public_key = BitString::from_bytes(raw_public_key)
+        .map_err(|_| Error::unsupported_algorithm("invalid subjectPublicKey BIT STRING"))?;
+
+    let spki = SubjectPublicKeyInfo {
+        algorithm: AlgorithmIdentifier { oid, parameters },
+        subject_public_key,
+    };
+
+    spki.to_der()
+        .map_err(|_| Error::unsupported_algorithm("failed to encode SubjectPublicKeyInfo"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mbedtls_backend_creation() {
+        let _backend = MbedtlsBackend;
+    }
 }

--- a/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/crypto_backend/mod.rs
@@ -22,6 +22,27 @@ mod mbedtls;
 #[cfg(feature = "mbedtls-backend")]
 pub use self::mbedtls::*;
 
+// The default crypto backend used by the convenience entry points
+// (`verify_cert_chain`, `Validator::new`, etc.).  `ring` and `mbedtls` are
+// mutually exclusive in practice, but Cargo features are additive; if both are
+// enabled the ring backend wins so behavior stays deterministic.
+#[cfg(feature = "ring-backend")]
+pub type DefaultBackend = RingBackend;
+#[cfg(all(feature = "mbedtls-backend", not(feature = "ring-backend")))]
+pub type DefaultBackend = MbedtlsBackend;
+
+/// Construct the default crypto backend (see [`DefaultBackend`]).
+#[cfg(feature = "ring-backend")]
+pub fn default_backend() -> DefaultBackend {
+    RingBackend
+}
+
+/// Construct the default crypto backend (see [`DefaultBackend`]).
+#[cfg(all(feature = "mbedtls-backend", not(feature = "ring-backend")))]
+pub fn default_backend() -> DefaultBackend {
+    MbedtlsBackend
+}
+
 /// Signature algorithm identifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SignatureAlgorithm {

--- a/spdmlib/src/crypto/spdm_x509/src/x509/chain.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/chain.rs
@@ -367,10 +367,10 @@ fn der_sequence_total_length(data: &[u8]) -> Result<usize> {
 /// - `Ok(())` if validation succeeds
 /// - `Err(Error)` if validation fails
 ///
-/// Validate an SPDM certificate chain using the default Ring backend.
+/// Validate an SPDM certificate chain using the default crypto backend.
 ///
 /// Convenience wrapper around [`validate_spdm_cert_chain_with_backend`].
-#[cfg(feature = "ring-backend")]
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
 pub fn validate_spdm_cert_chain(
     header: &SpdmCertChainHeader,
     certificates: &[Certificate],
@@ -382,19 +382,21 @@ pub fn validate_spdm_cert_chain(
         certificates,
         base_hash_algo,
         options,
-        crate::crypto_backend::RingBackend,
+        crate::crypto_backend::default_backend(),
     )
 }
 
 /// Fallback when no crypto backend is compiled in.
-#[cfg(not(feature = "ring-backend"))]
+#[cfg(not(any(feature = "ring-backend", feature = "mbedtls-backend")))]
 pub fn validate_spdm_cert_chain(
     _header: &SpdmCertChainHeader,
     _certificates: &[Certificate],
     _base_hash_algo: u32,
     _options: &ValidationOptions,
 ) -> Result<()> {
-    unimplemented!("validate_spdm_cert_chain requires a crypto backend feature (e.g. ring-backend)")
+    unimplemented!(
+        "validate_spdm_cert_chain requires a crypto backend feature (ring-backend or mbedtls-backend)"
+    )
 }
 
 /// Validate an SPDM certificate chain with SPDM-specific rules using the
@@ -500,7 +502,35 @@ fn compute_hash(data: &[u8], algo: SpdmBaseHashAlgo) -> Result<Vec<u8>> {
         Ok(hash.as_ref().to_vec())
     }
 
-    #[cfg(not(feature = "ring-backend"))]
+    #[cfg(all(feature = "mbedtls-backend", not(feature = "ring-backend")))]
+    {
+        use mbedtls::hash::{Md, Type};
+
+        let md_type = match algo {
+            SpdmBaseHashAlgo::Sha256 => Type::Sha256,
+            SpdmBaseHashAlgo::Sha384 => Type::Sha384,
+            SpdmBaseHashAlgo::Sha512 => Type::Sha512,
+            _ => {
+                return Err(Error::AlgorithmError(
+                    crate::error::AlgorithmError::Unsupported(alloc::format!(
+                        "Hash algorithm not supported by mbedtls backend: {:?}",
+                        algo
+                    )),
+                ));
+            }
+        };
+
+        // SHA-512 output (64 bytes) is the largest we compute.
+        let mut out = [0u8; 64];
+        let len = Md::hash(md_type, data, &mut out).map_err(|_| {
+            Error::AlgorithmError(crate::error::AlgorithmError::Unsupported(
+                alloc::string::String::from("mbedtls hash computation failed"),
+            ))
+        })?;
+        Ok(out[..len].to_vec())
+    }
+
+    #[cfg(not(any(feature = "ring-backend", feature = "mbedtls-backend")))]
     {
         let _ = data;
         let _ = algo;
@@ -984,24 +1014,31 @@ pub fn get_cert_from_cert_chain(cert_chain: &[u8], index: isize) -> Result<(usiz
 /// let cert_chain: &[u8] = &[];
 /// let _ = verify_cert_chain(cert_chain);
 /// ```
-/// Convenience wrapper using the default Ring backend.
+/// Convenience wrapper using the default crypto backend.
 ///
 /// See [`verify_cert_chain_with_backend`] for the generic version.
-#[cfg(feature = "ring-backend")]
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
 pub fn verify_cert_chain(cert_chain: &[u8]) -> Result<()> {
-    verify_cert_chain_with_backend(cert_chain, crate::crypto_backend::RingBackend, None, None)
+    verify_cert_chain_with_backend(
+        cert_chain,
+        crate::crypto_backend::default_backend(),
+        None,
+        None,
+    )
 }
 
 /// Fallback when no crypto backend is compiled in.
-#[cfg(not(feature = "ring-backend"))]
+#[cfg(not(any(feature = "ring-backend", feature = "mbedtls-backend")))]
 pub fn verify_cert_chain(_cert_chain: &[u8]) -> Result<()> {
-    unimplemented!("verify_cert_chain requires a crypto backend feature (e.g. ring-backend)")
+    unimplemented!(
+        "verify_cert_chain requires a crypto backend feature (ring-backend or mbedtls-backend)"
+    )
 }
 
-/// Convenience wrapper using the default Ring backend with algorithm options.
+/// Convenience wrapper using the default crypto backend with algorithm options.
 ///
 /// See [`verify_cert_chain_with_backend`] for the generic version.
-#[cfg(feature = "ring-backend")]
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
 pub fn verify_cert_chain_with_options(
     cert_chain: &[u8],
     base_asym_algo: Option<u32>,
@@ -1009,21 +1046,21 @@ pub fn verify_cert_chain_with_options(
 ) -> Result<()> {
     verify_cert_chain_with_backend(
         cert_chain,
-        crate::crypto_backend::RingBackend,
+        crate::crypto_backend::default_backend(),
         base_asym_algo,
         base_hash_algo,
     )
 }
 
 /// Fallback when no crypto backend is compiled in.
-#[cfg(not(feature = "ring-backend"))]
+#[cfg(not(any(feature = "ring-backend", feature = "mbedtls-backend")))]
 pub fn verify_cert_chain_with_options(
     _cert_chain: &[u8],
     _base_asym_algo: Option<u32>,
     _base_hash_algo: Option<u32>,
 ) -> Result<()> {
     unimplemented!(
-        "verify_cert_chain_with_options requires a crypto backend feature (e.g. ring-backend)"
+        "verify_cert_chain_with_options requires a crypto backend feature (ring-backend or mbedtls-backend)"
     )
 }
 

--- a/spdmlib/src/crypto/spdm_x509/src/x509/signature.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/signature.rs
@@ -997,7 +997,7 @@ pub fn verify_signature_with_backend<B: crate::crypto_backend::CryptoBackend>(
 ///     signature
 /// );
 /// ```
-#[cfg(feature = "ring-backend")]
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
 pub fn verify_signature(
     base_hash_algo: SpdmBaseHashAlgo,
     base_asym_algo: SpdmBaseAsymAlgo,
@@ -1011,12 +1011,12 @@ pub fn verify_signature(
         public_cert_der,
         data,
         signature,
-        &crate::crypto_backend::RingBackend,
+        &crate::crypto_backend::default_backend(),
     )
 }
 
 /// Fallback when no crypto backend is compiled in.
-#[cfg(not(feature = "ring-backend"))]
+#[cfg(not(any(feature = "ring-backend", feature = "mbedtls-backend")))]
 pub fn verify_signature(
     _base_hash_algo: SpdmBaseHashAlgo,
     _base_asym_algo: SpdmBaseAsymAlgo,
@@ -1024,5 +1024,7 @@ pub fn verify_signature(
     _data: &[u8],
     _signature: &[u8],
 ) -> Result<()> {
-    unimplemented!("verify_signature requires a crypto backend feature (e.g. ring-backend)")
+    unimplemented!(
+        "verify_signature requires a crypto backend feature (ring-backend or mbedtls-backend)"
+    )
 }

--- a/spdmlib/src/crypto/spdm_x509/src/x509/spdm_validator.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/spdm_validator.rs
@@ -138,9 +138,9 @@ pub struct SpdmValidator<B: crate::crypto_backend::CryptoBackend> {
     validator: Validator<B>,
 }
 
-#[cfg(feature = "ring-backend")]
-impl SpdmValidator<crate::crypto_backend::RingBackend> {
-    /// Create a new SPDM validator using the default Ring backend.
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
+impl SpdmValidator<crate::crypto_backend::DefaultBackend> {
+    /// Create a new SPDM validator using the default crypto backend.
     pub fn new() -> Self {
         Self {
             validator: Validator::new(),
@@ -148,15 +148,15 @@ impl SpdmValidator<crate::crypto_backend::RingBackend> {
     }
 }
 
-#[cfg(feature = "ring-backend")]
-impl Default for SpdmValidator<crate::crypto_backend::RingBackend> {
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
+impl Default for SpdmValidator<crate::crypto_backend::DefaultBackend> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-// `new()` and `Default` are only available with the ring backend.
-// Without ring, callers must use `SpdmValidator::with_backend(backend)`.
+// `new()` and `Default` are only available with a default crypto backend.
+// Without one, callers must use `SpdmValidator::with_backend(backend)`.
 
 impl<B: crate::crypto_backend::CryptoBackend> SpdmValidator<B> {
     /// Create a new SPDM validator with a specific crypto backend.

--- a/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
+++ b/spdmlib/src/crypto/spdm_x509/src/x509/validator.rs
@@ -18,8 +18,8 @@ use alloc::vec::Vec;
 
 use crate::certificate::Certificate;
 use crate::chain::CertificateChain;
-#[cfg(feature = "ring-backend")]
-use crate::crypto_backend::RingBackend;
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
+use crate::crypto_backend::{default_backend, DefaultBackend};
 use crate::crypto_backend::{CryptoBackend, SignatureAlgorithm};
 use crate::error::{Error, Result};
 use crate::x509::extensions::{
@@ -99,11 +99,11 @@ pub struct Validator<B: CryptoBackend> {
     known_extensions: Vec<ObjectIdentifier>,
 }
 
-#[cfg(feature = "ring-backend")]
-impl Validator<RingBackend> {
-    /// Create a new Validator with the Ring backend
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
+impl Validator<DefaultBackend> {
+    /// Create a new Validator with the default crypto backend
     pub fn new() -> Self {
-        Self::with_backend(RingBackend)
+        Self::with_backend(default_backend())
     }
 }
 
@@ -589,8 +589,8 @@ impl<B: CryptoBackend> Validator<B> {
     }
 }
 
-#[cfg(feature = "ring-backend")]
-impl Default for Validator<RingBackend> {
+#[cfg(any(feature = "ring-backend", feature = "mbedtls-backend"))]
+impl Default for Validator<DefaultBackend> {
     fn default() -> Self {
         Self::new()
     }

--- a/spdmlib_crypto_mbedtls/Cargo.toml
+++ b/spdmlib_crypto_mbedtls/Cargo.toml
@@ -7,10 +7,11 @@ license = "Apache-2.0 or MIT"
 [dependencies]
 spdmlib = { path = "../spdmlib", default-features = false}
 # spdm_x509 provides ML-DSA (FIPS 204) aware certificate-chain validation via
-# its ring-backed validator plus the runtime PQC verifier hook. Delegate to it
-# (as the ring cert operation does) so PQC certificate chains work with the
-# mbedtls backend too. ring-backend matches how spdmlib already builds spdm_x509.
-spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["ring-backend"] }
+# its pluggable crypto backend plus the runtime PQC verifier hook. Use the
+# mbedtls backend so classical (RSA/ECC) certificate signatures are verified by
+# mbedtls and no ring is linked; post-quantum signatures still dispatch to the
+# registered PQC verifier hook, so PQC certificate chains keep working.
+spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["mbedtls-backend"] }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.9.8"
 zeroize = { version = "1.5.0", features = ["zeroize_derive"]}

--- a/spdmlib_crypto_mbedtls/src/cert_operation_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/cert_operation_impl.rs
@@ -8,13 +8,14 @@ use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_CERT};
 // =============================================================================
 // spdm_x509 implementation
 //
-// The certificate-chain operations delegate to the spdm_x509 library (the same
-// path the ring backend uses) rather than to the mbedtls C X.509 verifier. This
-// gives the mbedtls backend ML-DSA (FIPS 204) aware chain validation: spdm_x509
-// parses the chain itself and dispatches classical (RSA/ECC) signatures to its
-// ring backend and post-quantum signatures to the registered PQC verifier hook.
-// mbedtls cannot verify ML-DSA certificate signatures, so delegating here is
-// what lets PQC certificate chains work with the mbedtls backend.
+// The certificate-chain operations delegate to the spdm_x509 library rather
+// than to the mbedtls C X.509 verifier. spdm_x509 is built here with its
+// mbedtls backend, so classical (RSA/ECC) certificate signatures are verified
+// by mbedtls and no ring is linked. spdm_x509 parses the chain itself and
+// dispatches classical signatures to that mbedtls backend and post-quantum
+// (ML-DSA / FIPS 204) signatures to the registered PQC verifier hook — mbedtls
+// cannot verify ML-DSA, so delegating here is what lets PQC certificate chains
+// work with the mbedtls backend.
 // =============================================================================
 
 pub static DEFAULT: SpdmCertOperation = SpdmCertOperation {

--- a/test/spdm-emu/Cargo.toml
+++ b/test/spdm-emu/Cargo.toml
@@ -8,11 +8,13 @@ edition = "2018"
 
 [dependencies]
 log = "0.4.13"
-# ring is only used for the emulator's classical secret-signing helper; optional
-# so a standalone aws-lc build (spdm-aws-lc without spdm-ring/spdm-mbedtls)
-# links no ring.
+# ring is only used for the emulator's classical secret-signing helper in the
+# spdm-ring build; optional so mbedtls/aws-lc builds link no ring.
 ring = { version = "0.17.14", optional = true }
 untrusted = { version = "0.9.0", optional = true }
+# mbedtls provides the emulator's classical secret-signing helper for the
+# spdm-mbedtls build (no ring linked). rdrand supplies the signing RNG.
+mbedtls = { version = "0.9.1", optional = true, features = ["rdrand"] }
 codec = { path = "../../codec" }
 spdmlib = { path = "../../spdmlib", default-features = false }
 mctp_transport = { path = "../../mctp_transport" }
@@ -36,7 +38,7 @@ mut-auth = ["spdmlib/mut-auth"]
 chunk-cap = ["spdmlib/chunk-cap"]
 mandatory-mut-auth = ["mut-auth", "spdmlib/mandatory-mut-auth"]
 spdm-ring = ["spdmlib/spdm-ring", "spdmlib/std", "dep:ring", "dep:untrusted"]
-spdm-mbedtls = ["spdmlib_crypto_mbedtls", "dep:ring", "dep:untrusted"]
+spdm-mbedtls = ["spdmlib_crypto_mbedtls", "dep:mbedtls"]
 # aws-lc-rs crypto (ML-DSA, ML-KEM, and the traditional primitives). Pulls
 # spdmlib/std because aws-lc-rs is std-only. Combined with spdm-ring or
 # spdm-mbedtls it is a PQC overlay on that classical backend; on its own (no

--- a/test/spdm-emu/src/crypto_callback.rs
+++ b/test/spdm-emu/src/crypto_callback.rs
@@ -35,12 +35,13 @@ pub static SECRET_PQC_ASYM_IMPL_INSTANCE: SpdmSecretPqcAsymSign = SpdmSecretPqcA
     sign_cb: pqc_asym_sign,
 };
 
-// Classical secret-signing for the emulator. Two implementations are provided:
-// a ring-based one (used by spdm-ring / spdm-mbedtls builds) and an aws-lc-based
-// one (used by a standalone spdm-aws-lc build that links no ring, i.e. spdm-aws-lc
-// without spdm-ring or spdm-mbedtls). Exactly one `asym_sign` is compiled, so
-// SECRET_ASYM_IMPL_INSTANCE resolves correctly.
-#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
+// Classical secret-signing for the emulator. Three implementations are provided:
+// a ring-based one (spdm-ring build), an mbedtls-based one (spdm-mbedtls build
+// with no ring), and an aws-lc-based one (standalone spdm-aws-lc build that links
+// no ring, i.e. spdm-aws-lc without spdm-ring or spdm-mbedtls). The cfg gates are
+// mutually exclusive — ring wins when spdm-ring is enabled — so exactly one
+// `asym_sign` is compiled and SECRET_ASYM_IMPL_INSTANCE resolves correctly.
+#[cfg(feature = "spdm-ring")]
 fn asym_sign(
     _spdm_context: &SpdmContext,
     base_hash_algo: SpdmBaseHashAlgo,
@@ -114,7 +115,7 @@ fn asym_sign(
     }
 }
 
-#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
+#[cfg(feature = "spdm-ring")]
 fn sign_ecdsa_asym_algo(
     algorithm: &'static ring::signature::EcdsaSigningAlgorithm,
     data: &[u8],
@@ -159,7 +160,7 @@ fn sign_ecdsa_asym_algo(
     })
 }
 
-#[cfg(any(feature = "spdm-ring", feature = "spdm-mbedtls"))]
+#[cfg(feature = "spdm-ring")]
 fn sign_rsa_asym_algo(
     padding_alg: &'static dyn ring::signature::RsaEncoding,
     key_len: usize,
@@ -212,6 +213,239 @@ fn sign_rsa_asym_algo(
         data_size: key_len as u16,
         data: full_sign,
     })
+}
+
+// mbedtls classical secret-signing, for a spdm-mbedtls build that links no ring.
+// mbedtls signs a pre-computed digest (not the message) and, for ECDSA, emits a
+// DER-encoded signature, so this pre-hashes the data and converts the ECDSA DER
+// output back to the fixed r||s form SPDM expects. RSA-PSS padding is selected
+// via Pk::set_options; PKCS#1 v1.5 is mbedtls's default for an RSA key.
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn asym_sign(
+    _spdm_context: &SpdmContext,
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    match (base_hash_algo, base_asym_algo) {
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384) => {
+            sign_ecdsa_asym_algo_mbedtls(base_hash_algo, base_asym_algo, data)
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
+            sign_rsa_asym_algo_mbedtls(
+                base_hash_algo,
+                false,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
+        | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
+            sign_rsa_asym_algo_mbedtls(
+                base_hash_algo,
+                true,
+                base_asym_algo.get_sig_size() as usize,
+                data,
+            )
+        }
+        _ => panic!(),
+    }
+}
+
+// Map an SPDM base hash algorithm to the mbedtls message-digest type used to
+// pre-hash the data before signing.
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn mbedtls_md_type(base_hash_algo: SpdmBaseHashAlgo) -> mbedtls::hash::Type {
+    match base_hash_algo {
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256 => mbedtls::hash::Type::Sha256,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_384 => mbedtls::hash::Type::Sha384,
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => mbedtls::hash::Type::Sha512,
+        _ => panic!("unsupported hash algo for mbedtls signing"),
+    }
+}
+
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn mbedtls_digest(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> ([u8; 64], usize) {
+    let md = mbedtls_md_type(base_hash_algo);
+    let mut out = [0u8; 64];
+    let len = mbedtls::hash::Md::hash(md, data, &mut out).expect("mbedtls digest failed");
+    (out, len)
+}
+
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn sign_ecdsa_asym_algo_mbedtls(
+    base_hash_algo: SpdmBaseHashAlgo,
+    base_asym_algo: SpdmBaseAsymAlgo,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
+        PathBuf::from(env_key_path)
+    } else {
+        let crate_dir = get_test_key_directory();
+        match base_asym_algo {
+            SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256 => {
+                crate_dir.join("test_key/ecp256/end_responder.key.p8")
+            }
+            SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384 => {
+                crate_dir.join("test_key/ecp384/end_responder.key.p8")
+            }
+            _ => panic!("not support"),
+        }
+    };
+    let der_file = std::fs::read(&key_file_path)
+        .unwrap_or_else(|e| panic!("unable to read key from {:?}: {}", key_file_path, e));
+
+    let mut pk = mbedtls::pk::Pk::from_private_key(der_file.as_slice(), None).ok()?;
+
+    let md = mbedtls_md_type(base_hash_algo);
+    let (digest, digest_len) = mbedtls_digest(base_hash_algo, data);
+
+    // mbedtls emits a DER-encoded ECDSA signature; sign into a scratch buffer
+    // (>= ECDSA_MAX_LEN) then convert to the fixed r||s form SPDM expects.
+    let mut der_sig = [0u8; mbedtls::pk::ECDSA_MAX_LEN];
+    let mut rng = mbedtls::rng::Rdrand;
+    let der_len = pk
+        .sign(md, &digest[..digest_len], &mut der_sig, &mut rng)
+        .ok()?;
+
+    let fixed_size = base_asym_algo.get_sig_size() as usize;
+    let mut full_signature: [u8; SPDM_MAX_ASYM_SIG_SIZE] = [0u8; SPDM_MAX_ASYM_SIG_SIZE];
+    ecc_signature_der_to_bin(&der_sig[..der_len], &mut full_signature[..fixed_size])?;
+
+    Some(SpdmSignatureStruct {
+        data_size: fixed_size as u16,
+        data: full_signature,
+    })
+}
+
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn sign_rsa_asym_algo_mbedtls(
+    base_hash_algo: SpdmBaseHashAlgo,
+    is_pss: bool,
+    key_len: usize,
+    data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    let key_file_path = if let Ok(env_key_path) = std::env::var("SPDMRS_RSP_EMU_PRIVATE_KEY_PATH") {
+        PathBuf::from(env_key_path)
+    } else {
+        let crate_dir = get_test_key_directory();
+        #[allow(unreachable_patterns)]
+        match key_len {
+            RSASSA_2048_SIG_SIZE | RSAPSS_2048_SIG_SIZE => {
+                crate_dir.join("test_key/rsa2048/end_responder.key.der")
+            }
+            RSASSA_3072_SIG_SIZE | RSAPSS_3072_SIG_SIZE => {
+                crate_dir.join("test_key/rsa3072/end_responder.key.der")
+            }
+            RSASSA_4096_SIG_SIZE | RSAPSS_4096_SIG_SIZE => {
+                crate_dir.join("test_key/rsa3072/end_responder.key.der")
+            }
+            _ => panic!("RSA key len not supported"),
+        }
+    };
+    let der_file = std::fs::read(&key_file_path)
+        .unwrap_or_else(|e| panic!("unable to read key from {:?}: {}", key_file_path, e));
+
+    let mut pk = mbedtls::pk::Pk::from_private_key(der_file.as_slice(), None).ok()?;
+
+    let md = mbedtls_md_type(base_hash_algo);
+    if is_pss {
+        // RSA-PSS with MGF1 using the same hash as the message digest.
+        pk.set_options(mbedtls::pk::Options::Rsa {
+            padding: mbedtls::pk::RsaPadding::Pkcs1V21 { mgf: md },
+        });
+    }
+
+    let (digest, digest_len) = mbedtls_digest(base_hash_algo, data);
+
+    let mut full_sign = [0u8; SPDM_MAX_ASYM_SIG_SIZE];
+    let sig_len = pk
+        .sign(
+            md,
+            &digest[..digest_len],
+            &mut full_sign[..key_len],
+            &mut mbedtls::rng::Rdrand,
+        )
+        .ok()?;
+    if sig_len != key_len {
+        panic!(
+            "unexpected RSA signature length {} (want {})",
+            sig_len, key_len
+        );
+    }
+
+    Some(SpdmSignatureStruct {
+        data_size: key_len as u16,
+        data: full_sign,
+    })
+}
+
+// Convert a DER-encoded ECDSA signature (SEQUENCE { INTEGER r, INTEGER s }) into
+// the fixed-width r||s form SPDM uses. `fixed` must be sized to the algorithm's
+// signature length (2 * coordinate size); r and s are left-zero-padded into
+// their halves. This is the inverse of the bin->DER conversion in the mbedtls
+// asym_verify backend.
+#[cfg(all(feature = "spdm-mbedtls", not(feature = "spdm-ring")))]
+fn ecc_signature_der_to_bin(der: &[u8], fixed: &mut [u8]) -> Option<()> {
+    let half = fixed.len() / 2;
+    // SEQUENCE
+    if der.len() < 2 || der[0] != 0x30 {
+        return None;
+    }
+    // Sequence length (assume short form; ECDSA P-256/P-384 sigs fit under 128).
+    let seq_len = der[1] as usize;
+    let mut idx = 2usize;
+    if idx + seq_len != der.len() {
+        return None;
+    }
+
+    // Parse an INTEGER, returning its content bytes with any leading 0x00
+    // sign-padding removed.
+    fn read_int<'a>(buf: &'a [u8], idx: &mut usize) -> Option<&'a [u8]> {
+        if *idx + 2 > buf.len() || buf[*idx] != 0x02 {
+            return None;
+        }
+        let len = buf[*idx + 1] as usize;
+        *idx += 2;
+        if *idx + len > buf.len() {
+            return None;
+        }
+        let mut val = &buf[*idx..*idx + len];
+        *idx += len;
+        while val.len() > 1 && val[0] == 0x00 {
+            val = &val[1..];
+        }
+        Some(val)
+    }
+
+    let r = read_int(der, &mut idx)?;
+    let s = read_int(der, &mut idx)?;
+    if r.len() > half || s.len() > half {
+        return None;
+    }
+
+    for b in fixed.iter_mut() {
+        *b = 0;
+    }
+    fixed[half - r.len()..half].copy_from_slice(r);
+    fixed[2 * half - s.len()..2 * half].copy_from_slice(s);
+    Some(())
 }
 
 // aws-lc-rs classical secret-signing, for a standalone aws-lc build with no ring.


### PR DESCRIPTION
Implement spdm_x509's mbedtls-backend (classical RSA/ECC cert-sig verify via mbedtls) and switch spdmlib_crypto_mbedtls to it; replace the emu's ring asym_sign with an mbedtls signer. PQC cert chains still use the hook.


Assisted-by: Claude Code:claude-opus-4-8