### PR TITLE
fix(spdmlib): keep responder active for empty certificate slots

### DIFF
--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -102,7 +102,7 @@ impl ResponderContext {
         if self.common.provision_info.my_cert_chain[slot_id].is_none() {
             self.write_spdm_error(SpdmErrorCode::SpdmErrorInvalidRequest, 0, writer);
             return (
-                Err(SPDM_STATUS_INVALID_STATE_LOCAL),
+                Err(SPDM_STATUS_INVALID_MSG_FIELD),
                 Some(writer.used_slice()),
             );
         }

--- a/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
@@ -19,6 +19,7 @@ use {
     alloc::sync::Arc,
     codec::{Codec, Writer},
     spdmlib::common::*,
+    spdmlib::error::SPDM_STATUS_INVALID_MSG_FIELD,
     spdmlib::message::*,
     spdmlib::protocol::*,
     spdmlib::{config, responder, secret},
@@ -92,6 +93,14 @@ fn test_case0_handle_spdm_certificate() {
             .handle_spdm_certificate(bytes, None, &mut writer)
             .0
             .is_ok());
+
+        bytes[2] = 1;
+        let mut response_buffer = [0u8; MAX_SPDM_MSG_SIZE];
+        let mut writer = Writer::init(&mut response_buffer);
+        assert_eq!(
+            context.handle_spdm_certificate(bytes, None, &mut writer).0,
+            Err(SPDM_STATUS_INVALID_MSG_FIELD)
+        );
 
         #[cfg(not(feature = "hashed-transcript-data"))]
         {


### PR DESCRIPTION
Return the invalid message field status after generating InvalidRequest for an unprovisioned certificate slot. This prevents the responder emulator from treating the request as local context corruption and closing its connection.