### PR TITLE
feat(aws-lc): upgrade aws-lc-rs to v1.17.3 (aws-lc-sys 0.43.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.3"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -164,12 +164,13 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.43.0"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1441,6 +1442,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,10 @@ resolver = "2"
 # The dev profile used for `cargo build`
 [profile.dev]
 opt-level = 3
+# aws-lc-sys must be opt-level 0 when AWS_LC_SYS_NO_ASM=1 (builder guard);
+# the ML-KEM AVX2 asm otherwise fails to link (pre-existing aws-lc-sys bug).
+[profile.dev.package.aws-lc-sys]
+opt-level = 0
 # The release profile used for `cargo build --release`
 [profile.release]
 opt-level = 3

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Intel Corporation
+// Copyright (c) 2025, 2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
@@ -15,7 +15,7 @@ const MLDSA_65_SIG_SIZE: usize = 3309;
 const MLDSA_87_SIG_SIZE: usize = 4627;
 
 extern "C" {
-    #[link_name = "aws_lc_0_39_0_ml_dsa_44_sign"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_44_sign"]
     fn ml_dsa_44_sign(
         private_key: *const c_uchar,
         sig: *mut c_uchar,
@@ -26,7 +26,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
-    #[link_name = "aws_lc_0_39_0_ml_dsa_65_sign"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_65_sign"]
     fn ml_dsa_65_sign(
         private_key: *const c_uchar,
         sig: *mut c_uchar,
@@ -37,7 +37,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
-    #[link_name = "aws_lc_0_39_0_ml_dsa_87_sign"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_87_sign"]
     fn ml_dsa_87_sign(
         private_key: *const c_uchar,
         sig: *mut c_uchar,

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Intel Corporation
+// Copyright (c) 2025, 2026 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
@@ -18,7 +18,7 @@ const SPDM_SIGNING_PREFIX_LEN: usize = 64;
 const SPDM_SIGNING_CONTEXT_FIELD_LEN: usize = 36;
 
 extern "C" {
-    #[link_name = "aws_lc_0_39_0_ml_dsa_44_verify"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_44_verify"]
     fn ml_dsa_44_verify(
         public_key: *const c_uchar,
         sig: *const c_uchar,
@@ -29,7 +29,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
-    #[link_name = "aws_lc_0_39_0_ml_dsa_65_verify"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_65_verify"]
     fn ml_dsa_65_verify(
         public_key: *const c_uchar,
         sig: *const c_uchar,
@@ -40,7 +40,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
-    #[link_name = "aws_lc_0_39_0_ml_dsa_87_verify"]
+    #[link_name = "aws_lc_0_43_0_ml_dsa_87_verify"]
     fn ml_dsa_87_verify(
         public_key: *const c_uchar,
         sig: *const c_uchar,


### PR DESCRIPTION
Rebase the no_std fork patch onto v1.17.3 and update the hardcoded ML-DSA symbol prefix aws_lc_0_39_0_ -> aws_lc_0_43_0_. Pin aws-lc-sys at opt-level 0 so AWS_LC_SYS_NO_ASM builds link (pre-existing ML-KEM AVX2 bug persists). Verified: 32 aws-lc unit tests + PQC requester/ responder integration test pass.


Assisted-by: Claude Code:claude-opus-4-8