### PR TITLE
feat(spdmlib): add PQC and no_std AWS-LC support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ name = "aws-lc-rs"
 version = "1.17.3"
 dependencies = [
  "aws-lc-sys",
+ "spin 0.9.8",
  "untrusted 0.7.1",
  "zeroize",
 ]
@@ -1954,6 +1955,7 @@ name = "spdmlib_crypto_aws_lc"
 version = "0.1.0"
 dependencies = [
  "aws-lc-rs",
+ "aws-lc-sys",
  "bytes",
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,6 +1962,7 @@ dependencies = [
  "spdm_x509",
  "spdmlib",
  "spin 0.9.8",
+ "zeroize",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -249,13 +249,15 @@ Both `spdm-ring` and `spdm-mbedtls` crypto backends support raw public key verif
 
 SPDM 1.4 introduces Post-Quantum Cryptography (PQC) support. spdm-rs supports ML-DSA for signature and ML-KEM for key exchange via the [aws-lc-rs](https://github.com/aws/aws-lc-rs) crypto backend.
 
-**Note:** PQC support with aws-lc-rs currently only works for std build. It does not work for no-std build.
+The patched aws-lc-rs dependency supports both hosted builds and the
+`x86_64-unknown-none` freestanding target.
 
 **Prerequisites:**
 
-1. Initialize the aws-lc-rs submodule:
+1. Initialize the aws-lc-rs submodule and apply its pinned patch stack:
 ```
-git submodule update --init --recursive external/aws-lc-rs
+git submodule update --init external/aws-lc-rs
+bash external/patches/aws-lc-rs/setup-aws-lc-rs.sh
 ```
 
 2. Build with the `spdm-aws-lc` feature and `pqc_config.json` (PQC signatures and key exchanges require larger buffer sizes than the default configuration):

--- a/external/patches/aws-lc-rs/0001-feat-aws-lc-rs-add-no-std-bare-metal-support.patch
+++ b/external/patches/aws-lc-rs/0001-feat-aws-lc-rs-add-no-std-bare-metal-support.patch
@@ -1,0 +1,2586 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index a044c6d83572582605877f3ebfc1e415b427ef18..6591f3c330a19f895583481b04f06bb75740da13 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -4,6 +4,7 @@ members = [
+     "aws-lc-sys",
+     "aws-lc-fips-sys",
+     "aws-lc-rs-testing",
++    "no-std-runtime-test",
+     "links-testing",
+     "builder-test",
+ ]
+@@ -12,7 +13,9 @@ exclude = [
+     "scripts/tools/semver.rs",
+     "scripts/tools/target-platform.rs",
+     "scripts/tests/assert_cpu_jitter_entropy.rs",
+-    "scripts/tests/prefix_test.rs"
++    "scripts/tests/prefix_test.rs",
++    "feature-tests/ml-dsa-disabled",
++    "feature-tests/ml-kem-disabled",
+ ]
+ resolver = "2"
+ 
+diff --git a/aws-lc-rs/Cargo.toml b/aws-lc-rs/Cargo.toml
+index f4e55e359fce97cb3cf0e5aecada3d5139e99331..a7fea081fd6cb018e044ba69e7fd148071669ea1 100644
+--- a/aws-lc-rs/Cargo.toml
++++ b/aws-lc-rs/Cargo.toml
+@@ -30,11 +30,24 @@ features = ["unstable", "legacy-des"]
+ 
+ [features]
+ alloc = []
+-default = ["aws-lc-sys", "alloc", "ring-io", "ring-sig-verify"]
++std = ["alloc"]
++default = [
++    "aws-lc-sys",
++    "alloc",
++    "std",
++    "ring-io",
++    "ring-sig-verify",
++    "ml-kem",
++    "ml-dsa",
++]
+ ring-io = ["dep:untrusted"]
+ ring-sig-verify = ["dep:untrusted"]
+ bindgen = ["aws-lc-sys?/bindgen", "aws-lc-fips-sys?/bindgen"]
+ asan = ["aws-lc-sys?/asan", "aws-lc-fips-sys?/asan"]
++ml-kem = ["aws-lc-sys?/ml-kem"]
++ml-dsa = ["aws-lc-sys?/ml-dsa"]
++pqc = ["ml-kem", "ml-dsa"]
++small = ["aws-lc-sys?/small"]
+ test_logging = []
+ unstable = []
+ prebuilt-nasm = ["aws-lc-sys?/prebuilt-nasm"]
+@@ -45,13 +58,14 @@ legacy-des = ["aws-lc-sys?/all-bindings"]
+ non-fips = ["aws-lc-sys"]
+ 
+ # require FIPS
+-fips = ["dep:aws-lc-fips-sys"]
++fips = ["dep:aws-lc-fips-sys", "ml-kem", "std"]
+ 
+ [dependencies]
+ untrusted = { workspace = true, optional = true }
+ aws-lc-sys = { version = "0.43.0", path = "../aws-lc-sys", default-features = false, optional = true }
+ aws-lc-fips-sys = { version = "0.13.16", path = "../aws-lc-fips-sys", optional = true }
+ zeroize.workspace = true
++spin = { version = "0.9", default-features = false, features = ["once"] }
+ 
+ [dev-dependencies]
+ paste.workspace = true
+diff --git a/aws-lc-rs/README.md b/aws-lc-rs/README.md
+index c5dcc5a8fe3ba0d1dde8677bca8ffa2990ef5ce4..e8434ecf4fa4ca3b460f3cc2474289df91cf8ef5 100644
+--- a/aws-lc-rs/README.md
++++ b/aws-lc-rs/README.md
+@@ -37,6 +37,36 @@ See our [User Guide](https://aws.github.io/aws-lc-rs/) for guidance on installin
+ Allows implementation to allocate values of arbitrary size. (The meaning of this feature differs
+ from the "alloc" feature of *ring*.) Currently, this is required by the `io::writer` module.
+ 
++##### ml-kem and ml-dsa (default)
++
++Enable the ML-KEM and ML-DSA implementations, respectively. `pqc` is a
++convenience alias that enables both. Algorithm features are additive.
++
++Consumers that do not need both algorithms must disable default features and
++select the required algorithm explicitly:
++
++```toml
++[dependencies]
++aws-lc-rs = { version = "1", default-features = false, features = [
++    "aws-lc-sys",
++    "alloc",
++    "std",
++    "ml-kem",
++] }
++```
++
++Omitting an algorithm removes its native implementation and Rust API. ML-DSA
++is also an unstable API and requires the `unstable` feature.
++
++##### Bare-metal targets
++
++Targets with `target_os = "none"` automatically use the freestanding C runtime
++adapter provided by `aws-lc-sys`. A no-std consumer must also disable default
++features and provide the platform hooks documented in the
++[`aws-lc-sys` README](../aws-lc-sys/README.md#no-std-runtime).
++Consumers that select `alloc` must additionally install a Rust global
++allocator.
++
+ ##### ring-io (default)
+ 
+ Enable feature to access the  `io`  module.
+@@ -188,8 +218,9 @@ that the NASM objects newly built from source match the NASM objects currently i
+ Although this library attempts to be fully compatible with *ring* (v0.16.x), there are a few places where our
+ behavior is observably different.
+ 
+-* Our implementation requires the `std` library. We currently do not support a
+-  [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html) build.
++* Freestanding [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html)
++  builds are selected by `target_os = "none"` and require platform-provided
++  allocation, entropy, time, and abort hooks.
+ * `aws-lc-rs` supports the platforms supported by `aws-lc-sys` and AWS-LC. See the
+   [Platform Support](https://aws.github.io/aws-lc-rs/platform_support.html) page in our User Guide.
+ * `Ed25519KeyPair::from_pkcs8` and `Ed25519KeyPair::from_pkcs8_maybe_unchecked` both support
+diff --git a/aws-lc-rs/src/aead.rs b/aws-lc-rs/src/aead.rs
+index d401da5a82f032137e0a7d79b22934919bd03350..393926d344281d11dd488d50d983a6ba5e9f5aac 100644
+--- a/aws-lc-rs/src/aead.rs
++++ b/aws-lc-rs/src/aead.rs
+@@ -1027,7 +1027,7 @@ impl AsRef<[u8]> for Tag {
+ }
+ 
+ impl core::fmt::Debug for Tag {
+-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
++    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+         f.debug_tuple("Tag").finish()
+     }
+ }
+diff --git a/aws-lc-rs/src/agreement.rs b/aws-lc-rs/src/agreement.rs
+index c0fc9c56ac4769aa0f682fca062928851c73aa79..b7d715fc64191f0466d3b6881b894ca366fae1e3 100644
+--- a/aws-lc-rs/src/agreement.rs
++++ b/aws-lc-rs/src/agreement.rs
+@@ -60,6 +60,7 @@ use crate::ec::verify_evp_key_nid;
+ use crate::ec::{evp_key_generate, validate_ec_evp_key};
+ use crate::error::{KeyRejected, Unspecified};
+ use crate::hex;
++use alloc::boxed::Box;
+ pub use ephemeral::{agree_ephemeral, EphemeralPrivateKey};
+ 
+ use crate::aws_lc::{
+@@ -547,7 +548,7 @@ unsafe impl Send for PublicKey {}
+ unsafe impl Sync for PublicKey {}
+ 
+ impl Debug for PublicKey {
+-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
++    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+         f.write_str(&format!(
+             "PublicKey {{ algorithm: {:?}, bytes: \"{}\" }}",
+             self.inner_key.algorithm(),
+diff --git a/aws-lc-rs/src/bn.rs b/aws-lc-rs/src/bn.rs
+index dbe936a1e4ea167a540eee157350352c39d266fd..1e1691a50fc0b777254daab9d652f3d2fef2b2bc 100644
+--- a/aws-lc-rs/src/bn.rs
++++ b/aws-lc-rs/src/bn.rs
+@@ -3,6 +3,7 @@
+ 
+ use crate::aws_lc::{BN_bin2bn, BN_bn2bin, BN_new, BN_num_bytes, BN_set_u64, BIGNUM};
+ use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
++use alloc::vec::Vec;
+ use core::ptr::null_mut;
+ 
+ impl TryFrom<&[u8]> for LcPtr<BIGNUM> {
+diff --git a/aws-lc-rs/src/buffer.rs b/aws-lc-rs/src/buffer.rs
+index 3cd5055529b3ab1eb4569bd6cd64dea46b5e8bb9..a43d01e34d2f319b2faaeb10a47e834a2b2d3b1f 100644
+--- a/aws-lc-rs/src/buffer.rs
++++ b/aws-lc-rs/src/buffer.rs
+@@ -6,7 +6,7 @@
+ 
+ #![allow(clippy::module_name_repetitions)]
+ 
+-use alloc::borrow::Cow;
++use alloc::{borrow::Cow, vec::Vec};
+ use core::fmt;
+ use core::marker::PhantomData;
+ 
+diff --git a/aws-lc-rs/src/cbb.rs b/aws-lc-rs/src/cbb.rs
+index 155bcbf80ceecb0c932913816876c3b35f23fc61..c170c05696e65103601fac07be8c04d2f49efc4b 100644
+--- a/aws-lc-rs/src/cbb.rs
++++ b/aws-lc-rs/src/cbb.rs
+@@ -4,6 +4,7 @@
+ use crate::aws_lc::{CBB_cleanup, CBB_finish, CBB_init, CBB_init_fixed, CBB};
+ use crate::error::Unspecified;
+ use crate::ptr::LcPtr;
++use alloc::vec::Vec;
+ use core::marker::PhantomData;
+ use core::mem::MaybeUninit;
+ use core::ptr::null_mut;
+@@ -29,7 +30,7 @@ impl LcCBB<'static> {
+         }
+ 
+         let out_data = LcPtr::new(out_data)?;
+-        let slice = unsafe { std::slice::from_raw_parts(out_data.as_const_ptr(), out_len) };
++        let slice = unsafe { core::slice::from_raw_parts(out_data.as_const_ptr(), out_len) };
+         // `to_vec()` copies the data into a new `Vec`
+         Ok(slice.to_vec())
+     }
+diff --git a/aws-lc-rs/src/cipher/key.rs b/aws-lc-rs/src/cipher/key.rs
+index a521f97306f12df220034bfe5c03c49de5117a47..13a8d2bad8eb67701c136a5289f8a2c172851a00 100644
+--- a/aws-lc-rs/src/cipher/key.rs
++++ b/aws-lc-rs/src/cipher/key.rs
+@@ -16,7 +16,7 @@ use core::mem::{size_of, MaybeUninit};
+ use core::ptr::copy_nonoverlapping;
+ // TODO: Uncomment when MSRV >= 1.64
+ // use core::ffi::c_uint;
+-use std::os::raw::c_uint;
++use core::ffi::c_uint;
+ use zeroize::Zeroize;
+ 
+ pub(crate) enum SymmetricCipherKey {
+diff --git a/aws-lc-rs/src/cipher/streaming.rs b/aws-lc-rs/src/cipher/streaming.rs
+index 4a01e11b80633d7d42ea01498996cb263381cc1f..84fec0bab51919ea4382153cd56e8ee3eaeee269 100644
+--- a/aws-lc-rs/src/cipher/streaming.rs
++++ b/aws-lc-rs/src/cipher/streaming.rs
+@@ -12,7 +12,7 @@ use crate::cipher::{
+ use crate::error::Unspecified;
+ use crate::fips::indicator_check;
+ use crate::ptr::LcPtr;
+-use std::ptr::{null, null_mut};
++use core::ptr::{null, null_mut};
+ 
+ use super::ConstPointer;
+ 
+diff --git a/aws-lc-rs/src/ec.rs b/aws-lc-rs/src/ec.rs
+index 3a22fbbe4fae2ef93b94f306dd7c664926074d1e..bac04a1f7bac3b9027f33997730dbd34415983fc 100644
+--- a/aws-lc-rs/src/ec.rs
++++ b/aws-lc-rs/src/ec.rs
+@@ -21,7 +21,7 @@ use crate::fips::indicator_check;
+ use crate::ptr::{ConstPointer, LcPtr};
+ use crate::signature::Signature;
+ use core::ffi::c_int;
+-use std::ptr::null;
++use core::ptr::null;
+ 
+ pub(crate) mod encoding;
+ pub(crate) mod key_pair;
+diff --git a/aws-lc-rs/src/ec/encoding.rs b/aws-lc-rs/src/ec/encoding.rs
+index 2cf40378d4a703b071d4e04904c97db2d868fb3f..737f46564bcab751a97a21f2c2593d2e7e005157 100644
+--- a/aws-lc-rs/src/ec/encoding.rs
++++ b/aws-lc-rs/src/ec/encoding.rs
+@@ -27,7 +27,8 @@ pub(crate) mod sec1 {
+     };
+     use crate::error::Unspecified;
+     use crate::ptr::{ConstPointer, DetachableLcPtr, LcPtr};
+-    use std::ptr::{null, null_mut};
++    use alloc::vec::Vec;
++    use core::ptr::{null, null_mut};
+ 
+     pub(crate) fn parse_sec1_public_point(
+         key_bytes: &[u8],
+@@ -230,6 +231,7 @@ pub(crate) mod rfc5915 {
+     use crate::ec::ec_group_from_nid;
+     use crate::error::{KeyRejected, Unspecified};
+     use crate::ptr::LcPtr;
++    use alloc::vec::Vec;
+ 
+     pub(crate) fn parse_rfc5915_private_key(
+         key_bytes: &[u8],
+diff --git a/aws-lc-rs/src/ec/signature.rs b/aws-lc-rs/src/ec/signature.rs
+index b46272ef2892564893ddc5b202f4d5228489b712..2263f748fe12314788f7eebab6302a76a61cb9fc 100644
+--- a/aws-lc-rs/src/ec/signature.rs
++++ b/aws-lc-rs/src/ec/signature.rs
+@@ -5,6 +5,7 @@ use crate::aws_lc::{
+     ECDSA_SIG_new, ECDSA_SIG_set0, ECDSA_SIG_to_bytes, NID_X9_62_prime256v1, NID_secp256k1,
+     NID_secp384r1, NID_secp521r1, BIGNUM, ECDSA_SIG, EVP_PKEY,
+ };
++use alloc::boxed::Box;
+ 
+ use crate::digest::Digest;
+ use crate::ec::compressed_public_key_size_bytes;
+@@ -20,9 +21,9 @@ use crate::signature::{ParsedPublicKey, ParsedVerificationAlgorithm, Verificatio
+ use crate::{digest, sealed};
+ use core::fmt;
+ use core::fmt::{Debug, Formatter};
+-use std::mem::MaybeUninit;
+-use std::ops::Deref;
+-use std::ptr::null_mut;
++use core::mem::MaybeUninit;
++use core::ops::Deref;
++use core::ptr::null_mut;
+ #[cfg(feature = "ring-sig-verify")]
+ use untrusted::Input;
+ 
+diff --git a/aws-lc-rs/src/ed25519.rs b/aws-lc-rs/src/ed25519.rs
+index 635237f9944caff25e6a05474eb9ed123ba56742..09c4a13d5459812cddec233494fb8bc62c363a03 100644
+--- a/aws-lc-rs/src/ed25519.rs
++++ b/aws-lc-rs/src/ed25519.rs
+@@ -3,9 +3,10 @@
+ // Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+ 
++use alloc::boxed::Box;
+ use core::fmt;
+ use core::fmt::{Debug, Formatter};
+-use std::marker::PhantomData;
++use core::marker::PhantomData;
+ 
+ #[cfg(feature = "ring-sig-verify")]
+ use untrusted::Input;
+diff --git a/aws-lc-rs/src/encoding.rs b/aws-lc-rs/src/encoding.rs
+index 84b4cbf4a45ebebdeabc963b5e68dce6eea6b0b8..e37ada84226f2023be0a9255217b82734a5bdafd 100644
+--- a/aws-lc-rs/src/encoding.rs
++++ b/aws-lc-rs/src/encoding.rs
+@@ -4,22 +4,26 @@
+ //! Serialization formats
+ 
+ use crate::buffer::Buffer;
++use alloc::vec::Vec;
+ 
+ macro_rules! generated_encodings {
+-    ($(($name:ident, $name_type:ident)),*) => {
++    ($($(#[$attr:meta])* ($name:ident, $name_type:ident)),*) => {
+         use core::fmt::{Debug, Error, Formatter};
+         use core::ops::Deref;
+         mod buffer_type {
+             $(
++                $(#[$attr])*
+                 pub struct $name_type {
+                     _priv: (),
+                 }
+             )*
+         }
+         $(
++            $(#[$attr])*
+             /// Serialized bytes
+             pub struct $name<'a>(Buffer<'a, buffer_type::$name_type>);
+ 
++            $(#[$attr])*
+             impl<'a> Deref for $name<'a> {
+                 type Target = Buffer<'a, buffer_type::$name_type>;
+ 
+@@ -28,6 +32,7 @@ macro_rules! generated_encodings {
+                 }
+             }
+ 
++            $(#[$attr])*
+             impl $name<'static> {
+                 #[allow(dead_code)]
+                 pub(crate) fn new(owned: Vec<u8>) -> Self {
+@@ -39,12 +44,14 @@ macro_rules! generated_encodings {
+                 }
+             }
+ 
++            $(#[$attr])*
+             impl Debug for $name<'_> {
+                 fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+                     f.debug_struct(stringify!($name)).finish()
+                 }
+             }
+ 
++            $(#[$attr])*
+             impl<'a> From<Buffer<'a, buffer_type::$name_type>> for $name<'a> {
+                 fn from(value: Buffer<'a, buffer_type::$name_type>) -> Self {
+                     Self(value)
+@@ -53,6 +60,7 @@ macro_rules! generated_encodings {
+         )*
+     }
+ }
++#[cfg(feature = "ml-kem")]
+ pub(crate) use generated_encodings;
+ generated_encodings!(
+     (Curve25519SeedBin, Curve25519SeedBinType),
+@@ -62,7 +70,9 @@ generated_encodings!(
+     (EcPublicKeyUncompressedBin, EcPublicKeyUncompressedBinType),
+     (Pkcs8V1Der, Pkcs8V1DerType),
+     (Pkcs8V2Der, Pkcs8V2DerType),
++    #[cfg(feature = "ml-dsa")]
+     (PqdsaPrivateKeyRaw, PqdsaPrivateKeyRawType),
++    #[cfg(feature = "ml-dsa")]
+     (PqdsaSeedRaw, PqdsaSeedRawType),
+     (PublicKeyX509Der, PublicKeyX509DerType)
+ );
+diff --git a/aws-lc-rs/src/error.rs b/aws-lc-rs/src/error.rs
+index a754ae5a35bb98362d75f5d44cfe7011babe7359..9a0a40639629d52fe708c3e2755fb57183fb9c3c 100644
+--- a/aws-lc-rs/src/error.rs
++++ b/aws-lc-rs/src/error.rs
+@@ -5,10 +5,8 @@
+ 
+ //! Error reporting.
+ 
+-extern crate std;
+-
+ use core::num::TryFromIntError;
+-// The Error trait is not in core: https://github.com/rust-lang/rust/issues/103765
++#[cfg(feature = "std")]
+ use std::error::Error;
+ 
+ /// An error with absolutely no details.
+@@ -154,6 +152,7 @@ impl KeyRejected {
+     }
+ }
+ 
++#[cfg(feature = "std")]
+ impl Error for KeyRejected {
+     fn description(&self) -> &str {
+         self.description_()
+@@ -164,6 +163,7 @@ impl Error for KeyRejected {
+     }
+ }
+ 
++#[cfg(feature = "std")]
+ impl Error for Unspecified {
+     #[allow(clippy::unnecessary_literal_bound)]
+     fn description(&self) -> &str {
+diff --git a/aws-lc-rs/src/evp_pkey.rs b/aws-lc-rs/src/evp_pkey.rs
+index f05c3427fd2bf43fdd277642ee8ace967e3fc590..2b6322eedd95b4767daf06867f59cf0c8ef5ba9f 100644
+--- a/aws-lc-rs/src/evp_pkey.rs
++++ b/aws-lc-rs/src/evp_pkey.rs
+@@ -12,7 +12,7 @@ use crate::aws_lc::{
+     EVP_parse_private_key, EVP_parse_public_key, EC_KEY, EVP_PKEY, EVP_PKEY_CTX, EVP_PKEY_ED25519,
+     RSA,
+ };
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+ use crate::aws_lc::{
+     EVP_PKEY_pqdsa_new_raw_private_key, EVP_PKEY_pqdsa_new_raw_public_key, EVP_PKEY_PQDSA,
+     NID_MLDSA44, NID_MLDSA65, NID_MLDSA87,
+@@ -25,8 +25,9 @@ use crate::fips::indicator_check;
+ use crate::pkcs8::Version;
+ use crate::ptr::{ConstPointer, LcPtr};
+ use crate::{cbs, digest};
++use alloc::{boxed::Box, vec::Vec};
+ use core::ffi::c_int;
+-use std::ptr::{null, null_mut};
++use core::ptr::{null, null_mut};
+ 
+ impl PartialEq<Self> for LcPtr<EVP_PKEY> {
+     /// Only compares params and public key
+@@ -260,7 +261,7 @@ impl LcPtr<EVP_PKEY> {
+         bytes: &[u8],
+         evp_pkey_type: c_int,
+     ) -> Result<Self, KeyRejected> {
+-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
++        #[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+         if evp_pkey_type == EVP_PKEY_PQDSA {
+             return match bytes.len() {
+                 2560 => Self::new(unsafe {
+@@ -287,7 +288,7 @@ impl LcPtr<EVP_PKEY> {
+         bytes: &[u8],
+         evp_pkey_type: c_int,
+     ) -> Result<Self, KeyRejected> {
+-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
++        #[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+         if evp_pkey_type == EVP_PKEY_PQDSA {
+             return match bytes.len() {
+                 1312 => Self::new(unsafe {
+diff --git a/aws-lc-rs/src/hex.rs b/aws-lc-rs/src/hex.rs
+index 9007240fbce15b5919d28fcbada55641c4e9d05f..c5be346b81771c822ab7193745bdbe4fb4ae1ea9 100644
+--- a/aws-lc-rs/src/hex.rs
++++ b/aws-lc-rs/src/hex.rs
+@@ -1,6 +1,11 @@
+ // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+ 
++use alloc::{
++    string::{String, ToString},
++    vec::Vec,
++};
++
+ /// Converts bytes to a lower-case hex string
+ #[allow(clippy::missing_panics_doc)]
+ pub fn encode<T: AsRef<[u8]>>(bytes: T) -> String {
+@@ -17,6 +22,7 @@ pub fn encode<T: AsRef<[u8]>>(bytes: T) -> String {
+ }
+ 
+ /// Converts bytes to an upper-case hex string
++#[allow(dead_code)]
+ pub fn encode_upper<T: AsRef<[u8]>>(bytes: T) -> String {
+     encode(bytes).to_ascii_uppercase()
+ }
+@@ -25,6 +31,7 @@ pub fn encode_upper<T: AsRef<[u8]>>(bytes: T) -> String {
+ /// # Errors
+ /// Returns an error if `hex_str` contains a non-hex digit.
+ #[allow(clippy::missing_panics_doc)]
++#[allow(dead_code)]
+ pub fn decode(hex_str: &str) -> Result<Vec<u8>, String> {
+     let mut bytes = Vec::<u8>::with_capacity(hex_str.len() / 2 + 1);
+     let mut current_byte = b'\0';
+@@ -60,6 +67,7 @@ pub fn decode(hex_str: &str) -> Result<Vec<u8>, String> {
+ /// It ignores any characters that are not valid hex digits.
+ #[must_use]
+ #[allow(clippy::missing_panics_doc)]
++#[allow(dead_code)]
+ pub fn decode_dirty(hex_str: &str) -> Vec<u8> {
+     let clean: String = hex_str.chars().filter(char::is_ascii_hexdigit).collect();
+     // DON'T PANIC: it should not be possible to panic because we filter out all non-hex digits.
+diff --git a/aws-lc-rs/src/hkdf.rs b/aws-lc-rs/src/hkdf.rs
+index b22558feebcd82a0dd77f2fe34e48154e061de26..600515063b9a575c1dc2229165dc1c84592e19c3 100644
+--- a/aws-lc-rs/src/hkdf.rs
++++ b/aws-lc-rs/src/hkdf.rs
+@@ -49,6 +49,7 @@ use crate::error::Unspecified;
+ use crate::fips::indicator_check;
+ use crate::{digest, hmac};
+ use alloc::sync::Arc;
++use alloc::{boxed::Box, vec::Vec};
+ use core::fmt;
+ use zeroize::Zeroize;
+ 
+diff --git a/aws-lc-rs/src/iv.rs b/aws-lc-rs/src/iv.rs
+index 0115e04fa7ee71a0e445b7d203cda86548fde914..56a1f39214310330538c60553f912fc9dc7cf951 100644
+--- a/aws-lc-rs/src/iv.rs
++++ b/aws-lc-rs/src/iv.rs
+@@ -8,6 +8,7 @@
+ 
+ use crate::error::Unspecified;
+ use crate::rand;
++use alloc::borrow::ToOwned;
+ use zeroize::Zeroize;
+ 
+ /// Length of a 64-bit IV in bytes (used by DES/3DES).
+diff --git a/aws-lc-rs/src/kem.rs b/aws-lc-rs/src/kem.rs
+index fe03301bf76407adf99a8f4f0834a931f87ffd2b..c3c50d87ef1b591df1e5fa16dd205b698d739503 100644
+--- a/aws-lc-rs/src/kem.rs
++++ b/aws-lc-rs/src/kem.rs
+@@ -54,6 +54,8 @@ use crate::encoding::generated_encodings;
+ use crate::error::{KeyRejected, Unspecified};
+ use crate::ptr::LcPtr;
+ use alloc::borrow::Cow;
++use alloc::boxed::Box;
++use alloc::vec::Vec;
+ use core::cmp::Ordering;
+ use zeroize::Zeroize;
+ 
+diff --git a/aws-lc-rs/src/key_wrap.rs b/aws-lc-rs/src/key_wrap.rs
+index 73aa2d6a2e09db42b3c310951b0f355df982d3ae..37bb7c6f4f6ff00541f97bf94a1bc67091a92ad0 100644
+--- a/aws-lc-rs/src/key_wrap.rs
++++ b/aws-lc-rs/src/key_wrap.rs
+@@ -39,6 +39,7 @@ use crate::aws_lc::{
+ use crate::error::Unspecified;
+ use crate::fips::indicator_check;
+ use crate::sealed::Sealed;
++use alloc::{boxed::Box, vec::Vec};
+ use core::fmt::Debug;
+ use core::mem::MaybeUninit;
+ use core::ptr::null;
+diff --git a/aws-lc-rs/src/lib.rs b/aws-lc-rs/src/lib.rs
+index c68a178a82b62cfe31f7f00f7c8f9464a24769c1..bede61a148e7a81ad254e7187d9340180a680a1d 100644
+--- a/aws-lc-rs/src/lib.rs
++++ b/aws-lc-rs/src/lib.rs
+@@ -39,6 +39,20 @@
+ //! Allows implementation to allocate values of arbitrary size. (The meaning of this feature differs
+ //! from the "alloc" feature of *ring*.) Currently, this is required by the `io::writer` module.
+ //!
++//! #### ml-kem and ml-dsa (default)
++//!
++//! Enable the ML-KEM and ML-DSA implementations, respectively. `pqc` enables
++//! both. Consumers selecting only one algorithm must disable default features.
++//! Omitting an algorithm removes its native implementation and Rust API.
++//! ML-DSA also requires the `unstable` feature.
++//!
++//! #### `target_os = "none"`
++//!
++//! Bare-metal targets automatically use the freestanding C runtime adapter.
++//! No-std consumers must disable default features and provide the platform
++//! hooks documented by `aws-lc-sys`. Consumers that select `alloc` must also
++//! install a Rust global allocator.
++//!
+ //! #### ring-io (default)
+ //!
+ //! Enable feature to access the  `io`  module.
+@@ -211,8 +225,9 @@
+ //! Although this library attempts to be fully compatible with *ring* (v0.16.x), there are a few places where our
+ //! behavior is observably different.
+ //!
+-//! * Our implementation requires the `std` library. We currently do not support a
+-//!   [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html) build.
++//! * Freestanding [`#![no_std]`](https://docs.rust-embedded.org/book/intro/no-std.html)
++//!   builds are selected by `target_os = "none"` and require platform-provided
++//!   allocation, entropy, time, and abort hooks.
+ //! * `aws-lc-rs` supports the platforms supported by `aws-lc-sys` and AWS-LC. See the
+ //!   [Platform Support](https://aws.github.io/aws-lc-rs/platform_support.html) page in our User Guide.
+ //! * `Ed25519KeyPair::from_pkcs8` and `Ed25519KeyPair::from_pkcs8_maybe_unchecked` both support
+@@ -239,7 +254,9 @@
+ #![warn(missing_docs)]
+ #![warn(clippy::exhaustive_enums)]
+ #![cfg_attr(aws_lc_rs_docsrs, feature(doc_cfg))]
++#![cfg_attr(not(feature = "std"), no_std)]
+ 
++#[macro_use]
+ extern crate alloc;
+ #[cfg(feature = "fips")]
+ extern crate aws_lc_fips_sys as aws_lc;
+@@ -261,6 +278,7 @@ pub mod pbkdf2;
+ pub mod pkcs8;
+ pub mod rand;
+ pub mod signature;
++#[cfg(feature = "std")]
+ pub mod test;
+ 
+ mod bn;
+@@ -279,26 +297,29 @@ mod hex;
+ pub mod iv;
+ pub mod kdf;
+ #[allow(clippy::module_name_repetitions)]
++#[cfg(feature = "ml-kem")]
+ pub mod kem;
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+ mod pqdsa;
+ mod ptr;
+ pub mod rsa;
+ pub mod tls_prf;
+ pub mod unstable;
+ 
++use crate::aws_lc::{CRYPTO_library_init, FIPS_mode, OpenSSL_version, OPENSSL_VERSION};
++#[cfg(feature = "std")]
++use crate::aws_lc::{ERR_error_string, ERR_get_error, ERR_GET_FUNC, ERR_GET_LIB, ERR_GET_REASON};
++use core::ffi::CStr;
+ pub(crate) use debug::derive_debug_via_id;
+-// TODO: Uncomment when MSRV >= 1.64
+-// use core::ffi::CStr;
+-use std::ffi::CStr;
+-
+-use crate::aws_lc::{
+-    CRYPTO_library_init, ERR_error_string, ERR_get_error, FIPS_mode, OpenSSL_version, ERR_GET_FUNC,
+-    ERR_GET_LIB, ERR_GET_REASON, OPENSSL_VERSION,
+-};
++#[cfg(not(feature = "std"))]
++use spin::Once;
++#[cfg(feature = "std")]
+ use std::sync::Once;
+ 
++#[cfg(feature = "std")]
+ static START: Once = Once::new();
++#[cfg(not(feature = "std"))]
++static START: Once<()> = Once::new();
+ 
+ #[inline]
+ /// Initialize the *AWS-LC* library. (This should generally not be needed.)
+@@ -394,6 +415,7 @@ pub fn try_fips_cpu_jitter_entropy() -> Result<(), &'static str> {
+ }
+ 
+ #[allow(dead_code)]
++#[cfg(feature = "std")]
+ unsafe fn dump_error() {
+     let err = ERR_get_error();
+     let lib = ERR_GET_LIB(err);
+diff --git a/aws-lc-rs/src/pkcs8.rs b/aws-lc-rs/src/pkcs8.rs
+index 36906cb5b65776329942c1c58ab4d98a6b8f8aa7..2f402201994eb2ae17845d6bf4244cf2825079db 100644
+--- a/aws-lc-rs/src/pkcs8.rs
++++ b/aws-lc-rs/src/pkcs8.rs
+@@ -7,6 +7,7 @@
+ //!
+ //! [RFC 5208]: https://tools.ietf.org/html/rfc5208.
+ 
++use alloc::vec::Vec;
+ use zeroize::Zeroize;
+ 
+ /// A generated PKCS#8 document.
+diff --git a/aws-lc-rs/src/pqdsa/key_pair.rs b/aws-lc-rs/src/pqdsa/key_pair.rs
+index 2255cd25c49b0bcdfcb2c0b15bb4a9f6d3267085..b781134418f133d29de635a830961fa5d0f64a5f 100644
+--- a/aws-lc-rs/src/pqdsa/key_pair.rs
++++ b/aws-lc-rs/src/pqdsa/key_pair.rs
+@@ -13,8 +13,8 @@ use crate::pqdsa::signature::{PqdsaSigningAlgorithm, PublicKey};
+ use crate::pqdsa::validate_pqdsa_evp_key;
+ use crate::ptr::LcPtr;
+ use crate::signature::KeyPair;
++use core::ffi::c_int;
+ use core::fmt::{Debug, Formatter};
+-use std::ffi::c_int;
+ 
+ /// A PQDSA (Post-Quantum Digital Signature Algorithm) key pair, used for signing and verification.
+ #[allow(clippy::module_name_repetitions)]
+@@ -26,7 +26,7 @@ pub struct PqdsaKeyPair {
+ 
+ #[allow(clippy::missing_fields_in_debug)]
+ impl Debug for PqdsaKeyPair {
+-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
++    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+         f.debug_struct("PqdsaKeyPair")
+             .field("algorithm", &self.algorithm)
+             .finish()
+diff --git a/aws-lc-rs/src/pqdsa/signature.rs b/aws-lc-rs/src/pqdsa/signature.rs
+index e7b1f2f4d3dc4035d7fed1bc50ef39b68fd2d3bd..d6fbb8dbeecc41b92d070782cf8639c0de60254e 100644
+--- a/aws-lc-rs/src/pqdsa/signature.rs
++++ b/aws-lc-rs/src/pqdsa/signature.rs
+@@ -11,6 +11,7 @@ use crate::pqdsa::{parse_pqdsa_public_key, AlgorithmID};
+ use crate::ptr::LcPtr;
+ use crate::signature::{ParsedPublicKey, ParsedVerificationAlgorithm, VerificationAlgorithm};
+ use crate::{digest, sealed};
++use alloc::boxed::Box;
+ use core::fmt;
+ use core::fmt::{Debug, Formatter};
+ #[cfg(feature = "ring-sig-verify")]
+diff --git a/aws-lc-rs/src/ptr.rs b/aws-lc-rs/src/ptr.rs
+index 3b0fdd1c9bbc0e1a7f18a4a0b561d187663153cf..89c828d3781d6d1dd242a660801d69c42d07b5bc 100644
+--- a/aws-lc-rs/src/ptr.rs
++++ b/aws-lc-rs/src/ptr.rs
+@@ -7,7 +7,7 @@ use crate::aws_lc::{
+     RSA_free, BIGNUM, CMAC_CTX, ECDSA_SIG, EC_GROUP, EC_KEY, EC_POINT, EVP_AEAD_CTX,
+     EVP_CIPHER_CTX, EVP_PKEY, EVP_PKEY_CTX, RSA,
+ };
+-use std::marker::PhantomData;
++use core::marker::PhantomData;
+ 
+ pub(crate) type LcPtr<T> = ManagedPointer<*mut T>;
+ pub(crate) type DetachableLcPtr<T> = DetachablePointer<*mut T>;
+diff --git a/aws-lc-rs/src/rsa/encoding.rs b/aws-lc-rs/src/rsa/encoding.rs
+index af69fd0612f83c35a864097c291af64aa77ca6af..6e4cb813c4a68eb8031d447aa57681493a4affa5 100644
+--- a/aws-lc-rs/src/rsa/encoding.rs
++++ b/aws-lc-rs/src/rsa/encoding.rs
+@@ -12,7 +12,8 @@ pub(in crate::rsa) mod rfc8017 {
+     use crate::cbs;
+     use crate::error::{KeyRejected, Unspecified};
+     use crate::ptr::{DetachableLcPtr, LcPtr};
+-    use std::ptr::null_mut;
++    use alloc::{boxed::Box, vec::Vec};
++    use core::ptr::null_mut;
+ 
+     /// DER encode a RSA public key to `RSAPublicKey` structure.
+     pub(in crate::rsa) fn encode_public_key_der(
+diff --git a/aws-lc-rs/src/rsa/key.rs b/aws-lc-rs/src/rsa/key.rs
+index 0459efcb2ad83b7c076428e09acc39a9d14c5f2f..052037deeebbaa9b241e7df7f07d70dde6b26bb5 100644
+--- a/aws-lc-rs/src/rsa/key.rs
++++ b/aws-lc-rs/src/rsa/key.rs
+@@ -19,6 +19,7 @@ use crate::ptr::{DetachableLcPtr, LcPtr};
+ use crate::rsa::PublicEncryptingKey;
+ use crate::sealed::Sealed;
+ use crate::{hex, rand};
++use alloc::boxed::Box;
+ #[cfg(feature = "fips")]
+ use aws_lc::RSA_check_fips;
+ use core::fmt::{self, Debug, Formatter};
+@@ -26,7 +27,7 @@ use core::ptr::null_mut;
+ 
+ // TODO: Uncomment when MSRV >= 1.64
+ // use core::ffi::c_int;
+-use std::os::raw::c_int;
++use core::ffi::c_int;
+ 
+ use crate::digest::{match_digest_type, Digest};
+ use crate::pkcs8::Version;
+diff --git a/aws-lc-rs/src/rsa/signature.rs b/aws-lc-rs/src/rsa/signature.rs
+index 510adbf953bd1daf334b49d1b4c8efe64ee4bcce..3deb2dfe29e75a8a967f2153d4dd8dfde8cb5cb0 100644
+--- a/aws-lc-rs/src/rsa/signature.rs
++++ b/aws-lc-rs/src/rsa/signature.rs
+@@ -1,8 +1,8 @@
+ // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+ 
+-use std::fmt::{self, Debug, Formatter};
+-use std::ops::RangeInclusive;
++use core::fmt::{self, Debug, Formatter};
++use core::ops::RangeInclusive;
+ 
+ use crate::aws_lc::{
+     EVP_PKEY_CTX_set_rsa_padding, EVP_PKEY_CTX_set_rsa_pss_saltlen, EVP_PKEY_CTX_set_signature_md,
+diff --git a/aws-lc-rs/src/signature.rs b/aws-lc-rs/src/signature.rs
+index 143810a9ca72868f94153182234084292fd54d40..19d2403f57a3344b5ffa3e190b4dba2378c69607 100644
+--- a/aws-lc-rs/src/signature.rs
++++ b/aws-lc-rs/src/signature.rs
+@@ -241,8 +241,9 @@ pub use crate::rsa::{
+     KeyPair as RsaKeyPair, PublicKey as RsaSubjectPublicKey,
+     PublicKeyComponents as RsaPublicKeyComponents, RsaParameters,
+ };
++use alloc::boxed::Box;
++use core::any::{Any, TypeId};
+ use core::fmt::{Debug, Formatter};
+-use std::any::{Any, TypeId};
+ #[cfg(feature = "ring-sig-verify")]
+ use untrusted::Input;
+ 
+@@ -264,7 +265,7 @@ use crate::ec::encoding::parse_ec_public_key;
+ use crate::ed25519::parse_ed25519_public_key;
+ use crate::encoding::{AsDer, PublicKeyX509Der};
+ use crate::error::{KeyRejected, Unspecified};
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+ use crate::pqdsa::{parse_pqdsa_public_key, signature::PqdsaVerificationAlgorithm};
+ use crate::ptr::LcPtr;
+ use crate::rsa::key::parse_rsa_public_key;
+@@ -673,7 +674,7 @@ pub(crate) fn parse_public_key(
+         parsed_algorithm = rsa_alg;
+         parse_rsa_public_key(bytes)?
+     } else {
+-        #[cfg(all(feature = "unstable", not(feature = "fips")))]
++        #[cfg(all(feature = "unstable", feature = "ml-dsa", not(feature = "fips")))]
+         if algorithm.type_id() == TypeId::of::<PqdsaVerificationAlgorithm>() {
+             #[allow(clippy::cast_ptr_alignment)]
+             let pqdsa_alg = unsafe {
+@@ -685,7 +686,7 @@ pub(crate) fn parse_public_key(
+         } else {
+             unreachable!()
+         }
+-        #[cfg(any(not(feature = "unstable"), feature = "fips"))]
++        #[cfg(any(not(feature = "unstable"), not(feature = "ml-dsa"), feature = "fips"))]
+         unreachable!()
+     };
+ 
+diff --git a/aws-lc-rs/src/signature/parsed_public_key_tests.rs b/aws-lc-rs/src/signature/parsed_public_key_tests.rs
+index 73ab3dadf717421e06abf1ff8f6bc6566a914618..64f65672947bbf41b24d11e1e13cddf4a3841323 100644
+--- a/aws-lc-rs/src/signature/parsed_public_key_tests.rs
++++ b/aws-lc-rs/src/signature/parsed_public_key_tests.rs
+@@ -12,7 +12,11 @@ use crate::signature::{
+ use crate::{rand, test};
+ use std::any::Any;
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ use crate::unstable::signature::{
+     PqdsaKeyPair, ML_DSA_44, ML_DSA_44_SIGNING, ML_DSA_65, ML_DSA_65_SIGNING, ML_DSA_87,
+     ML_DSA_87_SIGNING,
+@@ -367,7 +371,11 @@ fn test_parsed_public_key_cross_verification() {
+     }
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_ml_dsa_44() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
+@@ -386,7 +394,11 @@ fn test_parsed_public_key_ml_dsa_44() {
+     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_ml_dsa_65() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_65_SIGNING).unwrap();
+@@ -405,7 +417,11 @@ fn test_parsed_public_key_ml_dsa_65() {
+     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_ml_dsa_87() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_87_SIGNING).unwrap();
+@@ -424,7 +440,11 @@ fn test_parsed_public_key_ml_dsa_87() {
+     assert!(parsed.verify_sig(b"wrong message", &signature).is_err());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_pqdsa_with_x509_der() {
+     use crate::encoding::AsDer;
+@@ -442,7 +462,11 @@ fn test_parsed_public_key_pqdsa_with_x509_der() {
+     assert!(parsed.verify_sig(message, &signature).is_ok());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_pqdsa_invalid_key() {
+     // Test with wrong size key for ML-DSA-44 (expects 1312 bytes)
+@@ -453,7 +477,11 @@ fn test_parsed_public_key_pqdsa_invalid_key() {
+     assert!(ParsedPublicKey::new(&ML_DSA_44, invalid_key).is_err());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_pqdsa_algorithm_mismatch() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
+@@ -466,7 +494,11 @@ fn test_parsed_public_key_pqdsa_algorithm_mismatch() {
+     assert!(ParsedPublicKey::new(&ED25519, public_key_bytes).is_err());
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_pqdsa_cross_verification() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
+@@ -493,7 +525,11 @@ fn test_parsed_public_key_pqdsa_cross_verification() {
+     );
+ }
+ 
+-#[cfg(all(feature = "unstable", not(feature = "fips")))]
++#[cfg(all(
++    feature = "unstable",
++    feature = "ml-dsa",
++    not(feature = "fips")
++))]
+ #[test]
+ fn test_parsed_public_key_pqdsa_verify_digest() {
+     let key_pair = PqdsaKeyPair::generate(&ML_DSA_44_SIGNING).unwrap();
+diff --git a/aws-lc-rs/src/tls_prf.rs b/aws-lc-rs/src/tls_prf.rs
+index 39600a7c5fc098061b1722bbdb5997b0483da367..148e5abd50323d937a9bffb409a96cfea8e9eb7f 100644
+--- a/aws-lc-rs/src/tls_prf.rs
++++ b/aws-lc-rs/src/tls_prf.rs
+@@ -25,6 +25,7 @@
+ //! # }
+ //! ```
+ 
++use alloc::{boxed::Box, vec::Vec};
+ use core::fmt::Debug;
+ 
+ use crate::digest::{match_digest_type, AlgorithmID};
+diff --git a/aws-lc-rs/src/unstable.rs b/aws-lc-rs/src/unstable.rs
+index 59e5daf6b11348b48f554482ef90c375f7a3b199..3d521873de8259083176a0ad3d451a56e58f4486 100644
+--- a/aws-lc-rs/src/unstable.rs
++++ b/aws-lc-rs/src/unstable.rs
+@@ -9,5 +9,5 @@
+ //! The APIs under this module are not stable and may change in the future.
+ //! They are not covered by semver guarantees.
+ //!
+-#[cfg(not(feature = "fips"))]
++#[cfg(all(feature = "ml-dsa", not(feature = "fips")))]
+ pub mod signature;
+diff --git a/aws-lc-rs/tests/pqdsa_test.rs b/aws-lc-rs/tests/pqdsa_test.rs
+index 12bc5b0055191d5eb577c938c9ca6002ee639974..7935134091dc1e29c3960001db185759924a4fbc 100644
+--- a/aws-lc-rs/tests/pqdsa_test.rs
++++ b/aws-lc-rs/tests/pqdsa_test.rs
+@@ -1,6 +1,6 @@
+ // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+-#![cfg(all(not(feature = "fips"), feature = "unstable"))]
++#![cfg(all(not(feature = "fips"), feature = "ml-dsa", feature = "unstable"))]
+ 
+ use aws_lc_rs::encoding::{AsDer, AsRawBytes};
+ use aws_lc_rs::signature::{KeyPair, ParsedPublicKey, VerificationAlgorithm};
+diff --git a/aws-lc-sys/Cargo.toml b/aws-lc-sys/Cargo.toml
+index 863c1ca0649e440363a7b7727854bd046d3398b6..4b19fc0e74cf03b602b09ac9abffde352ae23df2 100644
+--- a/aws-lc-sys/Cargo.toml
++++ b/aws-lc-sys/Cargo.toml
+@@ -54,6 +54,7 @@ include = [
+     "/Cargo.toml",
+     "/generated-include/**",
+     "/include/**",
++    "/no-std/**",
+     "/src/**/*.rs",
+     "/tests/**/*.rs",
+ ]
+@@ -66,7 +67,11 @@ bindgen = ["dep:bindgen"] # Generate the bindings on the targeted platform as a
+ disable-prebuilt-nasm = []
+ prebuilt-nasm = []
+ all-bindings = []
+-default = ['all-bindings']
++ml-kem = []
++ml-dsa = []
++pqc = ["ml-kem", "ml-dsa"]
++small = []
++default = ["all-bindings", "ml-kem", "ml-dsa"]
+ fips = ['dep:bindgen']
+ 
+ [build-dependencies]
+diff --git a/aws-lc-sys/README.md b/aws-lc-sys/README.md
+index cd3caa6f041042942f14fc49d7eee69f71696d96..5a09291634114c48e04d4a1e8610fa3e1939920a 100644
+--- a/aws-lc-sys/README.md
++++ b/aws-lc-sys/README.md
+@@ -215,6 +215,46 @@ available at [aws-lc-fips-sys](https://crates.io/crates/aws-lc-fips-sys).
+ Details on the post-quantum algorithms supported by aws-lc-sys can be found at
+ [PQREADME](https://github.com/aws/aws-lc/tree/main/crypto/fipsmodule/PQREADME.md).
+ 
++`ml-kem` and `ml-dsa` are enabled by default. Disable default features and
++select either feature directly to build only that implementation. `pqc` is a
++convenience alias for both:
++
++```toml
++[dependencies]
++aws-lc-sys = { version = "0.43", default-features = false, features = ["ml-kem"] }
++```
++
++Disabling an algorithm removes its implementation, method tables, and
++algorithm self-tests. Public C declarations, generated Rust bindings, object
++identifiers, and generic EVP type metadata remain stable. They do not provide
++key generation, signing, verification, encapsulation, or decapsulation when
++the corresponding implementation feature is disabled.
++
++## No-Std Runtime
++
++Targets with `target_os = "none"` automatically use the freestanding adapter.
++The target remains unchanged when compiling AWS-LC. The adapter is not a
++general-purpose libc and assumes ownership of the C runtime symbols it
++provides. It configures AWS-LC for single-threaded operation; concurrent use
++is unsupported. The adapter supplies the libc subset needed by AWS-LC and
++delegates platform policy through these required hooks:
++
++| Hook | Contract |
++|------|----------|
++| `aws_lc_nostd_alloc` | Allocate the requested size and power-of-two alignment, or return null. |
++| `aws_lc_nostd_dealloc` | Release an allocation using its original size and alignment. |
++| `aws_lc_nostd_realloc` | Preserve the shorter of the old and new sizes; failure leaves the old allocation valid. |
++| `aws_lc_nostd_entropy` | Fill the complete output with cryptographically secure random bytes and return one, or return zero without exposing partial output. |
++| `aws_lc_nostd_time` | Return seconds since the Unix epoch. A fixed value is permitted only when the consumer does not rely on time validation. |
++| `aws_lc_nostd_abort` | Terminate execution and never return. |
++
++The authoritative declarations are in
++`no-std/include/aws_lc/no_std_runtime.h`. Rust consumers that enable `alloc`
++must separately install a Rust
++[`GlobalAlloc`](https://doc.rust-lang.org/core/alloc/trait.GlobalAlloc.html).
++The `no-std-runtime-test` workspace package is a final-linked bare-metal
++example.
++
+ ## Security Notification Process
+ 
+ If you discover a potential security issue in *AWS-LC* or *aws-lc-sys*, we ask that you notify AWS
+diff --git a/aws-lc-sys/no-std/include/assert.h b/aws-lc-sys/no-std/include/assert.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..df058427dbaead9906a2c095d85074c3c2509651
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/assert.h
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_ASSERT_H
++#define AWS_LC_SYS_NO_STD_ASSERT_H
++
++void __assert_fail(const char *expression, const char *file, unsigned int line,
++                   const char *function) __attribute__((noreturn));
++
++#ifdef NDEBUG
++#define assert(expression) ((void)0)
++#else
++#define assert(expression)                                                     \
++  ((expression) ? (void)0                                                      \
++                : __assert_fail(#expression, __FILE__, __LINE__, __func__))
++#endif
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/aws_lc/no_std_runtime.h b/aws-lc-sys/no-std/include/aws_lc/no_std_runtime.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..68b8f3e90fc5a7aa350764644c69858e8d8518d9
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/aws_lc/no_std_runtime.h
+@@ -0,0 +1,44 @@
++// Copyright (c) 2026 Intel Corporation
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++
++#ifndef AWS_LC_NO_STD_RUNTIME_H
++#define AWS_LC_NO_STD_RUNTIME_H
++
++#include <stddef.h>
++#include <stdint.h>
++
++#if defined(__cplusplus)
++extern "C" {
++#endif
++
++// Allocates |size| bytes aligned to |align|, or returns NULL. |align| is a
++// non-zero power of two. The returned allocation remains valid until passed to
++// aws_lc_nostd_dealloc or aws_lc_nostd_realloc.
++void *aws_lc_nostd_alloc(size_t size, size_t align);
++
++// Releases an allocation returned by aws_lc_nostd_alloc or
++// aws_lc_nostd_realloc. |size| and |align| equal the values used to create the
++// current allocation.
++void aws_lc_nostd_dealloc(void *ptr, size_t size, size_t align);
++
++// Resizes an allocation while preserving min(|old_size|, |new_size|) bytes.
++// Returns NULL without releasing |ptr| on failure.
++void *aws_lc_nostd_realloc(void *ptr, size_t old_size, size_t new_size,
++                           size_t align);
++
++// Fills exactly |len| bytes with cryptographically secure random data. Returns
++// one on success and zero without exposing partial output on failure.
++int aws_lc_nostd_entropy(uint8_t *out, size_t len);
++
++// Returns seconds since the Unix epoch. Platforms without a trusted wall clock
++// may return a fixed value, but time-dependent validation will then fail.
++int64_t aws_lc_nostd_time(void);
++
++// Terminates execution and never returns.
++void aws_lc_nostd_abort(void) __attribute__((noreturn));
++
++#if defined(__cplusplus)
++}
++#endif
++
++#endif  // AWS_LC_NO_STD_RUNTIME_H
+diff --git a/aws-lc-sys/no-std/include/ctype.h b/aws-lc-sys/no-std/include/ctype.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..a10f16ac7852b296416afc2c74ba84a5c5adc3b0
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/ctype.h
+@@ -0,0 +1,14 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_CTYPE_H
++#define AWS_LC_SYS_NO_STD_CTYPE_H
++
++int isalnum(int character);
++int isalpha(int character);
++int isdigit(int character);
++int isprint(int character);
++int isspace(int character);
++int isxdigit(int character);
++int tolower(int character);
++int toupper(int character);
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/errno.h b/aws-lc-sys/no-std/include/errno.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..bf6e6e424071aebac9092b0c740b62dc37201dcc
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/errno.h
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_ERRNO_H
++#define AWS_LC_SYS_NO_STD_ERRNO_H
++
++#define ENOENT 2
++#define ENOMEM 12
++#define EINVAL 22
++#define ERANGE 34
++
++int *__errno_location(void);
++#define errno (*__errno_location())
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/inttypes.h b/aws-lc-sys/no-std/include/inttypes.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..df1f17a19620e2fa7195d399de2b9f7a8d6ae810
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/inttypes.h
+@@ -0,0 +1,14 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_INTTYPES_H
++#define AWS_LC_SYS_NO_STD_INTTYPES_H
++
++#include <stdint.h>
++
++#define PRIX32 "X"
++#define PRIu32 "u"
++#define PRIx32 "x"
++#define PRId64 "ld"
++#define PRIu64 "lu"
++#define PRIx64 "lx"
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/stdio.h b/aws-lc-sys/no-std/include/stdio.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..838a4f0cc654757cf756f5041746fde6ac5d5ebf
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/stdio.h
+@@ -0,0 +1,34 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_STDIO_H
++#define AWS_LC_SYS_NO_STD_STDIO_H
++
++#include <stdarg.h>
++#include <stddef.h>
++
++typedef struct aws_lc_sys_no_std_file FILE;
++
++extern FILE *stderr;
++extern FILE *stdout;
++
++int fclose(FILE *stream);
++int feof(FILE *stream);
++int ferror(FILE *stream);
++int fflush(FILE *stream);
++char *fgets(char *buffer, int size, FILE *stream);
++int fprintf(FILE *stream, const char *format, ...);
++int fputs(const char *string, FILE *stream);
++size_t fread(void *buffer, size_t size, size_t count, FILE *stream);
++int fseek(FILE *stream, long offset, int origin);
++long ftell(FILE *stream);
++size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream);
++int printf(const char *format, ...);
++int snprintf(char *buffer, size_t size, const char *format, ...);
++int sscanf(const char *input, const char *format, ...);
++int vsnprintf(char *buffer, size_t size, const char *format, va_list args);
++
++#define EOF (-1)
++#define SEEK_CUR 1
++#define SEEK_END 2
++#define SEEK_SET 0
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/stdlib.h b/aws-lc-sys/no-std/include/stdlib.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..7994655a2777f6bcc956139d1ca2ed14ac2d54f2
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/stdlib.h
+@@ -0,0 +1,24 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_STDLIB_H
++#define AWS_LC_SYS_NO_STD_STDLIB_H
++
++#include <stddef.h>
++
++#define EXIT_FAILURE 1
++#define EXIT_SUCCESS 0
++#define RAND_MAX 2147483647
++
++void abort(void) __attribute__((noreturn));
++void *bsearch(const void *key, const void *base, size_t count, size_t size,
++              int (*compare)(const void *, const void *));
++void *calloc(size_t count, size_t size);
++void free(void *pointer);
++char *getenv(const char *name);
++void *malloc(size_t size);
++void qsort(void *base, size_t count, size_t size,
++           int (*compare)(const void *, const void *));
++void *realloc(void *pointer, size_t size);
++long strtol(const char *string, char **end, int base);
++unsigned long strtoul(const char *string, char **end, int base);
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/string.h b/aws-lc-sys/no-std/include/string.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..306edc1c1f072100f1c75eff936865f1a08f23fe
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/string.h
+@@ -0,0 +1,18 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_STRING_H
++#define AWS_LC_SYS_NO_STD_STRING_H
++
++#include <stddef.h>
++
++void *memchr(const void *buffer, int character, size_t size);
++int memcmp(const void *left, const void *right, size_t size);
++void *memcpy(void *destination, const void *source, size_t size);
++void *memmove(void *destination, const void *source, size_t size);
++void *memset(void *destination, int value, size_t size);
++char *strchr(const char *string, int character);
++int strcmp(const char *left, const char *right);
++char *strerror(int error);
++size_t strlen(const char *string);
++int strncmp(const char *left, const char *right, size_t size);
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/sys/stat.h b/aws-lc-sys/no-std/include/sys/stat.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..c6adc1ea5ac7bd7f027e50f2906d9d91dc703c27
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/sys/stat.h
+@@ -0,0 +1,9 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_SYS_STAT_H
++#define AWS_LC_SYS_NO_STD_SYS_STAT_H
++
++struct stat {
++  unsigned char unused;
++};
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/sys/types.h b/aws-lc-sys/no-std/include/sys/types.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..38a9b1d1ad9a611ef102cbd8c57dbbdd796377d0
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/sys/types.h
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_SYS_TYPES_H
++#define AWS_LC_SYS_NO_STD_SYS_TYPES_H
++
++#include <stddef.h>
++#include <stdint.h>
++
++typedef intptr_t ssize_t;
++typedef int64_t time_t;
++
++#endif
+diff --git a/aws-lc-sys/no-std/include/time.h b/aws-lc-sys/no-std/include/time.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..4bda191674323de9c98f073d4428d9c7f267e580
+--- /dev/null
++++ b/aws-lc-sys/no-std/include/time.h
+@@ -0,0 +1,21 @@
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++#ifndef AWS_LC_SYS_NO_STD_TIME_H
++#define AWS_LC_SYS_NO_STD_TIME_H
++
++#include <sys/types.h>
++
++struct tm {
++  int tm_sec;
++  int tm_min;
++  int tm_hour;
++  int tm_mday;
++  int tm_mon;
++  int tm_year;
++  int tm_wday;
++  int tm_yday;
++  int tm_isdst;
++};
++
++time_t time(time_t *result);
++
++#endif
+diff --git a/aws-lc-sys/no-std/runtime.c b/aws-lc-sys/no-std/runtime.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..5898bc7f3bcf9e0e5a9f5d1c080155c789245168
+--- /dev/null
++++ b/aws-lc-sys/no-std/runtime.c
+@@ -0,0 +1,367 @@
++// Copyright (c) 2026 Intel Corporation
++// SPDX-License-Identifier: Apache-2.0 OR ISC
++
++#include <openssl/rand.h>
++
++#include <aws_lc/no_std_runtime.h>
++#include <stdarg.h>
++#include <stdint.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#define ALLOC_ALIGNMENT 16
++#define ALLOC_HEADER_SIZE 16
++
++FILE *stderr;
++FILE *stdout;
++static int nostd_errno;
++
++int *__errno_location(void) { return &nostd_errno; }
++
++void *malloc(size_t size) {
++  if (size > SIZE_MAX - ALLOC_HEADER_SIZE) {
++    return NULL;
++  }
++  const size_t allocation_size = size + ALLOC_HEADER_SIZE;
++  uint8_t *allocation = aws_lc_nostd_alloc(allocation_size, ALLOC_ALIGNMENT);
++  if (allocation == NULL) {
++    return NULL;
++  }
++  *(size_t *)allocation = size;
++  return allocation + ALLOC_HEADER_SIZE;
++}
++
++void free(void *ptr) {
++  if (ptr == NULL) {
++    return;
++  }
++  uint8_t *allocation = (uint8_t *)ptr - ALLOC_HEADER_SIZE;
++  const size_t allocation_size = *(size_t *)allocation + ALLOC_HEADER_SIZE;
++  aws_lc_nostd_dealloc(allocation, allocation_size, ALLOC_ALIGNMENT);
++}
++
++void *calloc(size_t count, size_t size) {
++  if (size != 0 && count > SIZE_MAX / size) {
++    return NULL;
++  }
++  const size_t total = count * size;
++  void *ptr = malloc(total);
++  if (ptr != NULL) {
++    __builtin_memset(ptr, 0, total);
++  }
++  return ptr;
++}
++
++void *realloc(void *ptr, size_t size) {
++  if (ptr == NULL) {
++    return malloc(size);
++  }
++  if (size == 0) {
++    free(ptr);
++    return NULL;
++  }
++  if (size > SIZE_MAX - ALLOC_HEADER_SIZE) {
++    return NULL;
++  }
++  uint8_t *allocation = (uint8_t *)ptr - ALLOC_HEADER_SIZE;
++  const size_t old_size = *(size_t *)allocation + ALLOC_HEADER_SIZE;
++  const size_t new_size = size + ALLOC_HEADER_SIZE;
++  allocation =
++      aws_lc_nostd_realloc(allocation, old_size, new_size, ALLOC_ALIGNMENT);
++  if (allocation == NULL) {
++    return NULL;
++  }
++  *(size_t *)allocation = size;
++  return allocation + ALLOC_HEADER_SIZE;
++}
++
++int strcmp(const char *left, const char *right) {
++  while (*left != '\0' && *left == *right) {
++    left++;
++    right++;
++  }
++  return (unsigned char)*left - (unsigned char)*right;
++}
++
++char *strchr(const char *string, int character) {
++  do {
++    if (*string == (char)character) {
++      return (char *)string;
++    }
++  } while (*string++ != '\0');
++  return NULL;
++}
++
++void *memchr(const void *buffer, int character, size_t size) {
++  const unsigned char *bytes = buffer;
++  for (size_t index = 0; index < size; index++) {
++    if (bytes[index] == (unsigned char)character) {
++      return (void *)&bytes[index];
++    }
++  }
++  return NULL;
++}
++
++void *bsearch(const void *key, const void *base, size_t count, size_t size,
++              int (*compare)(const void *, const void *)) {
++  size_t low = 0;
++  size_t high = count;
++  while (low < high) {
++    const size_t middle = low + (high - low) / 2;
++    const void *element = (const uint8_t *)base + middle * size;
++    const int ordering = compare(key, element);
++    if (ordering < 0) {
++      high = middle;
++    } else if (ordering > 0) {
++      low = middle + 1;
++    } else {
++      return (void *)element;
++    }
++  }
++  return NULL;
++}
++
++void qsort(void *base, size_t count, size_t size,
++           int (*compare)(const void *, const void *)) {
++  uint8_t *bytes = base;
++  for (size_t index = 1; index < count; index++) {
++    size_t current = index;
++    while (current > 0) {
++      uint8_t *left = bytes + (current - 1) * size;
++      uint8_t *right = bytes + current * size;
++      if (compare(left, right) <= 0) {
++        break;
++      }
++      for (size_t offset = 0; offset < size; offset++) {
++        uint8_t value = left[offset];
++        left[offset] = right[offset];
++        right[offset] = value;
++      }
++      current--;
++    }
++  }
++}
++
++static unsigned long parse_unsigned(const char *string, char **end, int base,
++                                    int *negative) {
++  const char *cursor = string;
++  unsigned long value = 0;
++  while (*cursor == ' ' || (*cursor >= '\t' && *cursor <= '\r')) {
++    cursor++;
++  }
++  *negative = 0;
++  if (*cursor == '+' || *cursor == '-') {
++    *negative = *cursor++ == '-';
++  }
++  if ((base == 0 || base == 16) && cursor[0] == '0' &&
++      (cursor[1] == 'x' || cursor[1] == 'X')) {
++    base = 16;
++    cursor += 2;
++  } else if (base == 0) {
++    base = cursor[0] == '0' ? 8 : 10;
++  }
++  const char *digits = cursor;
++  for (;;) {
++    unsigned int digit;
++    if (*cursor >= '0' && *cursor <= '9') {
++      digit = (unsigned int)(*cursor - '0');
++    } else if (*cursor >= 'a' && *cursor <= 'z') {
++      digit = (unsigned int)(*cursor - 'a') + 10;
++    } else if (*cursor >= 'A' && *cursor <= 'Z') {
++      digit = (unsigned int)(*cursor - 'A') + 10;
++    } else {
++      break;
++    }
++    if (digit >= (unsigned int)base) {
++      break;
++    }
++    value = value * (unsigned int)base + digit;
++    cursor++;
++  }
++  if (end != NULL) {
++    *end = (char *)(cursor == digits ? string : cursor);
++  }
++  return value;
++}
++
++long strtol(const char *string, char **end, int base) {
++  int negative;
++  unsigned long value = parse_unsigned(string, end, base, &negative);
++  return negative ? -(long)value : (long)value;
++}
++
++unsigned long strtoul(const char *string, char **end, int base) {
++  int negative;
++  unsigned long value = parse_unsigned(string, end, base, &negative);
++  return negative ? 0 - value : value;
++}
++
++char *getenv(const char *name) {
++  (void)name;
++  return NULL;
++}
++
++int vsnprintf(char *buffer, size_t size, const char *format, va_list args) {
++  (void)format;
++  (void)args;
++  if (size != 0) {
++    buffer[0] = '\0';
++  }
++  return -1;
++}
++
++int snprintf(char *buffer, size_t size, const char *format, ...) {
++  va_list args;
++  va_start(args, format);
++  int result = vsnprintf(buffer, size, format, args);
++  va_end(args);
++  return result;
++}
++
++int sscanf(const char *input, const char *format, ...) {
++  (void)input;
++  (void)format;
++  return EOF;
++}
++
++int fclose(FILE *stream) {
++  (void)stream;
++  return EOF;
++}
++
++int feof(FILE *stream) {
++  (void)stream;
++  return 1;
++}
++
++int ferror(FILE *stream) {
++  (void)stream;
++  return 1;
++}
++
++int fflush(FILE *stream) {
++  (void)stream;
++  return 0;
++}
++
++char *fgets(char *buffer, int size, FILE *stream) {
++  (void)buffer;
++  (void)size;
++  (void)stream;
++  return NULL;
++}
++
++int fputs(const char *string, FILE *stream) {
++  (void)string;
++  (void)stream;
++  return EOF;
++}
++
++size_t fread(void *buffer, size_t size, size_t count, FILE *stream) {
++  (void)buffer;
++  (void)size;
++  (void)count;
++  (void)stream;
++  return 0;
++}
++
++int fseek(FILE *stream, long offset, int origin) {
++  (void)stream;
++  (void)offset;
++  (void)origin;
++  return -1;
++}
++
++long ftell(FILE *stream) {
++  (void)stream;
++  return -1;
++}
++
++size_t fwrite(const void *buffer, size_t size, size_t count, FILE *stream) {
++  (void)buffer;
++  (void)size;
++  (void)count;
++  (void)stream;
++  return 0;
++}
++
++int printf(const char *format, ...) {
++  (void)format;
++  return EOF;
++}
++
++int fprintf(FILE *stream, const char *format, ...) {
++  (void)stream;
++  (void)format;
++  aws_lc_nostd_abort();
++}
++
++char *strerror(int error) {
++  (void)error;
++  return "no-std runtime error";
++}
++
++static int ascii_is_upper(int character) {
++  return character >= 'A' && character <= 'Z';
++}
++
++static int ascii_is_lower(int character) {
++  return character >= 'a' && character <= 'z';
++}
++
++int isalpha(int character) {
++  return ascii_is_upper(character) || ascii_is_lower(character);
++}
++
++int isdigit(int character) { return character >= '0' && character <= '9'; }
++
++int isalnum(int character) { return isalpha(character) || isdigit(character); }
++
++int isprint(int character) { return character >= 0x20 && character <= 0x7e; }
++
++int isspace(int character) {
++  return character == ' ' || (character >= '\t' && character <= '\r');
++}
++
++int isxdigit(int character) {
++  return isdigit(character) || (character >= 'a' && character <= 'f') ||
++         (character >= 'A' && character <= 'F');
++}
++
++int tolower(int character) {
++  return ascii_is_upper(character) ? character + ('a' - 'A') : character;
++}
++
++int toupper(int character) {
++  return ascii_is_lower(character) ? character - ('a' - 'A') : character;
++}
++
++time_t time(time_t *result) {
++  time_t value = (time_t)aws_lc_nostd_time();
++  if (result != NULL) {
++    *result = value;
++  }
++  return value;
++}
++
++void abort(void) { aws_lc_nostd_abort(); }
++
++void __assert_fail(const char *assertion, const char *file, unsigned int line,
++                   const char *function) {
++  (void)assertion;
++  (void)file;
++  (void)line;
++  (void)function;
++  aws_lc_nostd_abort();
++}
++
++void CRYPTO_sysrand(uint8_t *out, size_t requested) {
++  if (!aws_lc_nostd_entropy(out, requested)) {
++    aws_lc_nostd_abort();
++  }
++}
++
++int CRYPTO_sysrand_if_available(uint8_t *out, size_t requested) {
++  return aws_lc_nostd_entropy(out, requested);
++}
+diff --git a/aws-lc-sys/src/lib.rs b/aws-lc-sys/src/lib.rs
+index d22ed1380a0009648913b86ca32b4190e1bcd492..def74cb4d89fdc0b310695ec20d3df1743af86ea 100644
+--- a/aws-lc-sys/src/lib.rs
++++ b/aws-lc-sys/src/lib.rs
+@@ -3,6 +3,7 @@
+ 
+ #![cfg_attr(not(clippy), allow(unexpected_cfgs))]
+ #![cfg_attr(not(clippy), allow(unknown_lints))]
++#![no_std]
+ 
+ #[allow(unused_macros)]
+ macro_rules! use_bindings {
+@@ -95,7 +96,7 @@ pub fn ERR_GET_FUNC(_packed_error: u32) -> i32 {
+ }
+ 
+ #[cfg(feature = "all-bindings")]
+-use std::os::raw::{c_char, c_long, c_void};
++use core::ffi::{c_char, c_long, c_void};
+ 
+ #[cfg(feature = "all-bindings")]
+ #[allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
+diff --git a/builder/cc_builder.rs b/builder/cc_builder.rs
+index 2cc833938abeae18a1c2211fec42b30bfc090073..b7d031d9d7f72eea0ccf0e42403454de6b9c398e 100644
+--- a/builder/cc_builder.rs
++++ b/builder/cc_builder.rs
+@@ -20,10 +20,10 @@ mod win_x86_64;
+ use crate::nasm_builder::NasmBuilder;
+ use crate::{
+     cargo_env, compiler_is_cl_like, emit_warning, env_var_to_bool, execute_command, find_clang_cl,
+-    get_crate_cc, get_crate_cflags, get_crate_cxx, is_cross_compiling, is_link_whole_archive,
+-    is_no_asm, out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy, target,
+-    target_arch, target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard,
+-    OutputLibType,
++    get_crate_cc, get_crate_cflags, get_crate_cxx, is_cross_compiling, is_freestanding_target,
++    is_link_whole_archive, is_ml_dsa_enabled, is_ml_kem_enabled, is_no_asm, is_small_enabled,
++    out_dir, requested_c_std, set_env_for_target, should_build_jitter_entropy, target, target_arch,
++    target_env, target_is_msvc, target_os, target_vendor, CStdRequested, EnvGuard, OutputLibType,
+ };
+ use std::cell::Cell;
+ use std::collections::HashMap;
+@@ -49,6 +49,18 @@ use std::fs;
+ fn identify_sources() -> Vec<&'static str> {
+     let mut source_files: Vec<&'static str> = vec![];
+     source_files.append(&mut Vec::from(universal::CRYPTO_LIBRARY));
++    if is_freestanding_target() {
++        source_files.retain(|source| {
++            !matches!(
++                *source,
++                "crypto/console/console.c"
++                    | "crypto/rand_extra/ccrandomgeneratebytes.c"
++                    | "crypto/rand_extra/getentropy.c"
++                    | "crypto/rand_extra/urandom.c"
++                    | "crypto/rand_extra/windows.c"
++            )
++        });
++    }
+     let mut target_specific_source_found = true;
+     if target_os() == "windows" {
+         if target_arch() == "x86_64" {
+@@ -89,6 +101,14 @@ fn identify_sources() -> Vec<&'static str> {
+         ));
+     }
+ 
++    source_files.retain(|source| {
++        (is_ml_kem_enabled()
++            || (!source.contains("/ml_kem/") && *source != "crypto/evp_extra/p_kem_asn1.c"))
++            && (is_ml_dsa_enabled()
++                || ((!source.contains("/ml_dsa/") && !source.contains("/mldsa/"))
++                    && *source != "crypto/evp_extra/p_pqdsa_asn1.c"))
++    });
++
+     source_files
+ }
+ 
+@@ -286,12 +306,26 @@ impl CcBuilder {
+ 
+     pub fn collect_cc_only_build_options(&self) -> Vec<BuildOption> {
+         let mut build_options: Vec<BuildOption> = Vec::new();
+-        let is_cl_like = compiler_is_cl_like(&cc::Build::new().get_compiler());
++        let cc_build = cc::Build::new();
++        let is_cl_like = compiler_is_cl_like(&cc_build.get_compiler());
++        build_options.push(BuildOption::define(
++            "AWSLC_ENABLE_ML_KEM",
++            if is_ml_kem_enabled() { "1" } else { "0" },
++        ));
++        build_options.push(BuildOption::define(
++            "AWSLC_ENABLE_ML_DSA",
++            if is_ml_dsa_enabled() { "1" } else { "0" },
++        ));
++        if is_freestanding_target() {
++            build_options.push(BuildOption::define("AWSLC_NO_STD", "1"));
++            build_options.push(BuildOption::flag("-nostdlibinc"));
++            build_options.push(BuildOption::flag("-ffreestanding"));
++        }
+         if !is_cl_like {
+             build_options.push(BuildOption::flag("-Wno-unused-parameter"));
+             // On emscripten, `-pthread` forces a shared-memory wasm module
+             // (requires SharedArrayBuffer); build single-threaded instead.
+-            if target_os() != "emscripten" {
++            if target_os() != "emscripten" && !is_freestanding_target() {
+                 build_options.push(BuildOption::flag("-pthread"));
+             }
+             if target_os() == "linux" || target_os() == "emscripten" {
+@@ -304,6 +338,14 @@ impl CcBuilder {
+         if !should_build_jitter_entropy() {
+             build_options.push(BuildOption::define("DISABLE_CPU_JITTER_ENTROPY", "1"));
+         }
++        if is_small_enabled() {
++            build_options.push(BuildOption::define("OPENSSL_SMALL", "1"));
++            for flag in ["-ffunction-sections", "-fdata-sections"] {
++                if let Some(option) = BuildOption::flag_if_supported(&cc_build, flag) {
++                    build_options.push(option);
++                }
++            }
++        }
+         self.add_includes(&mut build_options);
+         self.add_defines(&mut build_options, is_cl_like);
+ 
+@@ -320,6 +362,11 @@ impl CcBuilder {
+             ));
+         }
+         build_options.push(BuildOption::include(self.manifest_dir.join("include")));
++        if is_freestanding_target() {
++            build_options.push(BuildOption::include(
++                self.manifest_dir.join("no-std").join("include"),
++            ));
++        }
+         build_options.push(BuildOption::include(
+             self.manifest_dir.join("aws-lc").join("include"),
+         ));
+@@ -687,6 +734,9 @@ impl CcBuilder {
+                 cc_build.file(source_path);
+             }
+         }
++        if is_freestanding_target() {
++            cc_build.file(self.manifest_dir.join("no-std").join("runtime.c"));
++        }
+         self.compiler_features.set(compiler_features);
+         let s2n_bignum_object_files = s2n_bignum_builder.compile_intermediates();
+         for object in s2n_bignum_object_files {
+@@ -770,6 +820,12 @@ impl CcBuilder {
+             .file(source_file)
+             .warnings_into_errors(true)
+             .out_dir(&output_dir);
++        if is_freestanding_target() {
++            cc_build
++                .flag("-nostdlibinc")
++                .flag("-ffreestanding")
++                .include(self.manifest_dir.join("no-std").join("include"));
++        }
+         for flag in extra_flags {
+             let flag = flag.as_ref();
+             cc_build.flag(flag);
+diff --git a/builder/cc_builder/apple_x86_64.rs b/builder/cc_builder/apple_x86_64.rs
+index 6113ac33b7d396e7fd179fe6752a91c9177d3365..cb3fcd5bd8a622dfadf597cf36c21f071d3609d5 100644
+--- a/builder/cc_builder/apple_x86_64.rs
++++ b/builder/cc_builder/apple_x86_64.rs
+@@ -72,9 +72,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmulbase_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmuldouble.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_intt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_ntt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_reduce.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/bignum_montinv_p256.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/p256_montjscalarmul.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/p256_montjscalarmul_alt.S",
+@@ -110,7 +107,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jdouble_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jscalarmul.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jscalarmul_alt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak4_f1600.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak4_f1600_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak_f1600.S",
+ ];
+diff --git a/builder/cc_builder/linux_x86_64.rs b/builder/cc_builder/linux_x86_64.rs
+index 68265c3d361c2792959cf8e61b7de130af753389..0c6ed745cc42f4aba14e851dfa430e60d30d5881 100644
+--- a/builder/cc_builder/linux_x86_64.rs
++++ b/builder/cc_builder/linux_x86_64.rs
+@@ -1,11 +1,11 @@
+ // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+-// Wed Jul 15 15:34:27 UTC 2026
++// Fri Aug  7 13:47:33 UTC 2026
+ 
+ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/intt_avx2_asm.S",
+-    "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/nttunpack_avx2_asm.S",
+     "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/ntt_avx2_asm.S",
++    "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/nttunpack_avx2_asm.S",
+     "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/pointwise_acc_l4_avx2_asm.S",
+     "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/pointwise_acc_l5_avx2_asm.S",
+     "crypto/fipsmodule/ml_dsa/mldsa/native/x86_64/src/pointwise_acc_l7_avx2_asm.S",
+@@ -17,9 +17,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/nttfrombytes.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/ntttobytes.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/nttunpack.S",
+-    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S",
+-    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S",
+-    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_compress_d10.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_compress_d11.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_compress_d4.S",
+@@ -28,6 +25,9 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_decompress_d11.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_decompress_d4.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/poly_decompress_d5.S",
++    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k2.S",
++    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k3.S",
++    "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/polyvec_basemul_acc_montgomery_cached_asm_k4.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/reduce.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/rej_uniform_asm.S",
+     "crypto/fipsmodule/ml_kem/mlkem/native/x86_64/src/tomont.S",
+@@ -63,9 +63,9 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/bignum_mod_n25519.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/bignum_neg_p25519.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/curve25519_x25519.S",
++    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/curve25519_x25519_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/curve25519_x25519base.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/curve25519_x25519base_alt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/curve25519_x25519_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_decode.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_decode_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_encode.S",
+@@ -73,9 +73,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmulbase_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmuldouble.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_intt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_ntt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/mldsa/mldsa_reduce.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/bignum_montinv_p256.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/p256_montjscalarmul.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p256/p256_montjscalarmul_alt.S",
+@@ -111,7 +108,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jdouble_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jscalarmul.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/p521/p521_jscalarmul_alt.S",
+-    "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak4_f1600.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak4_f1600_alt.S",
+     "third_party/s2n-bignum/s2n-bignum-imported/x86_att/sha3/sha3_keccak_f1600.S",
+ ];
+diff --git a/builder/cc_builder/universal.rs b/builder/cc_builder/universal.rs
+index 8dccbbfd8a5854cc491049877979d8197866c41c..057f8c2757f51110385712705fa563a38749cf78 100644
+--- a/builder/cc_builder/universal.rs
++++ b/builder/cc_builder/universal.rs
+@@ -1,11 +1,8 @@
+ // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+-// Wed Jul 15 15:34:27 UTC 2026
++// Fri Aug  7 13:47:33 UTC 2026
+ 
+ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+-    "crypto/asn1/asn1_lib.c",
+-    "crypto/asn1/asn1_par.c",
+-    "crypto/asn1/asn_pack.c",
+     "crypto/asn1/a_bitstr.c",
+     "crypto/asn1/a_bool.c",
+     "crypto/asn1/a_d2i_fp.c",
+@@ -22,6 +19,9 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/asn1/a_type.c",
+     "crypto/asn1/a_utctm.c",
+     "crypto/asn1/a_utf8.c",
++    "crypto/asn1/asn1_lib.c",
++    "crypto/asn1/asn1_par.c",
++    "crypto/asn1/asn_pack.c",
+     "crypto/asn1/f_int.c",
+     "crypto/asn1/f_string.c",
+     "crypto/asn1/posix_time.c",
+@@ -59,10 +59,10 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/cipher_extra/cipher_extra.c",
+     "crypto/cipher_extra/cts.c",
+     "crypto/cipher_extra/derive_key.c",
+-    "crypto/cipher_extra/e_aesctrhmac.c",
+-    "crypto/cipher_extra/e_aesgcmsiv.c",
+     "crypto/cipher_extra/e_aes_cbc_hmac_sha1.c",
+     "crypto/cipher_extra/e_aes_cbc_hmac_sha256.c",
++    "crypto/cipher_extra/e_aesctrhmac.c",
++    "crypto/cipher_extra/e_aesgcmsiv.c",
+     "crypto/cipher_extra/e_chacha20poly1305.c",
+     "crypto/cipher_extra/e_des.c",
+     "crypto/cipher_extra/e_null.c",
+@@ -90,15 +90,14 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/digest_extra/digest_extra.c",
+     "crypto/dsa/dsa.c",
+     "crypto/dsa/dsa_asn1.c",
+-    "crypto/ecdh_extra/ecdh_extra.c",
+-    "crypto/ecdsa_extra/ecdsa_asn1.c",
+     "crypto/ec_extra/ec_asn1.c",
+     "crypto/ec_extra/ec_derive.c",
+     "crypto/ec_extra/hash_to_curve.c",
++    "crypto/ecdh_extra/ecdh_extra.c",
++    "crypto/ecdsa_extra/ecdsa_asn1.c",
+     "crypto/engine/engine.c",
+     "crypto/err/err.c",
+     "crypto/evp_extra/evp_asn1.c",
+-    "crypto/evp_extra/print.c",
+     "crypto/evp_extra/p_dh.c",
+     "crypto/evp_extra/p_dh_asn1.c",
+     "crypto/evp_extra/p_dsa.c",
+@@ -112,11 +111,13 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/evp_extra/p_rsa_asn1.c",
+     "crypto/evp_extra/p_x25519.c",
+     "crypto/evp_extra/p_x25519_asn1.c",
++    "crypto/evp_extra/print.c",
+     "crypto/evp_extra/scrypt.c",
+     "crypto/evp_extra/sign.c",
+     "crypto/ex_data.c",
+     "crypto/fipsmodule/bcm.c",
+     "crypto/fipsmodule/cpucap/cpucap.c",
++    "crypto/fipsmodule/fips_shared_support.c",
+     "crypto/hpke/hpke.c",
+     "crypto/hrss/hrss.c",
+     "crypto/lhash/lhash.c",
+@@ -162,10 +163,10 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/refcount_c11.c",
+     "crypto/refcount_lock.c",
+     "crypto/refcount_win.c",
+-    "crypto/rsa_extra/rsassa_pss_asn1.c",
+     "crypto/rsa_extra/rsa_asn1.c",
+     "crypto/rsa_extra/rsa_crypt.c",
+     "crypto/rsa_extra/rsa_print.c",
++    "crypto/rsa_extra/rsassa_pss_asn1.c",
+     "crypto/siphash/siphash.c",
+     "crypto/spake25519/spake25519.c",
+     "crypto/stack/stack.c",
+@@ -180,11 +181,11 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/ube/ube.c",
+     "crypto/ube/vm_ube_detect.c",
+     "crypto/ui/ui.c",
+-    "crypto/x509/algorithm.c",
+-    "crypto/x509/asn1_gen.c",
+     "crypto/x509/a_digest.c",
+     "crypto/x509/a_sign.c",
+     "crypto/x509/a_verify.c",
++    "crypto/x509/algorithm.c",
++    "crypto/x509/asn1_gen.c",
+     "crypto/x509/by_dir.c",
+     "crypto/x509/by_file.c",
+     "crypto/x509/i2d_pr.c",
+@@ -219,10 +220,6 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/x509/v3_skey.c",
+     "crypto/x509/v3_utl.c",
+     "crypto/x509/x509.c",
+-    "crypto/x509/x509cset.c",
+-    "crypto/x509/x509name.c",
+-    "crypto/x509/x509rset.c",
+-    "crypto/x509/x509spki.c",
+     "crypto/x509/x509_att.c",
+     "crypto/x509/x509_cmp.c",
+     "crypto/x509/x509_d2.c",
+@@ -237,6 +234,10 @@ pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+     "crypto/x509/x509_v3.c",
+     "crypto/x509/x509_vfy.c",
+     "crypto/x509/x509_vpm.c",
++    "crypto/x509/x509cset.c",
++    "crypto/x509/x509name.c",
++    "crypto/x509/x509rset.c",
++    "crypto/x509/x509spki.c",
+     "crypto/x509/x_algor.c",
+     "crypto/x509/x_all.c",
+     "crypto/x509/x_attrib.c",
+diff --git a/builder/cmake_builder.rs b/builder/cmake_builder.rs
+index f9c1cc9f3c912b7b080a64066d4a54c355046b74..d7fc421f77617e5708d830145faee4d6e6064870 100644
+--- a/builder/cmake_builder.rs
++++ b/builder/cmake_builder.rs
+@@ -5,8 +5,9 @@ use crate::cc_builder::CcBuilder;
+ use crate::OutputLib::{Crypto, Ssl};
+ use crate::{
+     allow_prebuilt_nasm, cargo_env, effective_target, emit_warning, execute_command,
+-    get_crate_cflags, is_crt_static, is_fips_build, is_no_asm, is_no_pregenerated_src,
+-    optional_env, optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
++    get_crate_cflags, is_crt_static, is_fips_build, is_ml_dsa_enabled, is_ml_kem_enabled,
++    is_no_asm, is_no_pregenerated_src, is_small_enabled, optional_env,
++    optional_env_optional_crate_target, sanitizer, set_env, set_env_for_target,
+     should_build_jitter_entropy, target, target_arch, target_env, target_is_msvc, target_os,
+     test_clang_cl_command, test_nasm_command, use_prebuilt_nasm, OutputLibType,
+ };
+@@ -171,6 +172,17 @@ impl CmakeBuilder {
+         cmake_cfg.define("BUILD_TESTING", "OFF");
+         cmake_cfg.define("BUILD_TOOL", "OFF");
+         cmake_cfg.define("ENABLE_SOURCE_MODIFICATION", "OFF");
++        cmake_cfg.define(
++            "AWSLC_ENABLE_ML_KEM",
++            if is_ml_kem_enabled() { "ON" } else { "OFF" },
++        );
++        cmake_cfg.define(
++            "AWSLC_ENABLE_ML_DSA",
++            if is_ml_dsa_enabled() { "ON" } else { "OFF" },
++        );
++        if is_small_enabled() {
++            cmake_cfg.define("OPENSSL_SMALL", "1");
++        }
+         if cfg!(feature = "ssl") {
+             cmake_cfg.define("BUILD_LIBSSL", "ON");
+         } else {
+diff --git a/builder/main.rs b/builder/main.rs
+index 2296f8b733bd110cf1e60b9188b09d2a3b76ee0d..9f828f873c19e67270c037bdbf8ce0f97e9f3d29 100644
+--- a/builder/main.rs
++++ b/builder/main.rs
+@@ -131,6 +131,30 @@ fn is_fips_crate() -> bool {
+     crate_name().contains("fips")
+ }
+ 
++fn cargo_feature_enabled(feature: &str) -> bool {
++    env::var_os(format!(
++        "CARGO_FEATURE_{}",
++        feature.replace('-', "_").to_ascii_uppercase()
++    ))
++    .is_some()
++}
++
++pub(crate) fn is_ml_kem_enabled() -> bool {
++    is_fips_build() || cargo_feature_enabled("ml-kem")
++}
++
++pub(crate) fn is_ml_dsa_enabled() -> bool {
++    is_fips_build() || cargo_feature_enabled("ml-dsa")
++}
++
++pub(crate) fn is_freestanding_target() -> bool {
++    !is_fips_build() && target_os() == "none"
++}
++
++pub(crate) fn is_small_enabled() -> bool {
++    cargo_feature_enabled("small")
++}
++
+ fn is_all_bindings() -> bool {
+     is_fips_crate() || env::var("CARGO_FEATURE_ALL_BINDINGS").is_ok()
+ }
+@@ -388,7 +412,6 @@ fn target_chokes_on_u1() -> bool {
+     target_arch() == "mips" || target_arch() == "mips64" || is_cranelift_backend()
+ }
+ 
+-#[cfg(any(feature = "bindgen", feature = "fips"))]
+ fn target_platform_prefix(name: &str) -> String {
+     if is_all_bindings() {
+         format!("{}_{}", effective_target().replace('-', "_"), name)
+@@ -1005,6 +1028,9 @@ fn should_build_jitter_entropy() -> bool {
+     }
+ 
+     *AVAILABLE.get_or_init(|| {
++        if is_freestanding_target() {
++            return false;
++        }
+         // wasm/emscripten targets do not support CPU jitter entropy.
+         if target_arch().starts_with("wasm") {
+             return false;
+@@ -1199,6 +1225,36 @@ fn is_crt_static() -> bool {
+     features.contains("crt-static")
+ }
+ 
++fn prepare_core_bindings(manifest_dir: &Path) -> bool {
++    if !has_pregenerated() {
++        return false;
++    }
++
++    let src_bindings_path = manifest_dir
++        .join("src")
++        .join(format!("{}.rs", target_platform_prefix("crypto")));
++    let mut bindings = std::fs::read_to_string(&src_bindings_path)
++        .unwrap_or_else(|error| panic!("failed to read {}: {error}", src_bindings_path.display()))
++        .replace("::std::os::raw::", "::core::ffi::")
++        .replace(":: std :: os :: raw ::", ":: core :: ffi ::")
++        .replace("::std::", "::core::")
++        .replace(":: std ::", ":: core ::");
++    if let Some(start) = bindings.find("#![allow(") {
++        let end = bindings[start..].find(")]").unwrap_or_else(|| {
++            panic!(
++                "unterminated allow attribute in {}",
++                src_bindings_path.display()
++            )
++        });
++        bindings.replace_range(start..start + end + 2, "");
++    }
++    let gen_bindings_path = out_dir().join("bindings.rs");
++    std::fs::write(&gen_bindings_path, bindings)
++        .unwrap_or_else(|error| panic!("failed to write {}: {error}", gen_bindings_path.display()));
++    emit_rustc_cfg("use_bindgen_pregenerated");
++    true
++}
++
+ #[cfg(any(feature = "bindgen", feature = "fips"))]
+ fn handle_bindgen(manifest_dir: &Path, prefix: &Option<String>) -> bool {
+     if internal_bindgen_supported() && !is_external_bindgen_requested().unwrap_or(false) {
+@@ -1299,6 +1355,8 @@ fn main() {
+             }
+             bindings_available = true;
+         }
++    } else if prepare_core_bindings(&manifest_dir) {
++        bindings_available = true;
+     } else if is_bindgen_required() {
+         assert!(
+             use_no_u1_bindings() != Some(true),
+diff --git a/builder/sys_bindgen.rs b/builder/sys_bindgen.rs
+index 8d5d5eff57086e58f4817bbf25c63c0e64489529..4fce3148268854846e8000dbfcfd0d3c55191eed 100644
+--- a/builder/sys_bindgen.rs
++++ b/builder/sys_bindgen.rs
+@@ -83,6 +83,7 @@ fn prepare_bindings_builder(manifest_dir: &Path, options: &BindingOptions) -> bi
+     let clang_args = crate::prepare_clang_args(manifest_dir, options);
+ 
+     let mut builder = bindgen::Builder::default()
++        .use_core()
+         .derive_copy(true)
+         .derive_debug(true)
+         .derive_default(true)
+diff --git a/feature-tests/.gitignore b/feature-tests/.gitignore
+new file mode 100644
+index 0000000000000000000000000000000000000000..35709a7c97d3d22822a2a85a729d77718ebd1eba
+--- /dev/null
++++ b/feature-tests/.gitignore
+@@ -0,0 +1,2 @@
++*/Cargo.lock
++*/target/
+diff --git a/feature-tests/ml-dsa-disabled/Cargo.toml b/feature-tests/ml-dsa-disabled/Cargo.toml
+new file mode 100644
+index 0000000000000000000000000000000000000000..76478fe71c527d9fb80612a2730a3f3fdbc456d8
+--- /dev/null
++++ b/feature-tests/ml-dsa-disabled/Cargo.toml
+@@ -0,0 +1,13 @@
++[package]
++name = "ml-dsa-disabled"
++version = "0.0.0"
++edition = "2021"
++publish = false
++
++[dependencies]
++aws-lc-rs = { path = "../../aws-lc-rs", default-features = false, features = [
++    "aws-lc-sys",
++    "unstable",
++] }
++
++[workspace]
+diff --git a/feature-tests/ml-dsa-disabled/src/main.rs b/feature-tests/ml-dsa-disabled/src/main.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..a0506fef05ab7eda1f08bdfb5869a3d7b8c82809
+--- /dev/null
++++ b/feature-tests/ml-dsa-disabled/src/main.rs
+@@ -0,0 +1,3 @@
++fn main() {
++    let _ = aws_lc_rs::unstable::signature::ML_DSA_44;
++}
+diff --git a/feature-tests/ml-kem-disabled/Cargo.toml b/feature-tests/ml-kem-disabled/Cargo.toml
+new file mode 100644
+index 0000000000000000000000000000000000000000..dd73a7eec910aeb5bc5e4791ec752628e2211fd2
+--- /dev/null
++++ b/feature-tests/ml-kem-disabled/Cargo.toml
+@@ -0,0 +1,12 @@
++[package]
++name = "ml-kem-disabled"
++version = "0.0.0"
++edition = "2021"
++publish = false
++
++[dependencies]
++aws-lc-rs = { path = "../../aws-lc-rs", default-features = false, features = [
++    "aws-lc-sys",
++] }
++
++[workspace]
+diff --git a/feature-tests/ml-kem-disabled/src/main.rs b/feature-tests/ml-kem-disabled/src/main.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..de39c7d6e1eee6656b195436d2475ba93cb92db2
+--- /dev/null
++++ b/feature-tests/ml-kem-disabled/src/main.rs
+@@ -0,0 +1,3 @@
++fn main() {
++    let _ = aws_lc_rs::kem::ML_KEM_512;
++}
+diff --git a/no-std-runtime-test/Cargo.toml b/no-std-runtime-test/Cargo.toml
+new file mode 100644
+index 0000000000000000000000000000000000000000..db540864b265cff15d18b1fc118fdb8a7e72a63c
+--- /dev/null
++++ b/no-std-runtime-test/Cargo.toml
+@@ -0,0 +1,14 @@
++[package]
++name = "no-std-runtime-test"
++version = "0.0.0"
++edition = "2021"
++publish = false
++
++[dependencies]
++aws-lc-rs = { path = "../aws-lc-rs", default-features = false, features = [
++    "alloc",
++    "aws-lc-sys",
++    "small",
++] }
++
++[build-dependencies]
+diff --git a/no-std-runtime-test/build.rs b/no-std-runtime-test/build.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..7fc7432276c70f19f4f4f07c8e31d35904eb23a4
+--- /dev/null
++++ b/no-std-runtime-test/build.rs
+@@ -0,0 +1,16 @@
++use std::env;
++use std::path::PathBuf;
++
++fn main() {
++    let target = env::var("TARGET").expect("Cargo must set TARGET");
++    if target != "x86_64-unknown-none" {
++        panic!("no-std-runtime-test must target x86_64-unknown-none");
++    }
++
++    let linker_script = PathBuf::from(
++        env::var_os("CARGO_MANIFEST_DIR").expect("Cargo must set CARGO_MANIFEST_DIR"),
++    )
++    .join("link.x");
++    println!("cargo:rustc-link-arg=-T{}", linker_script.display());
++    println!("cargo:rerun-if-changed=link.x");
++}
+diff --git a/no-std-runtime-test/link.x b/no-std-runtime-test/link.x
+new file mode 100644
+index 0000000000000000000000000000000000000000..512e066ae34c247f021310f107fec17436b375ac
+--- /dev/null
++++ b/no-std-runtime-test/link.x
+@@ -0,0 +1,10 @@
++ENTRY(_start)
++
++SECTIONS
++{
++  . = 1M;
++  .text : { *(.text .text.*) }
++  .rodata : { *(.rodata .rodata.*) }
++  .data : { *(.data .data.*) }
++  .bss : { *(.bss .bss.*) *(COMMON) }
++}
+diff --git a/no-std-runtime-test/src/main.rs b/no-std-runtime-test/src/main.rs
+new file mode 100644
+index 0000000000000000000000000000000000000000..3edb81a276fd22c9d909c3f0f895acce5afbed7a
+--- /dev/null
++++ b/no-std-runtime-test/src/main.rs
+@@ -0,0 +1,115 @@
++#![no_main]
++#![no_std]
++
++use aws_lc_rs::digest;
++use core::alloc::{GlobalAlloc, Layout};
++use core::cmp::min;
++use core::panic::PanicInfo;
++use core::ptr::{copy_nonoverlapping, null_mut};
++
++const HEAP_SIZE: usize = 256 * 1024;
++
++#[repr(align(16))]
++struct AlignedHeap([u8; HEAP_SIZE]);
++
++static mut HEAP: AlignedHeap = AlignedHeap([0; HEAP_SIZE]);
++static mut NEXT: usize = 0;
++static mut ENTROPY_STATE: u64 = 0x4d59_5df4_d0f3_3173;
++
++struct PlatformAllocator;
++
++unsafe impl GlobalAlloc for PlatformAllocator {
++    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
++        aws_lc_nostd_alloc(layout.size(), layout.align())
++    }
++
++    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
++        aws_lc_nostd_dealloc(ptr, layout.size(), layout.align());
++    }
++
++    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
++        aws_lc_nostd_realloc(ptr, layout.size(), new_size, layout.align())
++    }
++}
++
++#[global_allocator]
++static ALLOCATOR: PlatformAllocator = PlatformAllocator;
++
++#[no_mangle]
++extern "C" fn aws_lc_nostd_alloc(size: usize, align: usize) -> *mut u8 {
++    let Ok(layout) = Layout::from_size_align(size, align) else {
++        return null_mut();
++    };
++
++    unsafe {
++        let Some(start) = NEXT
++            .checked_add(layout.align() - 1)
++            .map(|value| value & !(layout.align() - 1))
++        else {
++            return null_mut();
++        };
++        let Some(end) = start.checked_add(layout.size()) else {
++            return null_mut();
++        };
++        if end > HEAP_SIZE {
++            return null_mut();
++        }
++        NEXT = end;
++        core::ptr::addr_of_mut!(HEAP).cast::<u8>().add(start)
++    }
++}
++
++#[no_mangle]
++extern "C" fn aws_lc_nostd_dealloc(_ptr: *mut u8, _size: usize, _align: usize) {}
++
++#[no_mangle]
++unsafe extern "C" fn aws_lc_nostd_realloc(
++    ptr: *mut u8,
++    old_size: usize,
++    new_size: usize,
++    align: usize,
++) -> *mut u8 {
++    let replacement = aws_lc_nostd_alloc(new_size, align);
++    if !replacement.is_null() {
++        copy_nonoverlapping(ptr, replacement, min(old_size, new_size));
++    }
++    replacement
++}
++
++#[no_mangle]
++unsafe extern "C" fn aws_lc_nostd_entropy(out: *mut u8, len: usize) -> i32 {
++    // Deterministic test data proves the hook is linked; it is not production entropy.
++    for index in 0..len {
++        ENTROPY_STATE ^= ENTROPY_STATE << 13;
++        ENTROPY_STATE ^= ENTROPY_STATE >> 7;
++        ENTROPY_STATE ^= ENTROPY_STATE << 17;
++        out.add(index).write(ENTROPY_STATE as u8);
++    }
++    1
++}
++
++#[no_mangle]
++extern "C" fn aws_lc_nostd_time() -> i64 {
++    0
++}
++
++#[no_mangle]
++extern "C" fn aws_lc_nostd_abort() -> ! {
++    loop {
++        unsafe { core::arch::asm!("hlt") };
++    }
++}
++
++#[panic_handler]
++fn panic(_info: &PanicInfo<'_>) -> ! {
++    aws_lc_nostd_abort()
++}
++
++#[no_mangle]
++extern "C" fn _start() -> ! {
++    let value = digest::digest(&digest::SHA256, b"aws-lc-rs no-std link test");
++    unsafe {
++        core::ptr::write_volatile(&raw mut NEXT, NEXT ^ usize::from(value.as_ref()[0]));
++    }
++    aws_lc_nostd_abort()
++}
+diff --git a/scripts/build/collect_build_src.sh b/scripts/build/collect_build_src.sh
+index 03a1a77f7ca5c68f99f0eef3670a9e302e56f2f1..a992dadaf7e9147dbc397e443287fcc370d088e8 100755
+--- a/scripts/build/collect_build_src.sh
++++ b/scripts/build/collect_build_src.sh
+@@ -3,15 +3,15 @@
+ # SPDX-License-Identifier: Apache-2.0 OR ISC
+ 
+ # This shell script performs a target-specific CMake static build of libcrypto. It extracts from that build artifact
+-# debug information on the complete set of source files utilized for the build and then generates a target-specific
+-# Rust source file (e.g., `x86_64_unknown_linux_gnu.rs`) that lists the files for subsequent use by the `cc_builder`
+-# module for consumer builds where CMake might not be available.
++# debug information on the complete set of source files utilized for the build and then generates Rust source files
++# containing the universal C sources and target-specific assembly sources used by cc_builder when CMake is
++# unavailable.
+ 
+ set -ex
+ set -o pipefail
+ 
+ if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+-    echo Must use bash 4 or later: ${BASH_VERSION}
++    echo Must use bash 4 or later: "${BASH_VERSION}"
+     exit 1
+ fi
+ 
+@@ -38,16 +38,28 @@ mkdir -p "${BUILD_CFG_DIR}"
+ 
+ function find_target() {
+   if [[ -z "${CROSS_TARGET_ARCH}" ]]; then
+-    rustc -vV | grep host | sed -e 's/host: *\(\w*\)/\1/'
++    rustc -vV | sed -n 's/^host: //p'
+   else
+     echo "${CROSS_TARGET_ARCH}"
+   fi
+ }
+ 
+-function target_filename() {
++function platform_filename() {
+   local target
+   target=$(find_target)
+-  echo "${target//-/_}"
++  case "${target}" in
++    x86_64*-linux-*) echo "linux_x86_64" ;;
++    i?86*-linux-*) echo "linux_x86" ;;
++    aarch64*-linux-*) echo "linux_aarch64" ;;
++    arm*-linux-*) echo "linux_arm" ;;
++    powerpc64le*-linux-*) echo "linux_ppc64le" ;;
++    x86_64*-apple-*) echo "apple_x86_64" ;;
++    aarch64*-apple-*) echo "apple_aarch64" ;;
++    *)
++      echo "Unsupported source-list target: ${target}" >&2
++      return 1
++      ;;
++  esac
+ }
+ 
+ function collect_source_files() {
+@@ -163,20 +175,13 @@ function generate_output() {
+ // SPDX-License-Identifier: Apache-2.0 OR ISC
+ // $TIMESTAMP
+ 
+-use crate::cc_builder::Library;
+-
+-pub(super) const CRYPTO_LIBRARY: Library = Library {
+-    name: "crypto",
+-    // This attribute is intentionally let blank
+-    flags: &[],
+-    sources: &[
++pub(super) const CRYPTO_LIBRARY: &[&str] = &[
+ EOF
+     for FILE in "${@}"; do
+-        echo "        \"${FILE}\","
++        echo "    \"${FILE}\","
+     done
+     cat << EOF
+-    ],
+-};
++];
+ EOF
+ }
+ 
+@@ -189,7 +194,7 @@ AWS_LC_SYS_CMAKE_BUILDER=1 AWS_LC_SYS_CC_SRC_COLLECTOR=1 cargo build --package a
+ else
+ # Install cross
+ cargo install cross --locked --git https://github.com/cross-rs/cross
+-AWS_LC_SYS_CMAKE_BUILDER=1 AWS_LC_SYS_CC_SRC_COLLECTOR=1 cross build --package aws-lc-sys --profile dev --target ${CROSS_TARGET_ARCH} --features bindgen
++AWS_LC_SYS_CMAKE_BUILDER=1 AWS_LC_SYS_CC_SRC_COLLECTOR=1 cross build --package aws-lc-sys --profile dev --target "${CROSS_TARGET_ARCH}" --features bindgen
+ fi
+ 
+ if [[ -z "${CROSS_TARGET_ARCH}" ]]; then
+@@ -199,31 +204,39 @@ LIB_CRYPTO_PATH=$(find target/"${CROSS_TARGET_ARCH}" -name "libaws_lc_0_*crypto.
+ fi
+ LIB_CRYPTO_PATH="${REPO_ROOT}/${LIB_CRYPTO_PATH}"
+ 
+-SOURCE_FILES=($(collect_source_files "${LIB_CRYPTO_PATH}"))
+-if [ $? -eq 1 ]; then
+-  echo "Error: collect_source_files failed"
+-  exit 1
+-fi
++SOURCE_FILES_OUTPUT=$(collect_source_files "${LIB_CRYPTO_PATH}")
++mapfile -t SOURCE_FILES <<< "${SOURCE_FILES_OUTPUT}"
+ 
+ # Both "refcount_lock.c" and "refcount_c11.c" should always be listed, even though only one may provide implementations
+ SOURCE_FILES+=("crypto/refcount_lock.c")
+ SOURCE_FILES+=("crypto/refcount_c11.c")
+ 
+-PROCESSED_SRC_FILES=($(process_source_files "${SOURCE_FILES[@]}"))
+-if [ $? -eq 1 ]; then
+-  echo "Error: process_source_files failed"
+-  exit 1
+-fi
++PROCESSED_SRC_FILES_OUTPUT=$(process_source_files "${SOURCE_FILES[@]}")
++mapfile -t PROCESSED_SRC_FILES <<< "${PROCESSED_SRC_FILES_OUTPUT}"
+ 
+ verify_source_files "${PROCESSED_SRC_FILES[@]}"
+ 
+-RUST_TRIPLE=$(target_filename)
+-BUILD_CFG_PATH="${BUILD_CFG_DIR}/${RUST_TRIPLE}.rs"
++UNIVERSAL_SOURCE_FILES=()
++TARGET_SOURCE_FILES=()
++for FILE in "${PROCESSED_SRC_FILES[@]}"; do
++  if [[ "${FILE}" == *.c ]]; then
++    UNIVERSAL_SOURCE_FILES+=("${FILE}")
++  else
++    TARGET_SOURCE_FILES+=("${FILE}")
++  fi
++done
++
++PLATFORM=$(platform_filename)
++UNIVERSAL_BUILD_CFG_PATH="${BUILD_CFG_DIR}/universal.rs"
++TARGET_BUILD_CFG_PATH="${BUILD_CFG_DIR}/${PLATFORM}.rs"
+ 
+-generate_output ${PROCESSED_SRC_FILES[@]} > ${BUILD_CFG_PATH}
++generate_output "${UNIVERSAL_SOURCE_FILES[@]}" > "${UNIVERSAL_BUILD_CFG_PATH}"
++generate_output "${TARGET_SOURCE_FILES[@]}" > "${TARGET_BUILD_CFG_PATH}"
+ 
+ echo
+-echo Build configuration written to: ${BUILD_CFG_PATH}
++echo Build configurations written to:
++echo "  ${UNIVERSAL_BUILD_CFG_PATH}"
++echo "  ${TARGET_BUILD_CFG_PATH}"
+ echo
+ 
+ cargo clean
+@@ -231,8 +244,8 @@ if [[ -z "${CROSS_TARGET_ARCH}" ]]; then
+   AWS_LC_SYS_CMAKE_BUILDER=0 cargo test --package aws-lc-sys --profile dev
+   AWS_LC_SYS_CMAKE_BUILDER=0 cargo test --package aws-lc-rs --profile dev
+ else
+-  AWS_LC_SYS_CMAKE_BUILDER=0 cross test --package aws-lc-sys --profile dev --target ${CROSS_TARGET_ARCH}
+-  AWS_LC_SYS_CMAKE_BUILDER=0 cross test --package aws-lc-rs --profile dev --target ${CROSS_TARGET_ARCH}
++  AWS_LC_SYS_CMAKE_BUILDER=0 cross test --package aws-lc-sys --profile dev --target "${CROSS_TARGET_ARCH}"
++  AWS_LC_SYS_CMAKE_BUILDER=0 cross test --package aws-lc-rs --profile dev --target "${CROSS_TARGET_ARCH}"
+ fi
+ popd
+ 

--- a/external/patches/aws-lc-rs/README.md
+++ b/external/patches/aws-lc-rs/README.md
@@ -1,0 +1,42 @@
+# AWS-LC patches
+
+These patches add the `no_std` and native build support required to use
+AWS-LC on bare-metal targets such as `x86_64-unknown-none`. They also provide
+the algorithm-scoped AWS-LC profile used by `spdmlib_crypto_aws_lc`.
+
+## Pinned bases
+
+- aws-lc-rs: `9232f4df246` (`v1.17.3`)
+- AWS-LC: `683ebde4b` (`v5.2.0`)
+
+The aws-lc-rs patch intentionally excludes the `aws-lc-sys/aws-lc` gitlink
+change. This keeps the patch independent of private fork commits. The patches
+use zero context because they target exact commits and are stored as new files
+in this repository. Apply the native AWS-LC patch inside the nested submodule
+before applying the aws-lc-rs patch:
+
+```sh
+git checkout 9232f4df246
+git submodule update --init aws-lc-sys/aws-lc
+
+git -C aws-lc-sys/aws-lc apply --unidiff-zero \
+  ../../../patches/aws-lc-rs/aws-lc/0001-build-aws-lc-add-no-std-bare-metal-support.patch
+git apply --unidiff-zero \
+  ../patches/aws-lc-rs/0001-feat-aws-lc-rs-add-no-std-bare-metal-support.patch
+```
+
+Paths above assume the commands are run from `external/aws-lc-rs` in an
+spdm-rs checkout.
+
+## Readiness
+
+The patches apply cleanly to the pinned public bases. The resulting source has
+passed default debug and release tests, all four ML-KEM/ML-DSA feature
+combinations, cc and CMake whole-archive links, FIPS checks, the final-linked
+`x86_64-unknown-none` fixture, and a complete consumer build and test pipeline.
+
+Treat the base commits as part of the production dependency lock. As of
+2026-08-12, neither patch applies directly to current upstream `main`
+(aws-lc-rs is 17 commits ahead of its base and AWS-LC is 40 commits ahead).
+Rebase, regenerate bindings, and repeat the validation matrix before updating
+either base or submitting the patches upstream.

--- a/external/patches/aws-lc-rs/aws-lc/0001-build-aws-lc-add-no-std-bare-metal-support.patch
+++ b/external/patches/aws-lc-rs/aws-lc/0001-build-aws-lc-add-no-std-bare-metal-support.patch
@@ -1,0 +1,394 @@
+From 2b2717ffedc9aad254e58b2e390824702b84ca13 Mon Sep 17 00:00:00 2001
+From: Stanislaw Grams <stanislaw.grams@intel.com>
+Date: Fri, 7 Aug 2026 16:39:18 +0200
+Subject: [PATCH] build: add no_std bare-metal target support
+
+---
+ CMakeLists.txt                            | 15 ++++++++++++
+ crypto/CMakeLists.txt                     | 30 ++++++++++++++++++-----
+ crypto/evp_extra/evp_asn1.c               |  8 +++++-
+ crypto/evp_extra/evp_extra_test.cc        |  4 +++
+ crypto/evp_extra/p_kem_test.cc            |  2 ++
+ crypto/evp_extra/p_methods.c              | 28 ++++++++++-----------
+ crypto/fips_callback_test.cc              |  8 ++++++
+ crypto/fipsmodule/CMakeLists.txt          |  6 ++---
+ crypto/fipsmodule/bcm.c                   | 12 +++++++++
+ crypto/fipsmodule/evp/evp.c               |  2 +-
+ crypto/fipsmodule/evp/evp_ctx.c           | 11 ++++++++-
+ crypto/fipsmodule/self_check/self_check.c | 18 +++++++++++---
+ crypto/internal.h                         | 18 ++++++++++++++
+ crypto/x509/x509_test.cc                  |  4 +++
+ include/openssl/target.h                  | 11 +++++++++
+ ssl/extensions.cc                         |  6 +++++
+ ssl/ssl_key_share.cc                      | 18 ++++++++++++++
+ ssl/ssl_privkey.cc                        |  2 ++
+ 18 files changed, 172 insertions(+), 31 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2305bdd7f..22ebd2224 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -621,0 +622,15 @@ option(MY_ASSEMBLER_IS_TOO_OLD_FOR_512AVX "Exclude AVX512 code from the build" O
++option(AWSLC_ENABLE_ML_KEM "Build ML-KEM support" ON)
++option(AWSLC_ENABLE_ML_DSA "Build ML-DSA support" ON)
++
++if(AWSLC_ENABLE_ML_KEM)
++  add_definitions(-DAWSLC_ENABLE_ML_KEM=1)
++else()
++  add_definitions(-DAWSLC_ENABLE_ML_KEM=0)
++endif()
++
++if(AWSLC_ENABLE_ML_DSA)
++  add_definitions(-DAWSLC_ENABLE_ML_DSA=1)
++else()
++  add_definitions(-DAWSLC_ENABLE_ML_DSA=0)
++endif()
++
+diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+index ade407902..df00bac83 100644
+--- a/crypto/CMakeLists.txt
++++ b/crypto/CMakeLists.txt
+@@ -319,0 +320,8 @@ endif()
++set(PQC_CRYPTO_SOURCES "")
++if(AWSLC_ENABLE_ML_KEM)
++  list(APPEND PQC_CRYPTO_SOURCES evp_extra/p_kem_asn1.c)
++endif()
++if(AWSLC_ENABLE_ML_DSA)
++  list(APPEND PQC_CRYPTO_SOURCES evp_extra/p_pqdsa_asn1.c)
++endif()
++
+@@ -415,2 +423 @@ add_library(
+-  evp_extra/p_kem_asn1.c
+-  evp_extra/p_pqdsa_asn1.c
++  ${PQC_CRYPTO_SOURCES}
+@@ -726,0 +734,14 @@ if(BUILD_TESTING)
++  set(PQC_CRYPTO_TEST_SOURCES "")
++  if(AWSLC_ENABLE_ML_KEM)
++    list(APPEND PQC_CRYPTO_TEST_SOURCES
++      evp_extra/p_kem_test.cc
++      fipsmodule/ml_kem/ml_kem_test.cc
++    )
++  endif()
++  if(AWSLC_ENABLE_ML_DSA)
++    list(APPEND PQC_CRYPTO_TEST_SOURCES
++      evp_extra/mldsa_test.cc
++      evp_extra/p_pqdsa_test.cc
++    )
++  endif()
++
+@@ -797,2 +817,0 @@ if(BUILD_TESTING)
+-    evp_extra/p_pqdsa_test.cc
+-    evp_extra/p_kem_test.cc
+@@ -800 +818,0 @@ if(BUILD_TESTING)
+-    evp_extra/mldsa_test.cc
+@@ -814 +831,0 @@ if(BUILD_TESTING)
+-    fipsmodule/ml_kem/ml_kem_test.cc
+@@ -865,0 +883 @@ if(BUILD_TESTING)
++    ${PQC_CRYPTO_TEST_SOURCES}
+diff --git a/crypto/evp_extra/evp_asn1.c b/crypto/evp_extra/evp_asn1.c
+index b3b84cb98..bb1f5a2cf 100644
+--- a/crypto/evp_extra/evp_asn1.c
++++ b/crypto/evp_extra/evp_asn1.c
+@@ -42 +42 @@ static const EVP_PKEY_ASN1_METHOD *parse_key_type(CBS *cbs, CBS *out_oid) {
+-  for (size_t i = 0; i < ASN1_EVP_PKEY_METHODS; i++) {
++  for (size_t i = 0; i < asn1_evp_pkey_methods_size; i++) {
+@@ -63,0 +64 @@ static const EVP_PKEY_ASN1_METHOD *parse_key_type(CBS *cbs, CBS *out_oid) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -67,0 +69,2 @@ static const EVP_PKEY_ASN1_METHOD *parse_key_type(CBS *cbs, CBS *out_oid) {
++#endif
++#if AWSLC_ENABLE_ML_KEM
+@@ -68,0 +72,3 @@ static const EVP_PKEY_ASN1_METHOD *parse_key_type(CBS *cbs, CBS *out_oid) {
++#else
++  return NULL;
++#endif
+diff --git a/crypto/evp_extra/evp_extra_test.cc b/crypto/evp_extra/evp_extra_test.cc
+index f7be3db2e..23b7ba963 100644
+--- a/crypto/evp_extra/evp_extra_test.cc
++++ b/crypto/evp_extra/evp_extra_test.cc
+@@ -1509,0 +1510 @@ TEST(EVPExtraTest, d2i_PrivateKey) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -1511,0 +1513 @@ TEST(EVPExtraTest, d2i_PrivateKey) {
++#endif
+@@ -2390,0 +2393 @@ INSTANTIATE_TEST_SUITE_P(All, EVPRsaPssBadKeyTest,
++#if AWSLC_ENABLE_ML_KEM
+@@ -3222,0 +3226 @@ TEST_P(PerMLKEMTest, InputValidation) {
++#endif  // AWSLC_ENABLE_ML_KEM
+diff --git a/crypto/evp_extra/p_kem_test.cc b/crypto/evp_extra/p_kem_test.cc
+index e65f7d854..519e2b86c 100644
+--- a/crypto/evp_extra/p_kem_test.cc
++++ b/crypto/evp_extra/p_kem_test.cc
+@@ -729,0 +730 @@ TEST(KEMTest, GetTypeWrongKeyType) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -742,0 +744 @@ TEST(KEMTest, GetTypeWrongKeyType) {
++#endif  // AWSLC_ENABLE_ML_DSA
+diff --git a/crypto/evp_extra/p_methods.c b/crypto/evp_extra/p_methods.c
+index 203596590..91c34c32b 100644
+--- a/crypto/evp_extra/p_methods.c
++++ b/crypto/evp_extra/p_methods.c
+@@ -17,12 +17,9 @@ const EVP_PKEY_ASN1_METHOD *const asn1_evp_pkey_methods[] = {
+-  &rsa_asn1_meth,
+-  &rsa_pss_asn1_meth,
+-  &ec_asn1_meth,
+-  &dsa_asn1_meth,
+-  &ed25519_asn1_meth,
+-  &x25519_asn1_meth,
+-  &pqdsa_asn1_meth,
+-  &kem_asn1_meth,
+-  &hmac_asn1_meth,
+-  &dh_asn1_meth,
+-  &ed25519ph_asn1_meth
+-};
++    &rsa_asn1_meth,   &rsa_pss_asn1_meth, &ec_asn1_meth,
++    &dsa_asn1_meth,   &ed25519_asn1_meth, &x25519_asn1_meth,
++#if AWSLC_ENABLE_ML_DSA
++    &pqdsa_asn1_meth,
++#endif
++#if AWSLC_ENABLE_ML_KEM
++    &kem_asn1_meth,
++#endif
++    &hmac_asn1_meth,  &dh_asn1_meth,      &ed25519ph_asn1_meth};
+@@ -34,3 +31,4 @@ OPENSSL_STATIC_ASSERT(
+-OPENSSL_STATIC_ASSERT(
+-  ASN1_EVP_PKEY_METHODS == OPENSSL_ARRAY_SIZE(asn1_evp_pkey_methods),
+-  ASN1_EVP_PKEY_METHODS_does_not_have_the_expected_value)
++OPENSSL_STATIC_ASSERT(ASN1_EVP_PKEY_METHODS - !AWSLC_ENABLE_ML_DSA -
++                              !AWSLC_ENABLE_ML_KEM ==
++                          OPENSSL_ARRAY_SIZE(asn1_evp_pkey_methods),
++                      ASN1_EVP_PKEY_METHODS_does_not_have_the_expected_value)
+diff --git a/crypto/fips_callback_test.cc b/crypto/fips_callback_test.cc
+index 82de6ff13..f73180cc7 100644
+--- a/crypto/fips_callback_test.cc
++++ b/crypto/fips_callback_test.cc
+@@ -99,0 +100 @@ TEST(FIPSCallback, PowerOnSelfTests) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -106,0 +108 @@ TEST(FIPSCallback, PowerOnSelfTests) {
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -116,0 +119 @@ TEST(FIPSCallback, PowerOnSelfTests) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -123,0 +127 @@ TEST(FIPSCallback, PowerOnSelfTests) {
++#endif  // AWSLC_ENABLE_ML_DSA
+@@ -160,0 +165 @@ TEST(FIPSCallback, PWCT) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -171,0 +177 @@ TEST(FIPSCallback, PWCT) {
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -172,0 +179 @@ TEST(FIPSCallback, PWCT) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -184,0 +192 @@ TEST(FIPSCallback, PWCT) {
++#endif  // AWSLC_ENABLE_ML_DSA
+diff --git a/crypto/fipsmodule/CMakeLists.txt b/crypto/fipsmodule/CMakeLists.txt
+index cee9476d8..4d2fae65a 100644
+--- a/crypto/fipsmodule/CMakeLists.txt
++++ b/crypto/fipsmodule/CMakeLists.txt
+@@ -407 +407 @@ endif()
+-if((ARCH STREQUAL "aarch64") AND UNIX)
++if(AWSLC_ENABLE_ML_KEM AND (ARCH STREQUAL "aarch64") AND UNIX)
+@@ -430 +430 @@ endif()
+-if((ARCH STREQUAL "x86_64") AND UNIX AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
++if(AWSLC_ENABLE_ML_KEM AND (ARCH STREQUAL "x86_64") AND UNIX AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX)
+@@ -467 +467 @@ endif()
+-if(UNIX AND ((ARCH STREQUAL "x86_64" AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR (ARCH STREQUAL "aarch64")))
++if(AWSLC_ENABLE_ML_DSA AND UNIX AND ((ARCH STREQUAL "x86_64" AND NOT MY_ASSEMBLER_IS_TOO_OLD_FOR_AVX) OR (ARCH STREQUAL "aarch64")))
+diff --git a/crypto/fipsmodule/bcm.c b/crypto/fipsmodule/bcm.c
+index 00a58c284..f102311d4 100644
+--- a/crypto/fipsmodule/bcm.c
++++ b/crypto/fipsmodule/bcm.c
+@@ -115,0 +116 @@
++#if AWSLC_ENABLE_ML_KEM
+@@ -116,0 +118,2 @@
++#endif
++#if AWSLC_ENABLE_ML_DSA
+@@ -117,0 +121 @@
++#endif
+@@ -122,0 +127 @@
++#if AWSLC_ENABLE_ML_KEM
+@@ -123,0 +129 @@
++#endif
+@@ -124,0 +131 @@
++#if AWSLC_ENABLE_ML_DSA
+@@ -125,0 +133,2 @@
++#endif
++#if AWSLC_ENABLE_ML_KEM
+@@ -126,0 +136 @@
++#endif
+@@ -135,0 +146 @@
++#if AWSLC_ENABLE_ML_DSA
+@@ -136,0 +148 @@
++#endif
+diff --git a/crypto/fipsmodule/evp/evp.c b/crypto/fipsmodule/evp/evp.c
+index 9dce9f37f..fffe62e1b 100644
+--- a/crypto/fipsmodule/evp/evp.c
++++ b/crypto/fipsmodule/evp/evp.c
+@@ -305 +305 @@ static const EVP_PKEY_ASN1_METHOD *evp_pkey_asn1_find(int nid) {
+-  for (size_t i = 0; i < ASN1_EVP_PKEY_METHODS; i++) {
++  for (size_t i = 0; i < asn1_evp_pkey_methods_size; i++) {
+diff --git a/crypto/fipsmodule/evp/evp_ctx.c b/crypto/fipsmodule/evp/evp_ctx.c
+index c90a99731..6b80b3152 100644
+--- a/crypto/fipsmodule/evp/evp_ctx.c
++++ b/crypto/fipsmodule/evp/evp_ctx.c
+@@ -23,0 +24 @@ DEFINE_LOCAL_DATA(struct fips_evp_pkey_methods, AWSLC_fips_evp_pkey_methods) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -24,0 +26,4 @@ DEFINE_LOCAL_DATA(struct fips_evp_pkey_methods, AWSLC_fips_evp_pkey_methods) {
++#else
++  out->methods[6] = NULL;
++#endif
++#if AWSLC_ENABLE_ML_DSA
+@@ -25,0 +31,3 @@ DEFINE_LOCAL_DATA(struct fips_evp_pkey_methods, AWSLC_fips_evp_pkey_methods) {
++#else
++  out->methods[7] = NULL;
++#endif
+@@ -35 +43,2 @@ static const EVP_PKEY_METHOD *evp_pkey_meth_find(int type) {
+-    if (fips_methods->methods[i]->pkey_id == type) {
++    if (fips_methods->methods[i] != NULL &&
++        fips_methods->methods[i]->pkey_id == type) {
+diff --git a/crypto/fipsmodule/self_check/self_check.c b/crypto/fipsmodule/self_check/self_check.c
+index f86f1f957..e5b10eb3b 100644
+--- a/crypto/fipsmodule/self_check/self_check.c
++++ b/crypto/fipsmodule/self_check/self_check.c
+@@ -800,0 +801 @@ err:
++#if AWSLC_ENABLE_ML_KEM
+@@ -1500,0 +1502 @@ err:
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -1501,0 +1504 @@ err:
++#if AWSLC_ENABLE_ML_DSA
+@@ -2305,0 +2309 @@ static OPENSSL_NOINLINE int boringssl_self_test_ml_dsa(void) {
++#endif  // AWSLC_ENABLE_ML_DSA
+@@ -2479,0 +2484 @@ void boringssl_ensure_ffdh_self_test(void) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -2490,0 +2496 @@ void boringssl_ensure_ml_kem_self_test(void) {
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -2491,0 +2498 @@ void boringssl_ensure_ml_kem_self_test(void) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -2502,0 +2510 @@ void boringssl_ensure_ml_dsa_self_test(void) {
++#endif  // AWSLC_ENABLE_ML_DSA
+@@ -3025,2 +3033 @@ int BORINGSSL_self_test(void) {
+-      !boringssl_self_test_rsa() ||
+-      !boringssl_self_test_ecc() ||
++      !boringssl_self_test_rsa() || !boringssl_self_test_ecc() ||
+@@ -3027,0 +3035 @@ int BORINGSSL_self_test(void) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -3028,0 +3037,2 @@ int BORINGSSL_self_test(void) {
++#endif
++#if AWSLC_ENABLE_ML_DSA
+@@ -3030,2 +3040,2 @@ int BORINGSSL_self_test(void) {
+-      !boringssl_self_test_eddsa() ||
+-      !boringssl_self_test_hasheddsa()) {
++#endif
++      !boringssl_self_test_eddsa() || !boringssl_self_test_hasheddsa()) {
+diff --git a/crypto/internal.h b/crypto/internal.h
+index 1f7ad6781..dc9394510 100644
+--- a/crypto/internal.h
++++ b/crypto/internal.h
+@@ -16,0 +17,10 @@
++// Build systems may disable individual post-quantum algorithms. Default to
++// the full AWS-LC algorithm set when no selection is provided.
++#if !defined(AWSLC_ENABLE_ML_KEM)
++#define AWSLC_ENABLE_ML_KEM 1
++#endif
++
++#if !defined(AWSLC_ENABLE_ML_DSA)
++#define AWSLC_ENABLE_ML_DSA 1
++#endif
++
+@@ -1234,0 +1245 @@ void boringssl_ensure_ffdh_self_test(void);
++#if AWSLC_ENABLE_ML_KEM
+@@ -1238,0 +1250 @@ void boringssl_ensure_ml_kem_self_test(void);
++#endif
+@@ -1239,0 +1252 @@ void boringssl_ensure_ml_kem_self_test(void);
++#if AWSLC_ENABLE_ML_DSA
+@@ -1243,0 +1257 @@ void boringssl_ensure_ml_dsa_self_test(void);
++#endif
+@@ -1261,0 +1276 @@ OPENSSL_INLINE void boringssl_ensure_ffdh_self_test(void) {}
++#if AWSLC_ENABLE_ML_KEM
+@@ -1262,0 +1278,2 @@ OPENSSL_INLINE void boringssl_ensure_ml_kem_self_test(void) {}
++#endif
++#if AWSLC_ENABLE_ML_DSA
+@@ -1263,0 +1281 @@ OPENSSL_INLINE void boringssl_ensure_ml_dsa_self_test(void) {}
++#endif
+diff --git a/crypto/x509/x509_test.cc b/crypto/x509/x509_test.cc
+index 21ae71da7..aadf0d077 100644
+--- a/crypto/x509/x509_test.cc
++++ b/crypto/x509/x509_test.cc
+@@ -3621,0 +3622 @@ TEST(X509Test, SignCSR) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -3677,0 +3679 @@ TEST(X509Test, PqdsaCSR) {
++#endif  // AWSLC_ENABLE_ML_DSA
+@@ -3695,0 +3698 @@ TEST(X509Test, Ed25519Sign) {
++#if AWSLC_ENABLE_ML_DSA
+@@ -3764,0 +3768 @@ TEST(X509Test, TestBadParamsMLDSA65) {
++#endif  // AWSLC_ENABLE_ML_DSA
+diff --git a/include/openssl/target.h b/include/openssl/target.h
+index 022d3d181..9a1ab42ae 100644
+--- a/include/openssl/target.h
++++ b/include/openssl/target.h
+@@ -136,0 +137,11 @@
++// AWSLC_NO_STD selects the platform-independent subset needed by freestanding
++// integrations. The embedding runtime remains responsible for providing the C
++// allocation, abort, and entropy interfaces used by AWS-LC.
++#if defined(AWSLC_NO_STD)
++#define OPENSSL_NO_FILESYSTEM
++#define OPENSSL_NO_POSIX_IO
++#define OPENSSL_NO_SOCK
++#define OPENSSL_NO_TTY
++#define OPENSSL_NO_THREADS_CORRUPT_MEMORY_AND_LEAK_SECRETS_IF_THREADED
++#endif
++
+diff --git a/ssl/extensions.cc b/ssl/extensions.cc
+index ac8ac14ea..99176d4ce 100644
+--- a/ssl/extensions.cc
++++ b/ssl/extensions.cc
+@@ -205,0 +206 @@ static const uint16_t kDefaultGroups[] = {
++#if AWSLC_ENABLE_ML_KEM
+@@ -208,0 +210 @@ static const uint16_t kDefaultGroups[] = {
++#endif
+@@ -301,0 +304 @@ static const uint16_t kVerifySignatureAlgorithms[] = {
++#if AWSLC_ENABLE_ML_DSA
+@@ -308,0 +312 @@ static const uint16_t kVerifySignatureAlgorithms[] = {
++#endif
+@@ -333,0 +338 @@ static const uint16_t kSignSignatureAlgorithms[] = {
++#if AWSLC_ENABLE_ML_DSA
+@@ -338,0 +344 @@ static const uint16_t kSignSignatureAlgorithms[] = {
++#endif
+diff --git a/ssl/ssl_key_share.cc b/ssl/ssl_key_share.cc
+index 06ad2f717..1d94ae3eb 100644
+--- a/ssl/ssl_key_share.cc
++++ b/ssl/ssl_key_share.cc
+@@ -25,0 +26 @@
++#if AWSLC_ENABLE_ML_KEM
+@@ -26,0 +28 @@
++#endif
+@@ -168,0 +171 @@ class X25519KeyShare : public SSLKeyShare {
++#if AWSLC_ENABLE_ML_KEM
+@@ -671,0 +675 @@ class HybridKeyShare : public SSLKeyShare {
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -678,0 +683 @@ CONSTEXPR_ARRAY NamedGroup kNamedGroups[] = {
++#if AWSLC_ENABLE_ML_KEM
+@@ -684,0 +690 @@ CONSTEXPR_ARRAY NamedGroup kNamedGroups[] = {
++#endif
+@@ -686,0 +693 @@ CONSTEXPR_ARRAY NamedGroup kNamedGroups[] = {
++#if AWSLC_ENABLE_ML_KEM
+@@ -720,0 +728 @@ CONSTEXPR_ARRAY HybridGroup kHybridGroups[] = {
++#endif  // AWSLC_ENABLE_ML_KEM
+@@ -728,0 +737 @@ Span<const HybridGroup> HybridGroups() {
++#if AWSLC_ENABLE_ML_KEM
+@@ -729,0 +739,3 @@ Span<const HybridGroup> HybridGroups() {
++#else
++  return {};
++#endif
+@@ -732,0 +745 @@ Span<const uint16_t> PQGroups() {
++#if AWSLC_ENABLE_ML_KEM
+@@ -733,0 +747,3 @@ Span<const uint16_t> PQGroups() {
++#else
++  return {};
++#endif
+@@ -747,0 +764 @@ UniquePtr<SSLKeyShare> SSLKeyShare::Create(uint16_t group_id) {
++#if AWSLC_ENABLE_ML_KEM
+@@ -759,0 +777 @@ UniquePtr<SSLKeyShare> SSLKeyShare::Create(uint16_t group_id) {
++#endif
+diff --git a/ssl/ssl_privkey.cc b/ssl/ssl_privkey.cc
+index 6d3e204e1..2021bc8ce 100644
+--- a/ssl/ssl_privkey.cc
++++ b/ssl/ssl_privkey.cc
+@@ -93,0 +94 @@ static const SSL_SIGNATURE_ALGORITHM kSignatureAlgorithms[] = {
++#if AWSLC_ENABLE_ML_DSA
+@@ -96,0 +98 @@ static const SSL_SIGNATURE_ALGORITHM kSignatureAlgorithms[] = {
++#endif

--- a/external/patches/aws-lc-rs/aws-lc/series
+++ b/external/patches/aws-lc-rs/aws-lc/series
@@ -1,0 +1,1 @@
+0001-build-aws-lc-add-no-std-bare-metal-support.patch

--- a/external/patches/aws-lc-rs/series
+++ b/external/patches/aws-lc-rs/series
@@ -1,0 +1,1 @@
+0001-feat-aws-lc-rs-add-no-std-bare-metal-support.patch

--- a/external/patches/aws-lc-rs/setup-aws-lc-rs.sh
+++ b/external/patches/aws-lc-rs/setup-aws-lc-rs.sh
@@ -1,26 +1,52 @@
 #!/bin/bash
-# Setup script for aws-lc-rs submodule on Windows and Linux.
-#
-# aws-lc-rs has a nested submodule (aws-lc-sys/aws-lc) and uses symlinks
-# (aws-lc-sys/builder -> ../builder). On Windows, git symlinks may not
-# resolve properly, so we replace them with copies or junctions.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AWS_LC_RS_DIR="$(cd "$SCRIPT_DIR/../../aws-lc-rs" && pwd)"
+AWS_LC_DIR="$AWS_LC_RS_DIR/aws-lc-sys/aws-lc"
+AWS_LC_RS_BASE="9232f4df24627662243a1a7cf71d885b2ff6ce72"
+AWS_LC_BASE="683ebde4bf3bcc016a9a710ad6b49c0c91b59161"
+AWS_LC_RS_PATCH="$SCRIPT_DIR/0001-feat-aws-lc-rs-add-no-std-bare-metal-support.patch"
+AWS_LC_PATCH="$SCRIPT_DIR/aws-lc/0001-build-aws-lc-add-no-std-bare-metal-support.patch"
+
+apply-patch() {
+    local repository="$1"
+    local patch="$2"
+
+    if git -C "$repository" apply --unidiff-zero --reverse --check "$patch" 2>/dev/null; then
+        echo "Already applied: $(basename "$patch")"
+    elif git -C "$repository" apply --unidiff-zero --check "$patch"; then
+        git -C "$repository" apply --unidiff-zero "$patch"
+        echo "Applied: $(basename "$patch")"
+    else
+        echo "Cannot apply $(basename "$patch") in $repository" >&2
+        echo "Reset the submodule to its pinned revision and retry." >&2
+        exit 1
+    fi
+}
+
+require-revision() {
+    local repository="$1"
+    local expected="$2"
+    local actual
+
+    actual="$(git -C "$repository" rev-parse HEAD)"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "$repository is at $actual; expected $expected" >&2
+        exit 1
+    fi
+}
 
 echo "Setting up aws-lc-rs at: $AWS_LC_RS_DIR"
 
-# Step 1: Initialize the nested aws-lc submodule
-pushd "$AWS_LC_RS_DIR" > /dev/null
-if [ ! -f "aws-lc-sys/aws-lc/CMakeLists.txt" ]; then
-    echo "Initializing aws-lc-sys/aws-lc submodule..."
-    git submodule update --init --depth 1 aws-lc-sys/aws-lc
-fi
-popd > /dev/null
+require-revision "$AWS_LC_RS_DIR" "$AWS_LC_RS_BASE"
+git -C "$AWS_LC_RS_DIR" submodule update --init aws-lc-sys/aws-lc
+require-revision "$AWS_LC_DIR" "$AWS_LC_BASE"
 
-# Step 2: Fix symlinks on Windows
+apply-patch "$AWS_LC_DIR" "$AWS_LC_PATCH"
+apply-patch "$AWS_LC_RS_DIR" "$AWS_LC_RS_PATCH"
+
 # aws-lc-sys/builder is a symlink to ../builder which may not resolve on Windows
 BUILDER_LINK="$AWS_LC_RS_DIR/aws-lc-sys/builder"
 BUILDER_TARGET="$AWS_LC_RS_DIR/builder"

--- a/sh_script/pre-build.sh
+++ b/sh_script/pre-build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
 TARGET_OPTION="x86_64-unknown-none"
 process_args() {
     while getopts ":t:" option; do
@@ -36,7 +41,7 @@ patch-ring() {
 }
 
 setup-aws-lc-rs() {
-    # setup aws-lc-rs: init nested submodule and fix symlinks
+    # Apply the pinned AWS-LC patch stack and fix platform-specific symlinks.
     bash external/patches/aws-lc-rs/setup-aws-lc-rs.sh
 }
 

--- a/spdmlib/Cargo.toml
+++ b/spdmlib/Cargo.toml
@@ -25,7 +25,7 @@ zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 maybe-async = "0.2.7"
 futures = { version = "0.3", default-features = false }
 async-trait = "0.1.71"
-spin = "0"
+spin = "0.9.8"
 
 [target.'cfg(any(target_os = "uefi", target_os = "none"))'.dependencies]
 sys_time = { path = "../sys_time" }
@@ -53,3 +53,12 @@ mandatory-mut-auth = ["mut-auth"]
 chunk-cap = []
 is_sync = ["maybe-async/is_sync"]
 fips = []
+sha256 = []
+sha384 = []
+sha512 = []
+aes-256-gcm = []
+ecdsa-p256 = []
+ecdsa-p384 = []
+rsa-pkcs1 = []
+ecdh-p256 = []
+ecdh-p384 = []

--- a/spdmlib/build.rs
+++ b/spdmlib/build.rs
@@ -18,6 +18,7 @@ struct SpdmConfig {
     max_session_count: usize,
     transport_config: SpdmBufferConfig,
     max_spdm_msg_size: usize,
+    max_spdm_context_size: usize,
     heartbeat_period_value: u8,
     max_root_cert_support: usize,
 }
@@ -39,6 +40,7 @@ impl SpdmConfig {
                 >= SPDM_MIN_DATA_TRANSFER_SIZE
         );
         assert!(self.max_spdm_msg_size >= SPDM_MIN_DATA_TRANSFER_SIZE);
+        assert!(self.max_spdm_context_size > 0);
 
         // Reserve some space for transport overhead.
         // 24 is miniaml requirement: session_id (4) + len (2) + app_len (2) + mac (16)
@@ -184,6 +186,9 @@ pub const SPDM_SENDER_DATA_TRANSFER_SIZE: usize = {snd_buf_sz} - TRANSPORT_OVERH
 /// This is max individual SPDM message size defined in SPDM 1.2.
 pub const MAX_SPDM_MSG_SIZE: usize = {max_spdm_mgs_sz};
 
+/// This is the workspace used to serialize an SPDM context for checkpointing.
+pub const MAX_SPDM_CONTEXT_SIZE: usize = {max_spdm_context_sz};
+
 /// This is min size of data transfer defined in SPDM 1.2.
 pub const SPDM_MIN_DATA_TRANSFER_SIZE: usize = {min_data_trans_sz};
 
@@ -233,6 +238,7 @@ fn main() {
         snd_buf_sz = spdm_config.transport_config.sender_buffer_size,
         rcv_buf_sz = spdm_config.transport_config.receiver_buffer_size,
         max_spdm_mgs_sz = spdm_config.max_spdm_msg_size,
+        max_spdm_context_sz = spdm_config.max_spdm_context_size,
         min_data_trans_sz = SPDM_MIN_DATA_TRANSFER_SIZE,
         trans_overhead_sz = TRANSPORT_OVERHEAD_SIZE,
         heartbeat_period = spdm_config.heartbeat_period_value,

--- a/spdmlib/etc/chunk_test_config.json
+++ b/spdmlib/etc/chunk_test_config.json
@@ -18,6 +18,7 @@
         "receiver_buffer_size": 108
     },
     "max_spdm_msg_size": 4096,
+    "max_spdm_context_size": 262144,
     "heartbeat_period_value": 0,
     "max_root_cert_support": 10
 }

--- a/spdmlib/etc/config.json
+++ b/spdmlib/etc/config.json
@@ -18,6 +18,7 @@
         "receiver_buffer_size": 4160
     },
     "max_spdm_msg_size": 4096,
+    "max_spdm_context_size": 262144,
     "heartbeat_period_value": 240,
     "max_root_cert_support": 10
 }

--- a/spdmlib/etc/pqc_config.json
+++ b/spdmlib/etc/pqc_config.json
@@ -18,6 +18,7 @@
         "receiver_buffer_size": 8256
     },
     "max_spdm_msg_size": 8192,
+    "max_spdm_context_size": 1048576,
     "heartbeat_period_value": 240,
     "max_root_cert_support": 10
 }

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -1318,8 +1318,7 @@ impl SpdmContext {
 
     /// Export all serializable data components of the SpdmContext
     pub fn export(&self) -> SpdmResult<Vec<u8>> {
-        // Use a large heap-allocated buffer for encoding
-        let mut buffer = Box::new([0u8; config::MAX_SPDM_CONTEXT_SIZE]);
+        let mut buffer = alloc::vec![0u8; config::MAX_SPDM_CONTEXT_SIZE];
         let mut writer = Writer::init(&mut buffer[..]);
 
         // Serialize core data structures

--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -1319,7 +1319,7 @@ impl SpdmContext {
     /// Export all serializable data components of the SpdmContext
     pub fn export(&self) -> SpdmResult<Vec<u8>> {
         // Use a large heap-allocated buffer for encoding
-        let mut buffer = Box::new([0u8; 0x20000]); // 128 KiB buffer on heap
+        let mut buffer = Box::new([0u8; config::MAX_SPDM_CONTEXT_SIZE]);
         let mut writer = Writer::init(&mut buffer[..]);
 
         // Serialize core data structures

--- a/spdmlib/src/crypto/crypto_callbacks.rs
+++ b/spdmlib/src/crypto/crypto_callbacks.rs
@@ -184,8 +184,10 @@ pub trait SpdmKemEncapKeyExchange {
         kem_cipher_text: &SpdmKemCipherTextStruct,
     ) -> Option<SpdmSharedSecretFinalKeyStruct>;
 
-    /// Export decapsulation (private) key bytes for serialization (checkpoint
-    /// support). Returns algorithm-specific decapsulation key data.
+    /// Export decapsulation (private) key bytes for checkpoint serialization.
+    ///
+    /// The caller owns the returned secret and must move it immediately into
+    /// zeroizing storage such as `KeyExchangeContextData`.
     fn export_decap_key(&self) -> Option<alloc::vec::Vec<u8>> {
         None // Default: not supported
     }

--- a/spdmlib/src/message/mod_test.common.inc.rs
+++ b/spdmlib/src/message/mod_test.common.inc.rs
@@ -8,6 +8,7 @@ use crate::message::SpdmMessage;
 use codec::{Reader, Writer};
 use spin::Mutex;
 extern crate alloc;
+#[cfg(not(feature = "is_sync"))]
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 

--- a/spdmlib/src/protocol/algo.rs
+++ b/spdmlib/src/protocol/algo.rs
@@ -1305,9 +1305,12 @@ impl AsRef<[u8]> for SpdmCertChainData {
 
 impl Codec for SpdmCertChainData {
     fn encode(&self, writer: &mut Writer) -> Result<usize, codec::EncodeErr> {
+        if self.data_size as usize > config::MAX_SPDM_CERT_CHAIN_DATA_SIZE {
+            return Err(codec::EncodeErr);
+        }
         let mut size = 0usize;
         size += self.data_size.encode(writer)?;
-        for d in self.data.iter() {
+        for d in self.data.iter().take(self.data_size as usize) {
             size += d.encode(writer)?;
         }
         Ok(size)
@@ -1319,7 +1322,7 @@ impl Codec for SpdmCertChainData {
             return None;
         }
         let mut data = [0u8; config::MAX_SPDM_CERT_CHAIN_DATA_SIZE];
-        for d in data.iter_mut() {
+        for d in data.iter_mut().take(data_size as usize) {
             *d = u8::read(reader)?;
         }
         Some(SpdmCertChainData { data_size, data })
@@ -2384,6 +2387,31 @@ impl Codec for KeyExchangeContextData {
 mod tests {
     use super::*;
     use codec::{Codec, Reader, Writer};
+
+    #[test]
+    fn test_spdm_cert_chain_data_codec() {
+        let mut value = SpdmCertChainData {
+            data_size: 3,
+            ..Default::default()
+        };
+        value.data[..3].copy_from_slice(&[1, 2, 3]);
+
+        let mut encoded = [0u8; 7];
+        let mut writer = Writer::init(&mut encoded);
+        assert_eq!(value.encode(&mut writer), Ok(encoded.len()));
+
+        let mut reader = Reader::init(&encoded);
+        assert_eq!(SpdmCertChainData::read(&mut reader), Some(value));
+        assert_eq!(reader.left(), 0);
+
+        let oversized = (config::MAX_SPDM_CERT_CHAIN_DATA_SIZE as u32) + 1;
+        value.data_size = oversized;
+        let mut encoded = [0u8; 4];
+        assert!(value.encode(&mut Writer::init(&mut encoded)).is_err());
+
+        oversized.encode(&mut Writer::init(&mut encoded)).unwrap();
+        assert_eq!(SpdmCertChainData::read(&mut Reader::init(&encoded)), None);
+    }
 
     #[test]
     fn test_case0_spdm_measurement_specification() {

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -7,7 +7,8 @@ license = "Apache-2.0 or MIT"
 [dependencies]
 spdmlib = { path = "../spdmlib", default-features = false }
 spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false }
-aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", features = ["unstable"] }
+aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", default-features = false, features = ["alloc", "aws-lc-sys", "unstable"] }
+aws-lc-sys = { path = "../external/aws-lc-rs/aws-lc-sys", default-features = false }
 log = { version = "0.4", default-features = false }
 # For the streaming hash-context handle table (hashed-transcript-data).
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
@@ -16,10 +17,50 @@ spin = "0.9.8"
 bytes = { version = "1", default-features = false }
 
 [dev-dependencies]
-# Enable the ring backend + std so the cert-chain tests can read test-key DER
-# files and exercise the full validator.
-spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["ring-backend", "std"] }
+# Enable std so certificate tests can read test-key DER files.
+spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false, features = ["std"] }
 
 [features]
-default = []
+default = ["full"]
+small = ["aws-lc-rs/small", "aws-lc-sys/small"]
+full = [
+	"sha256",
+	"sha384",
+	"sha512",
+	"aes-128-gcm",
+	"aes-256-gcm",
+	"chacha20-poly1305",
+	"ecdsa-p256",
+	"ecdsa-p384",
+	"rsa-pkcs1",
+	"rsa-pss",
+	"ed25519",
+	"ecdh-p256",
+	"ecdh-p384",
+	"ml-kem-512",
+	"ml-kem-768",
+	"ml-kem-1024",
+	"ml-dsa-44",
+	"ml-dsa-65",
+	"ml-dsa-87",
+]
 hashed-transcript-data = ["spdmlib/hashed-transcript-data"]
+sha256 = ["spdmlib/sha256"]
+sha384 = ["spdmlib/sha384"]
+sha512 = ["spdmlib/sha512"]
+aes-128-gcm = []
+aes-256-gcm = ["spdmlib/aes-256-gcm"]
+chacha20-poly1305 = []
+ecdsa-p256 = ["spdmlib/ecdsa-p256"]
+ecdsa-p384 = ["spdmlib/ecdsa-p384"]
+rsa-pkcs1 = ["spdmlib/rsa-pkcs1"]
+rsa-pss = []
+ed25519 = []
+ecdh-p256 = ["spdmlib/ecdh-p256"]
+ecdh-p384 = ["spdmlib/ecdh-p384"]
+ml-kem-512 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]
+ml-kem-768 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]
+ml-kem-1024 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]
+ml-dsa-44 = ["aws-lc-rs/ml-dsa", "aws-lc-sys/ml-dsa"]
+ml-dsa-65 = ["aws-lc-rs/ml-dsa", "aws-lc-sys/ml-dsa"]
+ml-dsa-87 = ["aws-lc-rs/ml-dsa", "aws-lc-sys/ml-dsa"]

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.9.8"
 # For building SpdmDheExchangeStruct via its From<BytesMut> impl.
 bytes = { version = "1", default-features = false }
+zeroize = { version = "1.5", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 # Enable std so certificate tests can read test-key DER files.
@@ -48,6 +49,8 @@ hashed-transcript-data = ["spdmlib/hashed-transcript-data"]
 sha256 = ["spdmlib/sha256"]
 sha384 = ["spdmlib/sha384"]
 sha512 = ["spdmlib/sha512"]
+# spdmlib currently has no negotiation gates for these algorithms; these
+# features gate only the AWS-LC backend implementations.
 aes-128-gcm = []
 aes-256-gcm = ["spdmlib/aes-256-gcm"]
 chacha20-poly1305 = []
@@ -58,6 +61,8 @@ rsa-pss = []
 ed25519 = []
 ecdh-p256 = ["spdmlib/ecdh-p256"]
 ecdh-p384 = ["spdmlib/ecdh-p384"]
+# AWS-LC builds every parameter set for each PQC family. Per-size features
+# still trim the corresponding Rust match arms in this backend.
 ml-kem-512 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]
 ml-kem-768 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]
 ml-kem-1024 = ["aws-lc-rs/ml-kem", "aws-lc-sys/ml-kem"]

--- a/spdmlib_crypto_aws_lc/src/aead_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/aead_impl.rs
@@ -113,8 +113,11 @@ fn make_key<K: aws_lc_rs::aead::BoundKey<OneNonceSequence>>(
     nonce: aws_lc_rs::aead::Nonce,
 ) -> SpdmResult<K> {
     let algorithm = match aead_algo {
+        #[cfg(feature = "aes-128-gcm")]
         SpdmAeadAlgo::AES_128_GCM => &aws_lc_rs::aead::AES_128_GCM,
+        #[cfg(feature = "aes-256-gcm")]
         SpdmAeadAlgo::AES_256_GCM => &aws_lc_rs::aead::AES_256_GCM,
+        #[cfg(feature = "chacha20-poly1305")]
         SpdmAeadAlgo::CHACHA20_POLY1305 => &aws_lc_rs::aead::CHACHA20_POLY1305,
         _ => return Err(SPDM_STATUS_CRYPTO_ERROR),
     };

--- a/spdmlib_crypto_aws_lc/src/asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/asym_verify_impl.rs
@@ -87,15 +87,18 @@ fn asym_verify(
 
             // RFC7250 uses FIXED signature format (not ASN.1 DER) for ECDSA
             match base_asym_algo {
+                #[cfg(any(feature = "ecdsa-p256", feature = "ecdsa-p384"))]
                 SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
                 | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384 => {
                     // RFC7250 uses FIXED format. Ring only supports matching curve+hash:
                     // P256+SHA256 and P384+SHA384. Cross-combinations only exist in ASN1 format.
                     let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                        #[cfg(all(feature = "ecdsa-p256", feature = "sha256"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
                         ) => &signature::ECDSA_P256_SHA256_FIXED,
+                        #[cfg(all(feature = "ecdsa-p384", feature = "sha384"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                             SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
@@ -109,6 +112,7 @@ fn asym_verify(
                     pk.verify(data, &signature.data[..signature.data_size as usize])
                         .map_err(|_| SPDM_STATUS_VERIF_FAIL)
                 }
+                #[cfg(any(feature = "rsa-pkcs1", feature = "rsa-pss"))]
                 SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048
                 | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072
                 | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096
@@ -116,6 +120,7 @@ fn asym_verify(
                 | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
                 | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096 => {
                     let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                        #[cfg(all(feature = "rsa-pkcs1", feature = "sha256"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
@@ -128,6 +133,7 @@ fn asym_verify(
                             SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
                         ) => &signature::RSA_PKCS1_2048_8192_SHA256,
+                        #[cfg(all(feature = "rsa-pss", feature = "sha256"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                             SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
@@ -140,6 +146,7 @@ fn asym_verify(
                             SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                             SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
                         ) => &signature::RSA_PSS_2048_8192_SHA256,
+                        #[cfg(all(feature = "rsa-pkcs1", feature = "sha384"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
@@ -152,6 +159,7 @@ fn asym_verify(
                             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
                         ) => &signature::RSA_PKCS1_2048_8192_SHA384,
+                        #[cfg(all(feature = "rsa-pss", feature = "sha384"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                             SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
@@ -164,6 +172,7 @@ fn asym_verify(
                             SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                             SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096,
                         ) => &signature::RSA_PSS_2048_8192_SHA384,
+                        #[cfg(all(feature = "rsa-pkcs1", feature = "sha512"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_512,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048,
@@ -176,6 +185,7 @@ fn asym_verify(
                             SpdmBaseHashAlgo::TPM_ALG_SHA_512,
                             SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
                         ) => &signature::RSA_PKCS1_2048_8192_SHA512,
+                        #[cfg(all(feature = "rsa-pss", feature = "sha512"))]
                         (
                             SpdmBaseHashAlgo::TPM_ALG_SHA_512,
                             SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048,
@@ -239,6 +249,7 @@ fn asym_verify_with_spdm_x509(
     let pub_key_bytes = pub_key_info.subject_public_key.raw_bytes();
 
     match base_asym_algo {
+        #[cfg(any(feature = "ecdsa-p256", feature = "ecdsa-p384"))]
         SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
         | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384 => {
             // For ECDSA, we need to convert the signature from FIXED format to ASN.1 DER format
@@ -250,18 +261,22 @@ fn asym_verify_with_spdm_x509(
 
             // Select the appropriate algorithm (ASN.1 versions, not FIXED)
             let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                #[cfg(all(feature = "ecdsa-p256", feature = "sha256"))]
                 (
                     SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                     SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
                 ) => &signature::ECDSA_P256_SHA256_ASN1,
+                #[cfg(all(feature = "ecdsa-p256", feature = "sha384"))]
                 (
                     SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                     SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
                 ) => &signature::ECDSA_P256_SHA384_ASN1,
+                #[cfg(all(feature = "ecdsa-p384", feature = "sha256"))]
                 (
                     SpdmBaseHashAlgo::TPM_ALG_SHA_256,
                     SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
                 ) => &signature::ECDSA_P384_SHA256_ASN1,
+                #[cfg(all(feature = "ecdsa-p384", feature = "sha384"))]
                 (
                     SpdmBaseHashAlgo::TPM_ALG_SHA_384,
                     SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
@@ -284,6 +299,7 @@ fn asym_verify_with_spdm_x509(
                 }
             }
         }
+        #[cfg(any(feature = "rsa-pkcs1", feature = "rsa-pss"))]
         SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048
         | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072
         | SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096
@@ -292,31 +308,37 @@ fn asym_verify_with_spdm_x509(
         | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096 => {
             // For RSA, use ring signature verification
             let sign_algorithm = match (base_hash_algo, base_asym_algo) {
+                #[cfg(all(feature = "rsa-pkcs1", feature = "sha256"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
                     &signature::RSA_PKCS1_2048_8192_SHA256
                 }
+                #[cfg(all(feature = "rsa-pss", feature = "sha256"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_256, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
                     &signature::RSA_PSS_2048_8192_SHA256
                 }
+                #[cfg(all(feature = "rsa-pkcs1", feature = "sha384"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
                     &signature::RSA_PKCS1_2048_8192_SHA384
                 }
+                #[cfg(all(feature = "rsa-pss", feature = "sha384"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_384, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {
                     &signature::RSA_PSS_2048_8192_SHA384
                 }
+                #[cfg(all(feature = "rsa-pkcs1", feature = "sha512"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096) => {
                     &signature::RSA_PKCS1_2048_8192_SHA512
                 }
+                #[cfg(all(feature = "rsa-pss", feature = "sha512"))]
                 (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_2048)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072)
                 | (SpdmBaseHashAlgo::TPM_ALG_SHA_512, SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_4096) => {

--- a/spdmlib_crypto_aws_lc/src/cert_operation_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/cert_operation_impl.rs
@@ -31,34 +31,59 @@ impl CryptoBackend for AwsLcBackend {
     ) -> Result<()> {
         // ML-DSA: aws-lc-rs accepts a raw or SPKI-DER public key; empty context
         // for X.509 certificate signatures.
-        use aws_lc_rs::unstable::signature::{ML_DSA_44, ML_DSA_65, ML_DSA_87};
+        #[cfg(feature = "ml-dsa-44")]
+        use aws_lc_rs::unstable::signature::ML_DSA_44;
+        #[cfg(feature = "ml-dsa-65")]
+        use aws_lc_rs::unstable::signature::ML_DSA_65;
+        #[cfg(feature = "ml-dsa-87")]
+        use aws_lc_rs::unstable::signature::ML_DSA_87;
 
+        #[allow(unreachable_patterns)]
         let classical: &dyn signature::VerificationAlgorithm = match algorithm {
+            #[cfg(all(feature = "ecdsa-p256", feature = "sha256"))]
             SignatureAlgorithm::EcdsaP256Sha256 => &signature::ECDSA_P256_SHA256_ASN1,
+            #[cfg(all(feature = "ecdsa-p256", feature = "sha384"))]
             SignatureAlgorithm::EcdsaP256Sha384 => &signature::ECDSA_P256_SHA384_ASN1,
+            #[cfg(all(feature = "ecdsa-p384", feature = "sha256"))]
             SignatureAlgorithm::EcdsaP384Sha256 => &signature::ECDSA_P384_SHA256_ASN1,
+            #[cfg(all(feature = "ecdsa-p384", feature = "sha384"))]
             SignatureAlgorithm::EcdsaP384Sha384 => &signature::ECDSA_P384_SHA384_ASN1,
+            #[cfg(all(feature = "rsa-pkcs1", feature = "sha256"))]
             SignatureAlgorithm::RsaPkcs1Sha256 => &signature::RSA_PKCS1_2048_8192_SHA256,
+            #[cfg(all(feature = "rsa-pkcs1", feature = "sha384"))]
             SignatureAlgorithm::RsaPkcs1Sha384 => &signature::RSA_PKCS1_2048_8192_SHA384,
+            #[cfg(all(feature = "rsa-pkcs1", feature = "sha512"))]
             SignatureAlgorithm::RsaPkcs1Sha512 => &signature::RSA_PKCS1_2048_8192_SHA512,
+            #[cfg(all(feature = "rsa-pss", feature = "sha256"))]
             SignatureAlgorithm::RsaPssSha256 => &signature::RSA_PSS_2048_8192_SHA256,
+            #[cfg(all(feature = "rsa-pss", feature = "sha384"))]
             SignatureAlgorithm::RsaPssSha384 => &signature::RSA_PSS_2048_8192_SHA384,
+            #[cfg(all(feature = "rsa-pss", feature = "sha512"))]
             SignatureAlgorithm::RsaPssSha512 => &signature::RSA_PSS_2048_8192_SHA512,
+            #[cfg(feature = "ed25519")]
             SignatureAlgorithm::Ed25519 => &signature::ED25519,
-            SignatureAlgorithm::MlDsa44
-            | SignatureAlgorithm::MlDsa65
-            | SignatureAlgorithm::MlDsa87 => {
-                let algo = match algorithm {
-                    SignatureAlgorithm::MlDsa44 => &ML_DSA_44,
-                    SignatureAlgorithm::MlDsa65 => &ML_DSA_65,
-                    SignatureAlgorithm::MlDsa87 => &ML_DSA_87,
-                    _ => unreachable!(),
-                };
-                let pk = UnparsedPublicKey::new(algo, public_key);
+            #[cfg(feature = "ml-dsa-44")]
+            SignatureAlgorithm::MlDsa44 => {
+                let pk = UnparsedPublicKey::new(&ML_DSA_44, public_key);
                 return pk.verify(tbs_data, signature).map_err(|_| {
                     Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
                 });
             }
+            #[cfg(feature = "ml-dsa-65")]
+            SignatureAlgorithm::MlDsa65 => {
+                let pk = UnparsedPublicKey::new(&ML_DSA_65, public_key);
+                return pk.verify(tbs_data, signature).map_err(|_| {
+                    Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
+                });
+            }
+            #[cfg(feature = "ml-dsa-87")]
+            SignatureAlgorithm::MlDsa87 => {
+                let pk = UnparsedPublicKey::new(&ML_DSA_87, public_key);
+                return pk.verify(tbs_data, signature).map_err(|_| {
+                    Error::SignatureError(spdm_x509::error::SignatureError::VerificationFailed)
+                });
+            }
+            _ => return Err(Error::unsupported_algorithm("signature algorithm")),
         };
 
         let pk = UnparsedPublicKey::new(classical, public_key);
@@ -96,18 +121,21 @@ fn verify_cert_chain(
 mod tests {
     use super::*;
 
+    #[cfg(feature = "ecdsa-p384")]
     #[test]
     fn test_verify_cert_chain_ecp384() {
         let chain = &include_bytes!("../../test_key/ecp384/bundle_responder.certchain.der")[..];
         assert!(verify_cert_chain(chain, None, None).is_ok());
     }
 
+    #[cfg(feature = "rsa-pkcs1")]
     #[test]
     fn test_verify_cert_chain_rsa3072() {
         let chain = &include_bytes!("../../test_key/rsa3072/bundle_responder.certchain.der")[..];
         assert!(verify_cert_chain(chain, None, None).is_ok());
     }
 
+    #[cfg(feature = "ml-dsa-87")]
     #[test]
     fn test_verify_cert_chain_mldsa87() {
         let chain = &include_bytes!("../../test_key/mldsa87/bundle_responder.certchain.der")[..];

--- a/spdmlib_crypto_aws_lc/src/dhe_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/dhe_impl.rs
@@ -26,7 +26,9 @@ pub static DEFAULT: SpdmDhe = SpdmDhe {
 
 fn algo_of(dhe_algo: SpdmDheAlgo) -> Option<&'static agreement::Algorithm> {
     match dhe_algo {
+        #[cfg(feature = "ecdh-p256")]
         SpdmDheAlgo::SECP_256_R1 => Some(&agreement::ECDH_P256),
+        #[cfg(feature = "ecdh-p384")]
         SpdmDheAlgo::SECP_384_R1 => Some(&agreement::ECDH_P384),
         _ => None,
     }
@@ -128,11 +130,13 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ecdh-p256")]
     #[test]
     fn test_dhe_p256() {
         roundtrip(SpdmDheAlgo::SECP_256_R1);
     }
 
+    #[cfg(feature = "ecdh-p384")]
     #[test]
     fn test_dhe_p384() {
         roundtrip(SpdmDheAlgo::SECP_384_R1);
@@ -159,11 +163,13 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ecdh-p256")]
     #[test]
     fn test_dhe_export_import_p256() {
         export_import_roundtrip(SpdmDheAlgo::SECP_256_R1);
     }
 
+    #[cfg(feature = "ecdh-p384")]
     #[test]
     fn test_dhe_export_import_p384() {
         export_import_roundtrip(SpdmDheAlgo::SECP_384_R1);

--- a/spdmlib_crypto_aws_lc/src/hash_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hash_impl.rs
@@ -26,8 +26,11 @@ pub static DEFAULT: SpdmHash = SpdmHash {
 
 fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestStruct> {
     let algorithm = match base_hash_algo {
+        #[cfg(feature = "sha256")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => &aws_lc_rs::digest::SHA256,
+        #[cfg(feature = "sha384")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => &aws_lc_rs::digest::SHA384,
+        #[cfg(feature = "sha512")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_512 => &aws_lc_rs::digest::SHA512,
         _ => return None,
     };
@@ -40,11 +43,24 @@ mod hash_ext {
     use super::*;
     use alloc::boxed::Box;
     use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
+    #[cfg(feature = "sha256")]
+    use aws_lc_sys::SHA256_CTX;
+    #[cfg(any(feature = "sha384", feature = "sha512"))]
+    use aws_lc_sys::SHA512_CTX;
     use lazy_static::lazy_static;
     use spdmlib::error::{SpdmResult, SPDM_STATUS_CRYPTO_ERROR};
     use spin::Mutex;
 
-    pub type HashCtxConcrete = aws_lc_rs::digest::Context;
+    #[derive(Clone)]
+    pub enum HashCtxConcrete {
+        #[cfg(feature = "sha256")]
+        Sha256(SHA256_CTX),
+        #[cfg(feature = "sha384")]
+        Sha384(SHA512_CTX),
+        #[cfg(feature = "sha512")]
+        Sha512(SHA512_CTX),
+    }
 
     lazy_static! {
         static ref HASH_CTX_TABLE: Mutex<BTreeMap<usize, Box<HashCtxConcrete>>> =
@@ -52,27 +68,72 @@ mod hash_ext {
     }
 
     pub fn hash_ctx_init(base_hash_algo: SpdmBaseHashAlgo) -> Option<usize> {
-        let algorithm = match base_hash_algo {
-            SpdmBaseHashAlgo::TPM_ALG_SHA_256 => &aws_lc_rs::digest::SHA256,
-            SpdmBaseHashAlgo::TPM_ALG_SHA_384 => &aws_lc_rs::digest::SHA384,
-            SpdmBaseHashAlgo::TPM_ALG_SHA_512 => &aws_lc_rs::digest::SHA512,
+        let ctx = match base_hash_algo {
+            #[cfg(feature = "sha256")]
+            SpdmBaseHashAlgo::TPM_ALG_SHA_256 => {
+                let mut ctx = SHA256_CTX::default();
+                (unsafe { aws_lc_sys::SHA256_Init(&mut ctx) } == 1)
+                    .then_some(HashCtxConcrete::Sha256(ctx))?
+            }
+            #[cfg(feature = "sha384")]
+            SpdmBaseHashAlgo::TPM_ALG_SHA_384 => {
+                let mut ctx = SHA512_CTX::default();
+                (unsafe { aws_lc_sys::SHA384_Init(&mut ctx) } == 1)
+                    .then_some(HashCtxConcrete::Sha384(ctx))?
+            }
+            #[cfg(feature = "sha512")]
+            SpdmBaseHashAlgo::TPM_ALG_SHA_512 => {
+                let mut ctx = SHA512_CTX::default();
+                (unsafe { aws_lc_sys::SHA512_Init(&mut ctx) } == 1)
+                    .then_some(HashCtxConcrete::Sha512(ctx))?
+            }
             _ => return None,
         };
-        let ctx = Box::new(HashCtxConcrete::new(algorithm));
-        Some(insert_to_table(ctx))
+        Some(insert_to_table(Box::new(ctx)))
     }
 
     pub fn hash_ctx_update(handle: usize, data: &[u8]) -> SpdmResult {
         let mut table = HASH_CTX_TABLE.lock();
         let ctx = table.get_mut(&handle).ok_or(SPDM_STATUS_CRYPTO_ERROR)?;
-        ctx.update(data);
-        Ok(())
+        let result = unsafe {
+            match ctx.as_mut() {
+                #[cfg(feature = "sha256")]
+                HashCtxConcrete::Sha256(ctx) => {
+                    aws_lc_sys::SHA256_Update(ctx, data.as_ptr().cast(), data.len())
+                }
+                #[cfg(feature = "sha384")]
+                HashCtxConcrete::Sha384(ctx) => {
+                    aws_lc_sys::SHA384_Update(ctx, data.as_ptr().cast(), data.len())
+                }
+                #[cfg(feature = "sha512")]
+                HashCtxConcrete::Sha512(ctx) => {
+                    aws_lc_sys::SHA512_Update(ctx, data.as_ptr().cast(), data.len())
+                }
+            }
+        };
+        (result == 1).then_some(()).ok_or(SPDM_STATUS_CRYPTO_ERROR)
     }
 
     pub fn hash_ctx_finalize(handle: usize) -> Option<SpdmDigestStruct> {
-        let ctx = HASH_CTX_TABLE.lock().remove(&handle)?;
-        let digest_value = ctx.finish();
-        Some(SpdmDigestStruct::from(digest_value.as_ref()))
+        let mut ctx = HASH_CTX_TABLE.lock().remove(&handle)?;
+        let mut digest = [0u8; 64];
+        let (result, size) = unsafe {
+            match ctx.as_mut() {
+                #[cfg(feature = "sha256")]
+                HashCtxConcrete::Sha256(ctx) => {
+                    (aws_lc_sys::SHA256_Final(digest.as_mut_ptr(), ctx), 32)
+                }
+                #[cfg(feature = "sha384")]
+                HashCtxConcrete::Sha384(ctx) => {
+                    (aws_lc_sys::SHA384_Final(digest.as_mut_ptr(), ctx), 48)
+                }
+                #[cfg(feature = "sha512")]
+                HashCtxConcrete::Sha512(ctx) => {
+                    (aws_lc_sys::SHA512_Final(digest.as_mut_ptr(), ctx), 64)
+                }
+            }
+        };
+        (result == 1).then(|| SpdmDigestStruct::from(&digest[..size]))
     }
 
     pub fn hash_ctx_dup(handle: usize) -> Option<usize> {
@@ -91,16 +152,99 @@ mod hash_ext {
         handle
     }
 
-    // aws-lc-rs digest::Context does not expose serialize/deserialize of the
-    // in-progress state, so checkpoint/resume of a hash context is unsupported
-    // on this backend. These return None; callers that need transcript
-    // checkpointing must use a backend that supports it.
-    pub fn hash_ctx_serialize(_handle: usize) -> Option<alloc::vec::Vec<u8>> {
-        None
+    pub fn hash_ctx_serialize(handle: usize) -> Option<Vec<u8>> {
+        let table = HASH_CTX_TABLE.lock();
+        let ctx = table.get(&handle)?;
+        let mut bytes = Vec::new();
+        match ctx.as_ref() {
+            #[cfg(feature = "sha256")]
+            HashCtxConcrete::Sha256(ctx) => {
+                bytes.push(1);
+                for value in ctx.h {
+                    bytes.extend_from_slice(&value.to_le_bytes());
+                }
+                bytes.extend_from_slice(&ctx.Nl.to_le_bytes());
+                bytes.extend_from_slice(&ctx.Nh.to_le_bytes());
+                bytes.extend_from_slice(&ctx.data);
+                bytes.extend_from_slice(&ctx.num.to_le_bytes());
+                bytes.extend_from_slice(&ctx.md_len.to_le_bytes());
+            }
+            #[cfg(feature = "sha384")]
+            HashCtxConcrete::Sha384(ctx) => {
+                bytes.push(2);
+                for value in ctx.h {
+                    bytes.extend_from_slice(&value.to_le_bytes());
+                }
+                bytes.extend_from_slice(&ctx.Nl.to_le_bytes());
+                bytes.extend_from_slice(&ctx.Nh.to_le_bytes());
+                bytes.extend_from_slice(&ctx.p);
+                bytes.extend_from_slice(&ctx.num.to_le_bytes());
+                bytes.extend_from_slice(&ctx.md_len.to_le_bytes());
+            }
+            #[cfg(feature = "sha512")]
+            HashCtxConcrete::Sha512(ctx) => {
+                bytes.push(3);
+                for value in ctx.h {
+                    bytes.extend_from_slice(&value.to_le_bytes());
+                }
+                bytes.extend_from_slice(&ctx.Nl.to_le_bytes());
+                bytes.extend_from_slice(&ctx.Nh.to_le_bytes());
+                bytes.extend_from_slice(&ctx.p);
+                bytes.extend_from_slice(&ctx.num.to_le_bytes());
+                bytes.extend_from_slice(&ctx.md_len.to_le_bytes());
+            }
+        }
+        Some(bytes)
     }
 
-    pub fn hash_ctx_deserialize(_bytes: &[u8]) -> Option<usize> {
-        None
+    pub fn hash_ctx_deserialize(bytes: &[u8]) -> Option<usize> {
+        fn take<const N: usize>(bytes: &mut &[u8]) -> Option<[u8; N]> {
+            let (value, rest) = bytes.split_at_checked(N)?;
+            *bytes = rest;
+            value.try_into().ok()
+        }
+
+        let (&kind, mut bytes) = bytes.split_first()?;
+        let ctx = match kind {
+            #[cfg(feature = "sha256")]
+            1 => {
+                let mut ctx = SHA256_CTX::default();
+                for value in &mut ctx.h {
+                    *value = u32::from_le_bytes(take(&mut bytes)?);
+                }
+                ctx.Nl = u32::from_le_bytes(take(&mut bytes)?);
+                ctx.Nh = u32::from_le_bytes(take(&mut bytes)?);
+                ctx.data = take(&mut bytes)?;
+                ctx.num = u32::from_le_bytes(take(&mut bytes)?);
+                ctx.md_len = u32::from_le_bytes(take(&mut bytes)?);
+                (ctx.num < 64 && ctx.md_len == 32 && bytes.is_empty())
+                    .then_some(HashCtxConcrete::Sha256(ctx))?
+            }
+            #[cfg(any(feature = "sha384", feature = "sha512"))]
+            2 | 3 => {
+                let mut ctx = SHA512_CTX::default();
+                for value in &mut ctx.h {
+                    *value = u64::from_le_bytes(take(&mut bytes)?);
+                }
+                ctx.Nl = u64::from_le_bytes(take(&mut bytes)?);
+                ctx.Nh = u64::from_le_bytes(take(&mut bytes)?);
+                ctx.p = take(&mut bytes)?;
+                ctx.num = u32::from_le_bytes(take(&mut bytes)?);
+                ctx.md_len = u32::from_le_bytes(take(&mut bytes)?);
+                if ctx.num >= 128 || !bytes.is_empty() {
+                    return None;
+                }
+                match kind {
+                    #[cfg(feature = "sha384")]
+                    2 if ctx.md_len == 48 => HashCtxConcrete::Sha384(ctx),
+                    #[cfg(feature = "sha512")]
+                    3 if ctx.md_len == 64 => HashCtxConcrete::Sha512(ctx),
+                    _ => return None,
+                }
+            }
+            _ => return None,
+        };
+        Some(insert_to_table(Box::new(ctx)))
     }
 }
 
@@ -108,18 +252,38 @@ mod hash_ext {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "hashed-transcript-data")]
+    fn test_hash_ctx_round_trip(base_hash_algo: SpdmBaseHashAlgo) {
+        let first = b"SPDM transcript before checkpoint";
+        let second = b" and after restore";
+        let handle = hash_ext::hash_ctx_init(base_hash_algo).unwrap();
+        hash_ext::hash_ctx_update(handle, first).unwrap();
+        let serialized = hash_ext::hash_ctx_serialize(handle).unwrap();
+        let restored_handle = hash_ext::hash_ctx_deserialize(&serialized).unwrap();
+        hash_ext::hash_ctx_update(restored_handle, second).unwrap();
+        let actual = hash_ext::hash_ctx_finalize(restored_handle).unwrap();
+
+        let mut message = first.to_vec();
+        message.extend_from_slice(second);
+        assert_eq!(actual, hash_all(base_hash_algo, &message).unwrap());
+        hash_ext::hash_ctx_finalize(handle).unwrap();
+    }
+
+    #[cfg(feature = "sha256")]
     #[test]
     fn test_hash_all_sha256() {
         let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_256, &[0u8; 32]).unwrap();
         assert_eq!(d.data_size, 32);
     }
 
+    #[cfg(feature = "sha384")]
     #[test]
     fn test_hash_all_sha384() {
         let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_384, &[0u8; 48]).unwrap();
         assert_eq!(d.data_size, 48);
     }
 
+    #[cfg(feature = "sha512")]
     #[test]
     fn test_hash_all_sha512() {
         let d = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_512, &[0u8; 64]).unwrap();
@@ -129,5 +293,13 @@ mod tests {
     #[test]
     fn test_hash_all_invalid() {
         assert!(hash_all(SpdmBaseHashAlgo::empty(), &[0u8; 32]).is_none());
+    }
+
+    #[cfg(feature = "hashed-transcript-data")]
+    #[test]
+    fn test_hash_context_checkpoint_round_trip() {
+        test_hash_ctx_round_trip(SpdmBaseHashAlgo::TPM_ALG_SHA_256);
+        test_hash_ctx_round_trip(SpdmBaseHashAlgo::TPM_ALG_SHA_384);
+        test_hash_ctx_round_trip(SpdmBaseHashAlgo::TPM_ALG_SHA_512);
     }
 }

--- a/spdmlib_crypto_aws_lc/src/hash_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hash_impl.rs
@@ -152,6 +152,11 @@ mod hash_ext {
         handle
     }
 
+    /// Serialize an AWS-LC hash context for trusted local checkpointing.
+    ///
+    /// The little-endian format is tied to the pinned AWS-LC context ABI. It
+    /// is not versioned or suitable for untrusted input or cross-version
+    /// persistence.
     pub fn hash_ctx_serialize(handle: usize) -> Option<Vec<u8>> {
         let table = HASH_CTX_TABLE.lock();
         let ctx = table.get(&handle)?;
@@ -197,6 +202,10 @@ mod hash_ext {
         Some(bytes)
     }
 
+    /// Restore a context emitted by `hash_ctx_serialize` in the same build.
+    ///
+    /// Callers must treat the blob as trusted and non-portable across AWS-LC
+    /// revisions; validation here only protects structural memory safety.
     pub fn hash_ctx_deserialize(bytes: &[u8]) -> Option<usize> {
         fn take<const N: usize>(bytes: &mut &[u8]) -> Option<[u8; N]> {
             let (value, rest) = bytes.split_at_checked(N)?;

--- a/spdmlib_crypto_aws_lc/src/hkdf_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hkdf_impl.rs
@@ -25,8 +25,11 @@ fn hkdf_extract(
     // HKDF-Extract(salt, IKM) == HMAC(salt, IKM); use HMAC to produce the PRK,
     // matching the ring backend's behavior.
     let algorithm = match hash_algo {
+        #[cfg(feature = "sha256")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        #[cfg(feature = "sha384")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        #[cfg(feature = "sha512")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
         _ => return None,
     };
@@ -44,9 +47,12 @@ fn hkdf_expand(
     if out_size as usize > SPDM_MAX_HKDF_OKM_SIZE {
         return None;
     }
-    let algo = match hash_algo {
+    let algo: aws_lc_rs::hkdf::Algorithm = match hash_algo {
+        #[cfg(feature = "sha256")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hkdf::HKDF_SHA256,
+        #[cfg(feature = "sha384")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hkdf::HKDF_SHA384,
+        #[cfg(feature = "sha512")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hkdf::HKDF_SHA512,
         _ => return None,
     };

--- a/spdmlib_crypto_aws_lc/src/hmac_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/hmac_impl.rs
@@ -15,8 +15,11 @@ pub static DEFAULT: SpdmHmac = SpdmHmac {
 
 fn hmac(base_hash_algo: SpdmBaseHashAlgo, key: &[u8], data: &[u8]) -> Option<SpdmDigestStruct> {
     let algorithm = match base_hash_algo {
+        #[cfg(feature = "sha256")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        #[cfg(feature = "sha384")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        #[cfg(feature = "sha512")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
         _ => return None,
     };
@@ -32,8 +35,11 @@ fn hmac_verify(
     hmac: &SpdmDigestStruct,
 ) -> SpdmResult {
     let algorithm = match base_hash_algo {
+        #[cfg(feature = "sha256")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => aws_lc_rs::hmac::HMAC_SHA256,
+        #[cfg(feature = "sha384")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => aws_lc_rs::hmac::HMAC_SHA384,
+        #[cfg(feature = "sha512")]
         SpdmBaseHashAlgo::TPM_ALG_SHA_512 => aws_lc_rs::hmac::HMAC_SHA512,
         _ => return Err(SPDM_STATUS_VERIF_FAIL),
     };

--- a/spdmlib_crypto_aws_lc/src/kem_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/kem_impl.rs
@@ -23,6 +23,7 @@ use spdmlib::protocol::{
     SpdmKemAlgo, SpdmKemCipherTextStruct, SpdmKemEncapKeyStruct, SpdmSharedSecretFinalKeyStruct,
     SPDM_MAX_KEM_CIPHER_TEXT_SIZE, SPDM_MAX_KEM_ENCAP_KEY_SIZE, SPDM_MAX_KEM_SHARED_SECRET_SIZE,
 };
+use zeroize::Zeroizing;
 
 pub static DEFAULT_DECAP: SpdmKemDecap = SpdmKemDecap {
     generate_key_pair_cb: kem_generate_key_pair,
@@ -35,7 +36,7 @@ pub static DEFAULT_ENCAP: SpdmKemEncap = SpdmKemEncap {
 
 struct AwsLcKemDecapKey {
     kem_algo: SpdmKemAlgo,
-    decap_key_bytes: Vec<u8>,
+    decap_key_bytes: Zeroizing<Vec<u8>>,
 }
 
 impl SpdmKemEncapKeyExchange for AwsLcKemDecapKey {
@@ -94,7 +95,7 @@ impl SpdmKemEncapKeyExchange for AwsLcKemDecapKey {
     fn export_decap_key(&self) -> Option<Vec<u8>> {
         // Raw decapsulation (private) key bytes, the same encoding accepted by
         // `kem_import_decap_key` (and by `DecapsulationKey::new`).
-        Some(self.decap_key_bytes.clone())
+        Some(self.decap_key_bytes.to_vec())
     }
 }
 
@@ -204,7 +205,7 @@ fn kem_generate_key_pair(
 
     let exchange: Box<dyn SpdmKemEncapKeyExchange + Send> = Box::new(AwsLcKemDecapKey {
         kem_algo,
-        decap_key_bytes,
+        decap_key_bytes: Zeroizing::new(decap_key_bytes),
     });
 
     Some((ek_struct, exchange))
@@ -255,7 +256,7 @@ fn kem_import_decap_key(
 
     Some(Box::new(AwsLcKemDecapKey {
         kem_algo,
-        decap_key_bytes: Vec::from(decap_key_bytes),
+        decap_key_bytes: Zeroizing::new(Vec::from(decap_key_bytes)),
     }))
 }
 

--- a/spdmlib_crypto_aws_lc/src/kem_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/kem_impl.rs
@@ -2,9 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
-use aws_lc_rs::kem::{
-    Ciphertext, DecapsulationKey, EncapsulationKey, ML_KEM_1024, ML_KEM_512, ML_KEM_768,
-};
+use alloc::{boxed::Box, vec::Vec};
+#[cfg(feature = "ml-kem-1024")]
+use aws_lc_rs::kem::ML_KEM_1024;
+#[cfg(feature = "ml-kem-512")]
+use aws_lc_rs::kem::ML_KEM_512;
+#[cfg(feature = "ml-kem-768")]
+use aws_lc_rs::kem::ML_KEM_768;
+#[cfg(any(
+    feature = "ml-kem-512",
+    feature = "ml-kem-768",
+    feature = "ml-kem-1024"
+))]
+use aws_lc_rs::kem::{Ciphertext, DecapsulationKey, EncapsulationKey};
+use log::debug;
 use spdmlib::crypto::{
     SpdmKemCipherTextExchange, SpdmKemDecap, SpdmKemEncap, SpdmKemEncapKeyExchange,
 };
@@ -32,31 +43,52 @@ impl SpdmKemEncapKeyExchange for AwsLcKemDecapKey {
         self: Box<Self>,
         kem_cipher_text: &SpdmKemCipherTextStruct,
     ) -> Option<SpdmSharedSecretFinalKeyStruct> {
-        let ct_size = self.kem_algo.get_cipher_text_size() as usize;
-        let ct_bytes = &kem_cipher_text.data[..ct_size];
+        #[cfg(any(
+            feature = "ml-kem-512",
+            feature = "ml-kem-768",
+            feature = "ml-kem-1024"
+        ))]
+        {
+            let ct_size = self.kem_algo.get_cipher_text_size() as usize;
+            let ct_bytes = &kem_cipher_text.data[..ct_size];
 
-        let shared_secret = match self.kem_algo {
-            SpdmKemAlgo::ALG_MLKEM_512 => {
-                let dk = DecapsulationKey::new(&ML_KEM_512, &self.decap_key_bytes).ok()?;
-                dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
-            }
-            SpdmKemAlgo::ALG_MLKEM_768 => {
-                let dk = DecapsulationKey::new(&ML_KEM_768, &self.decap_key_bytes).ok()?;
-                dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
-            }
-            SpdmKemAlgo::ALG_MLKEM_1024 => {
-                let dk = DecapsulationKey::new(&ML_KEM_1024, &self.decap_key_bytes).ok()?;
-                dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
-            }
-            _ => return None,
-        };
+            let shared_secret = match self.kem_algo {
+                #[cfg(feature = "ml-kem-512")]
+                SpdmKemAlgo::ALG_MLKEM_512 => {
+                    let dk = DecapsulationKey::new(&ML_KEM_512, &self.decap_key_bytes).ok()?;
+                    dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
+                }
+                #[cfg(feature = "ml-kem-768")]
+                SpdmKemAlgo::ALG_MLKEM_768 => {
+                    let dk = DecapsulationKey::new(&ML_KEM_768, &self.decap_key_bytes).ok()?;
+                    dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
+                }
+                #[cfg(feature = "ml-kem-1024")]
+                SpdmKemAlgo::ALG_MLKEM_1024 => {
+                    let dk = DecapsulationKey::new(&ML_KEM_1024, &self.decap_key_bytes).ok()?;
+                    dk.decapsulate(Ciphertext::from(ct_bytes)).ok()?
+                }
+                _ => return None,
+            };
 
-        let ss_bytes = shared_secret.as_ref();
-        let mut result = SpdmSharedSecretFinalKeyStruct::default();
-        let len = ss_bytes.len().min(SPDM_MAX_KEM_SHARED_SECRET_SIZE);
-        result.data[..len].copy_from_slice(&ss_bytes[..len]);
-        result.data_size = len as u16;
-        Some(result)
+            let ss_bytes = shared_secret.as_ref();
+            let mut result = SpdmSharedSecretFinalKeyStruct::default();
+            let len = ss_bytes.len().min(SPDM_MAX_KEM_SHARED_SECRET_SIZE);
+            result.data[..len].copy_from_slice(&ss_bytes[..len]);
+            result.data_size = len as u16;
+            debug!("ML-KEM shared secret derived: {:?}", self.kem_algo);
+            Some(result)
+        }
+
+        #[cfg(not(any(
+            feature = "ml-kem-512",
+            feature = "ml-kem-768",
+            feature = "ml-kem-1024"
+        )))]
+        {
+            let _ = kem_cipher_text;
+            None
+        }
     }
 
     fn export_decap_key(&self) -> Option<Vec<u8>> {
@@ -75,38 +107,62 @@ impl SpdmKemCipherTextExchange for AwsLcKemEncapKey {
     fn encap_key(
         self: Box<Self>,
     ) -> Option<(SpdmKemCipherTextStruct, SpdmSharedSecretFinalKeyStruct)> {
-        let (ciphertext, shared_secret) = match self.kem_algo {
-            SpdmKemAlgo::ALG_MLKEM_512 => {
-                let ek = EncapsulationKey::new(&ML_KEM_512, &self.encap_key_bytes).ok()?;
-                ek.encapsulate().ok()?
-            }
-            SpdmKemAlgo::ALG_MLKEM_768 => {
-                let ek = EncapsulationKey::new(&ML_KEM_768, &self.encap_key_bytes).ok()?;
-                ek.encapsulate().ok()?
-            }
-            SpdmKemAlgo::ALG_MLKEM_1024 => {
-                let ek = EncapsulationKey::new(&ML_KEM_1024, &self.encap_key_bytes).ok()?;
-                ek.encapsulate().ok()?
-            }
-            _ => return None,
-        };
+        #[cfg(any(
+            feature = "ml-kem-512",
+            feature = "ml-kem-768",
+            feature = "ml-kem-1024"
+        ))]
+        {
+            let (ciphertext, shared_secret) = match self.kem_algo {
+                #[cfg(feature = "ml-kem-512")]
+                SpdmKemAlgo::ALG_MLKEM_512 => {
+                    let ek = EncapsulationKey::new(&ML_KEM_512, &self.encap_key_bytes).ok()?;
+                    ek.encapsulate().ok()?
+                }
+                #[cfg(feature = "ml-kem-768")]
+                SpdmKemAlgo::ALG_MLKEM_768 => {
+                    let ek = EncapsulationKey::new(&ML_KEM_768, &self.encap_key_bytes).ok()?;
+                    ek.encapsulate().ok()?
+                }
+                #[cfg(feature = "ml-kem-1024")]
+                SpdmKemAlgo::ALG_MLKEM_1024 => {
+                    let ek = EncapsulationKey::new(&ML_KEM_1024, &self.encap_key_bytes).ok()?;
+                    ek.encapsulate().ok()?
+                }
+                _ => return None,
+            };
 
-        let ct_bytes = ciphertext.as_ref();
-        let mut ct_struct = SpdmKemCipherTextStruct::default();
-        let ct_len = ct_bytes.len().min(SPDM_MAX_KEM_CIPHER_TEXT_SIZE);
-        ct_struct.data[..ct_len].copy_from_slice(&ct_bytes[..ct_len]);
-        ct_struct.data_size = ct_len as u16;
+            let ct_bytes = ciphertext.as_ref();
+            let mut ct_struct = SpdmKemCipherTextStruct::default();
+            let ct_len = ct_bytes.len().min(SPDM_MAX_KEM_CIPHER_TEXT_SIZE);
+            ct_struct.data[..ct_len].copy_from_slice(&ct_bytes[..ct_len]);
+            ct_struct.data_size = ct_len as u16;
 
-        let ss_bytes = shared_secret.as_ref();
-        let mut ss_struct = SpdmSharedSecretFinalKeyStruct::default();
-        let ss_len = ss_bytes.len().min(SPDM_MAX_KEM_SHARED_SECRET_SIZE);
-        ss_struct.data[..ss_len].copy_from_slice(&ss_bytes[..ss_len]);
-        ss_struct.data_size = ss_len as u16;
+            let ss_bytes = shared_secret.as_ref();
+            let mut ss_struct = SpdmSharedSecretFinalKeyStruct::default();
+            let ss_len = ss_bytes.len().min(SPDM_MAX_KEM_SHARED_SECRET_SIZE);
+            ss_struct.data[..ss_len].copy_from_slice(&ss_bytes[..ss_len]);
+            ss_struct.data_size = ss_len as u16;
 
-        Some((ct_struct, ss_struct))
+            Some((ct_struct, ss_struct))
+        }
+
+        #[cfg(not(any(
+            feature = "ml-kem-512",
+            feature = "ml-kem-768",
+            feature = "ml-kem-1024"
+        )))]
+        {
+            None
+        }
     }
 }
 
+#[cfg(any(
+    feature = "ml-kem-512",
+    feature = "ml-kem-768",
+    feature = "ml-kem-1024"
+))]
 fn kem_generate_key_pair(
     kem_algo: SpdmKemAlgo,
 ) -> Option<(
@@ -114,6 +170,7 @@ fn kem_generate_key_pair(
     Box<dyn SpdmKemEncapKeyExchange + Send>,
 )> {
     let (encap_key_bytes, decap_key_bytes) = match kem_algo {
+        #[cfg(feature = "ml-kem-512")]
         SpdmKemAlgo::ALG_MLKEM_512 => {
             let dk = DecapsulationKey::generate(&ML_KEM_512).ok()?;
             let ek = dk.encapsulation_key().ok()?;
@@ -121,6 +178,7 @@ fn kem_generate_key_pair(
             let dk_bytes = dk.key_bytes().ok()?;
             (Vec::from(ek_bytes.as_ref()), Vec::from(dk_bytes.as_ref()))
         }
+        #[cfg(feature = "ml-kem-768")]
         SpdmKemAlgo::ALG_MLKEM_768 => {
             let dk = DecapsulationKey::generate(&ML_KEM_768).ok()?;
             let ek = dk.encapsulation_key().ok()?;
@@ -128,6 +186,7 @@ fn kem_generate_key_pair(
             let dk_bytes = dk.key_bytes().ok()?;
             (Vec::from(ek_bytes.as_ref()), Vec::from(dk_bytes.as_ref()))
         }
+        #[cfg(feature = "ml-kem-1024")]
         SpdmKemAlgo::ALG_MLKEM_1024 => {
             let dk = DecapsulationKey::generate(&ML_KEM_1024).ok()?;
             let ek = dk.encapsulation_key().ok()?;
@@ -151,6 +210,25 @@ fn kem_generate_key_pair(
     Some((ek_struct, exchange))
 }
 
+#[cfg(not(any(
+    feature = "ml-kem-512",
+    feature = "ml-kem-768",
+    feature = "ml-kem-1024"
+)))]
+fn kem_generate_key_pair(
+    _kem_algo: SpdmKemAlgo,
+) -> Option<(
+    SpdmKemEncapKeyStruct,
+    Box<dyn SpdmKemEncapKeyExchange + Send>,
+)> {
+    None
+}
+
+#[cfg(any(
+    feature = "ml-kem-512",
+    feature = "ml-kem-768",
+    feature = "ml-kem-1024"
+))]
 fn kem_import_decap_key(
     kem_algo: SpdmKemAlgo,
     decap_key_bytes: &[u8],
@@ -160,12 +238,15 @@ fn kem_import_decap_key(
     // the key the same way (matching the DHE import path). This rejects
     // mismatched sizes / wrong algorithms up front.
     match kem_algo {
+        #[cfg(feature = "ml-kem-512")]
         SpdmKemAlgo::ALG_MLKEM_512 => {
             DecapsulationKey::new(&ML_KEM_512, decap_key_bytes).ok()?;
         }
+        #[cfg(feature = "ml-kem-768")]
         SpdmKemAlgo::ALG_MLKEM_768 => {
             DecapsulationKey::new(&ML_KEM_768, decap_key_bytes).ok()?;
         }
+        #[cfg(feature = "ml-kem-1024")]
         SpdmKemAlgo::ALG_MLKEM_1024 => {
             DecapsulationKey::new(&ML_KEM_1024, decap_key_bytes).ok()?;
         }
@@ -176,6 +257,18 @@ fn kem_import_decap_key(
         kem_algo,
         decap_key_bytes: Vec::from(decap_key_bytes),
     }))
+}
+
+#[cfg(not(any(
+    feature = "ml-kem-512",
+    feature = "ml-kem-768",
+    feature = "ml-kem-1024"
+)))]
+fn kem_import_decap_key(
+    _kem_algo: SpdmKemAlgo,
+    _decap_key_bytes: &[u8],
+) -> Option<Box<dyn SpdmKemEncapKeyExchange + Send>> {
+    None
 }
 
 fn kem_new_key(

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -57,6 +57,8 @@ unsafe fn fill_entropy_with_rdrand(
     len: usize,
     mut rdrand_step: impl FnMut(&mut u64) -> bool,
 ) -> bool {
+    use zeroize::Zeroize;
+
     const MAX_RETRIES: usize = 10;
 
     let mut offset = 0;
@@ -70,12 +72,14 @@ unsafe fn fill_entropy_with_rdrand(
             }
         }
         if !ready {
+            value.zeroize();
             core::ptr::write_bytes(output, 0, len);
             return false;
         }
 
         let count = core::cmp::min(core::mem::size_of::<u64>(), len - offset);
         core::ptr::copy_nonoverlapping(value.to_ne_bytes().as_ptr(), output.add(offset), count);
+        value.zeroize();
         offset += count;
     }
     true

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+#![no_std]
+
 //! spdm-rs crypto backend using aws-lc-rs.
 //!
 //! Historically this crate supplied only the post-quantum primitives (ML-KEM,
@@ -9,8 +11,102 @@
 //! provides the traditional primitives (hash, HMAC, AEAD, ECDHE, RSA/ECDSA
 //! verify, HKDF, rand, certificate-chain verification), so aws-lc-rs can be
 //! used as a **standalone** backend for both traditional and PQC crypto on
-//! std targets (no ring, no mbedtls). See `register_crypto_callbacks` in the
+//! std and no-std targets (no ring, no mbedtls). See `register_crypto_callbacks` in the
 //! emulator layer.
+
+#[cfg(test)]
+extern crate std;
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_alloc(size: usize, align: usize) -> *mut u8 {
+    let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) else {
+        return core::ptr::null_mut();
+    };
+    alloc::alloc::alloc(layout)
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_dealloc(ptr: *mut u8, size: usize, align: usize) {
+    if let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) {
+        alloc::alloc::dealloc(ptr, layout);
+    }
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_realloc(
+    ptr: *mut u8,
+    old_size: usize,
+    new_size: usize,
+    align: usize,
+) -> *mut u8 {
+    let Ok(layout) = alloc::alloc::Layout::from_size_align(old_size, align) else {
+        return core::ptr::null_mut();
+    };
+    alloc::alloc::realloc(ptr, layout, new_size)
+}
+
+#[cfg(all(target_arch = "x86_64", any(target_os = "none", test)))]
+unsafe fn fill_entropy_with_rdrand(
+    output: *mut u8,
+    len: usize,
+    mut rdrand_step: impl FnMut(&mut u64) -> bool,
+) -> bool {
+    const MAX_RETRIES: usize = 10;
+
+    let mut offset = 0;
+    while offset < len {
+        let mut value = 0u64;
+        let mut ready = false;
+        for _ in 0..MAX_RETRIES {
+            if rdrand_step(&mut value) {
+                ready = true;
+                break;
+            }
+        }
+        if !ready {
+            core::ptr::write_bytes(output, 0, len);
+            return false;
+        }
+
+        let count = core::cmp::min(core::mem::size_of::<u64>(), len - offset);
+        core::ptr::copy_nonoverlapping(value.to_ne_bytes().as_ptr(), output.add(offset), count);
+        offset += count;
+    }
+    true
+}
+
+#[cfg(all(target_os = "none", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_entropy(output: *mut u8, len: usize) -> i32 {
+    use core::arch::x86_64::{__cpuid, _rdrand64_step};
+
+    const RDRAND_BIT: u32 = 1 << 30;
+
+    if (__cpuid(1).ecx & RDRAND_BIT) == 0 {
+        if len != 0 {
+            core::ptr::write_bytes(output, 0, len);
+        }
+        return 0;
+    }
+
+    if fill_entropy_with_rdrand(output, len, |value| _rdrand64_step(value) == 1) {
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub extern "C" fn aws_lc_nostd_abort() -> ! {
+    panic!("AWS-LC terminated the no-std runtime")
+}
 
 // PQC (post-quantum) primitives.
 pub mod kem_impl;
@@ -33,16 +129,42 @@ mod tests {
     use super::*;
     use spdmlib::protocol::SpdmKemAlgo;
 
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn entropy_failure_clears_partial_output() {
+        let mut output = [0xa5; 16];
+        let mut calls = 0;
+
+        let result = unsafe {
+            fill_entropy_with_rdrand(output.as_mut_ptr(), output.len(), |value| {
+                calls += 1;
+                if calls == 1 {
+                    *value = u64::MAX;
+                    true
+                } else {
+                    false
+                }
+            })
+        };
+
+        assert!(!result);
+        assert_eq!(calls, 11);
+        assert_eq!(output, [0; 16]);
+    }
+
+    #[cfg(feature = "ml-kem-512")]
     #[test]
     fn test_kem_512_roundtrip() {
         kem_roundtrip(SpdmKemAlgo::ALG_MLKEM_512);
     }
 
+    #[cfg(feature = "ml-kem-768")]
     #[test]
     fn test_kem_768_roundtrip() {
         kem_roundtrip(SpdmKemAlgo::ALG_MLKEM_768);
     }
 
+    #[cfg(feature = "ml-kem-1024")]
     #[test]
     fn test_kem_1024_roundtrip() {
         kem_roundtrip(SpdmKemAlgo::ALG_MLKEM_1024);
@@ -72,6 +194,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ml-dsa-44")]
     #[test]
     fn test_mldsa_44_sign_verify() {
         mldsa_sign_verify_roundtrip(
@@ -80,6 +203,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ml-dsa-65")]
     #[test]
     fn test_mldsa_65_sign_verify() {
         mldsa_sign_verify_roundtrip(
@@ -88,6 +212,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "ml-dsa-87")]
     #[test]
     fn test_mldsa_87_sign_verify() {
         mldsa_sign_verify_roundtrip(

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
@@ -10,11 +10,15 @@ const SPDM_SIGNING_PREFIX_LEN: usize = 64;
 const SPDM_SIGNING_CONTEXT_FIELD_LEN: usize = 36;
 
 // ML-DSA signature sizes
+#[cfg(feature = "ml-dsa-44")]
 const MLDSA_44_SIG_SIZE: usize = 2420;
+#[cfg(feature = "ml-dsa-65")]
 const MLDSA_65_SIG_SIZE: usize = 3309;
+#[cfg(feature = "ml-dsa-87")]
 const MLDSA_87_SIG_SIZE: usize = 4627;
 
 extern "C" {
+    #[cfg(feature = "ml-dsa-44")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_sign"]
     fn ml_dsa_44_sign(
         private_key: *const c_uchar,
@@ -26,6 +30,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
+    #[cfg(feature = "ml-dsa-65")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_65_sign"]
     fn ml_dsa_65_sign(
         private_key: *const c_uchar,
@@ -37,6 +42,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
+    #[cfg(feature = "ml-dsa-87")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_87_sign"]
     fn ml_dsa_87_sign(
         private_key: *const c_uchar,
@@ -69,6 +75,7 @@ fn extract_signing_context(data: &[u8]) -> &[u8] {
 ///
 /// `raw_private_key` is the raw ML-DSA private key bytes (not PKCS#8).
 /// `data` is the SPDM signing message (prefix + context + hash).
+#[cfg(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87"))]
 pub fn pqc_sign_with_context(
     pqc_asym_algo: SpdmPqcAsymAlgo,
     raw_private_key: &[u8],
@@ -82,15 +89,21 @@ pub fn pqc_sign_with_context(
     };
 
     let sig_size = match pqc_asym_algo {
+        #[cfg(feature = "ml-dsa-44")]
         SpdmPqcAsymAlgo::ALG_MLDSA_44 => MLDSA_44_SIG_SIZE,
+        #[cfg(feature = "ml-dsa-65")]
         SpdmPqcAsymAlgo::ALG_MLDSA_65 => MLDSA_65_SIG_SIZE,
+        #[cfg(feature = "ml-dsa-87")]
         SpdmPqcAsymAlgo::ALG_MLDSA_87 => MLDSA_87_SIG_SIZE,
         _ => return None,
     };
 
     let sign_fn: unsafe extern "C" fn(_, _, _, _, _, _, _) -> _ = match pqc_asym_algo {
+        #[cfg(feature = "ml-dsa-44")]
         SpdmPqcAsymAlgo::ALG_MLDSA_44 => ml_dsa_44_sign,
+        #[cfg(feature = "ml-dsa-65")]
         SpdmPqcAsymAlgo::ALG_MLDSA_65 => ml_dsa_65_sign,
+        #[cfg(feature = "ml-dsa-87")]
         SpdmPqcAsymAlgo::ALG_MLDSA_87 => ml_dsa_87_sign,
         _ => return None,
     };
@@ -121,4 +134,13 @@ pub fn pqc_sign_with_context(
         data_size: sig_len as u16,
         data: full_signature,
     })
+}
+
+#[cfg(not(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87")))]
+pub fn pqc_sign_with_context(
+    _pqc_asym_algo: SpdmPqcAsymAlgo,
+    _raw_private_key: &[u8],
+    _data: &[u8],
+) -> Option<SpdmSignatureStruct> {
+    None
 }

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
@@ -17,6 +17,9 @@ const MLDSA_65_SIG_SIZE: usize = 3309;
 #[cfg(feature = "ml-dsa-87")]
 const MLDSA_87_SIG_SIZE: usize = 4627;
 
+// These context-signing functions are not exposed by the safe aws-lc-rs API.
+// Their prefixed names are tied to the aws-lc-sys revision pinned in
+// external/patches/aws-lc-rs/README.md and must be updated with that pin.
 extern "C" {
     #[cfg(feature = "ml-dsa-44")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_sign"]

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
@@ -21,6 +21,9 @@ const MLDSA_87_KEY_SIZE: usize = 2592;
 const SPDM_SIGNING_PREFIX_LEN: usize = 64;
 const SPDM_SIGNING_CONTEXT_FIELD_LEN: usize = 36;
 
+// These context-verification functions are not exposed by the safe aws-lc-rs
+// API. Their prefixed names are tied to the aws-lc-sys revision pinned in
+// external/patches/aws-lc-rs/README.md and must be updated with that pin.
 extern "C" {
     #[cfg(feature = "ml-dsa-44")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_verify"]

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
@@ -2,15 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+use alloc::vec::Vec;
 use core::ffi::{c_int, c_uchar};
-use log::error;
+use log::{debug, error};
 use spdmlib::crypto::SpdmPqcAsymVerify;
 use spdmlib::error::{SpdmResult, SPDM_STATUS_INVALID_CERT, SPDM_STATUS_VERIF_FAIL};
 use spdmlib::protocol::{SpdmBaseHashAlgo, SpdmPqcAsymAlgo, SpdmSignatureStruct};
 
 // Raw public key sizes for ML-DSA variants (without SPKI DER header)
+#[cfg(feature = "ml-dsa-44")]
 const MLDSA_44_KEY_SIZE: usize = 1312;
+#[cfg(feature = "ml-dsa-65")]
 const MLDSA_65_KEY_SIZE: usize = 1952;
+#[cfg(feature = "ml-dsa-87")]
 const MLDSA_87_KEY_SIZE: usize = 2592;
 
 // SPDM signing prefix is 64 bytes, followed by 36 bytes of (zeropad + context_string).
@@ -18,6 +22,7 @@ const SPDM_SIGNING_PREFIX_LEN: usize = 64;
 const SPDM_SIGNING_CONTEXT_FIELD_LEN: usize = 36;
 
 extern "C" {
+    #[cfg(feature = "ml-dsa-44")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_verify"]
     fn ml_dsa_44_verify(
         public_key: *const c_uchar,
@@ -29,6 +34,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
+    #[cfg(feature = "ml-dsa-65")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_65_verify"]
     fn ml_dsa_65_verify(
         public_key: *const c_uchar,
@@ -40,6 +46,7 @@ extern "C" {
         ctx_string_len: usize,
     ) -> c_int;
 
+    #[cfg(feature = "ml-dsa-87")]
     #[link_name = "aws_lc_0_43_0_ml_dsa_87_verify"]
     fn ml_dsa_87_verify(
         public_key: *const c_uchar,
@@ -142,6 +149,7 @@ fn extract_signing_context(data: &[u8]) -> &[u8] {
     &[]
 }
 
+#[cfg(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87"))]
 fn pqc_asym_verify(
     _base_hash_algo: SpdmBaseHashAlgo,
     pqc_asym_algo: SpdmPqcAsymAlgo,
@@ -153,8 +161,11 @@ fn pqc_asym_verify(
     let ctx_string = extract_signing_context(data);
 
     let expected_key_size = match pqc_asym_algo {
+        #[cfg(feature = "ml-dsa-44")]
         SpdmPqcAsymAlgo::ALG_MLDSA_44 => MLDSA_44_KEY_SIZE,
+        #[cfg(feature = "ml-dsa-65")]
         SpdmPqcAsymAlgo::ALG_MLDSA_65 => MLDSA_65_KEY_SIZE,
+        #[cfg(feature = "ml-dsa-87")]
         SpdmPqcAsymAlgo::ALG_MLDSA_87 => MLDSA_87_KEY_SIZE,
         _ => return Err(SPDM_STATUS_VERIF_FAIL),
     };
@@ -171,8 +182,11 @@ fn pqc_asym_verify(
         };
 
     let verify_fn: unsafe extern "C" fn(_, _, _, _, _, _, _) -> _ = match pqc_asym_algo {
+        #[cfg(feature = "ml-dsa-44")]
         SpdmPqcAsymAlgo::ALG_MLDSA_44 => ml_dsa_44_verify,
+        #[cfg(feature = "ml-dsa-65")]
         SpdmPqcAsymAlgo::ALG_MLDSA_65 => ml_dsa_65_verify,
+        #[cfg(feature = "ml-dsa-87")]
         SpdmPqcAsymAlgo::ALG_MLDSA_87 => ml_dsa_87_verify,
         _ => return Err(SPDM_STATUS_VERIF_FAIL),
     };
@@ -196,8 +210,20 @@ fn pqc_asym_verify(
     };
 
     if result == 1 {
+        debug!("ML-DSA signature verified: {:?}", pqc_asym_algo);
         Ok(())
     } else {
         Err(SPDM_STATUS_VERIF_FAIL)
     }
+}
+
+#[cfg(not(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87")))]
+fn pqc_asym_verify(
+    _base_hash_algo: SpdmBaseHashAlgo,
+    _pqc_asym_algo: SpdmPqcAsymAlgo,
+    _public_key_der: &[u8],
+    _data: &[u8],
+    _signature: &SpdmSignatureStruct,
+) -> SpdmResult {
+    Err(SPDM_STATUS_VERIF_FAIL)
 }

--- a/spdmlib_crypto_aws_lc/src/pqc_cert_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_cert_verify_impl.rs
@@ -16,7 +16,12 @@
 //! `UnparsedPublicKey::verify` directly.
 
 use aws_lc_rs::signature::UnparsedPublicKey;
-use aws_lc_rs::unstable::signature::{ML_DSA_44, ML_DSA_65, ML_DSA_87};
+#[cfg(feature = "ml-dsa-44")]
+use aws_lc_rs::unstable::signature::ML_DSA_44;
+#[cfg(feature = "ml-dsa-65")]
+use aws_lc_rs::unstable::signature::ML_DSA_65;
+#[cfg(feature = "ml-dsa-87")]
+use aws_lc_rs::unstable::signature::ML_DSA_87;
 use log::error;
 use spdm_x509::crypto_backend::SignatureAlgorithm;
 use spdm_x509::error::{Error, Result};
@@ -26,6 +31,7 @@ use spdm_x509::error::{Error, Result};
 /// `public_key` may be either the raw FIPS 204 public key (the BIT STRING
 /// content of a SubjectPublicKeyInfo) or a DER-encoded SubjectPublicKeyInfo;
 /// aws-lc-rs's parser accepts both encodings.
+#[cfg(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87"))]
 fn verify_pqc_dsa(
     algorithm: SignatureAlgorithm,
     tbs_data: &[u8],
@@ -33,8 +39,11 @@ fn verify_pqc_dsa(
     public_key: &[u8],
 ) -> Result<()> {
     let verification_algo: &'static _ = match algorithm {
+        #[cfg(feature = "ml-dsa-44")]
         SignatureAlgorithm::MlDsa44 => &ML_DSA_44,
+        #[cfg(feature = "ml-dsa-65")]
         SignatureAlgorithm::MlDsa65 => &ML_DSA_65,
+        #[cfg(feature = "ml-dsa-87")]
         SignatureAlgorithm::MlDsa87 => &ML_DSA_87,
         _ => {
             return Err(Error::unsupported_algorithm(
@@ -50,6 +59,16 @@ fn verify_pqc_dsa(
     })
 }
 
+#[cfg(not(any(feature = "ml-dsa-44", feature = "ml-dsa-65", feature = "ml-dsa-87")))]
+fn verify_pqc_dsa(
+    _algorithm: SignatureAlgorithm,
+    _tbs_data: &[u8],
+    _signature: &[u8],
+    _public_key: &[u8],
+) -> Result<()> {
+    Err(Error::unsupported_algorithm("ML-DSA is disabled"))
+}
+
 /// Register the ML-DSA certificate verifier with `spdm_x509`.
 ///
 /// Idempotent: the first registration wins (mirroring the spdm-rs crypto
@@ -61,7 +80,14 @@ pub fn register() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    fn verify_chain(chain: &[u8]) -> spdm_x509::error::Result<()> {
+        spdm_x509::x509::chain::verify_cert_chain_with_backend(
+            chain,
+            crate::cert_operation_impl::AwsLcBackend,
+            None,
+            None,
+        )
+    }
 
     fn test_key_path(relative: &str) -> std::string::String {
         std::format!("{}/../test_key/{}", env!("CARGO_MANIFEST_DIR"), relative)
@@ -80,12 +106,12 @@ mod tests {
     /// real ML-DSA certificate chain (root self-signature + intermediate +
     /// leaf) end to end — this is the certificate-chain path exercised by the
     /// SPDM handshake in cert-chain mode.
+    #[cfg(feature = "full")]
     #[test]
     fn test_ml_dsa_cert_chain_happy_path() {
-        register();
         for dir in ["mldsa44", "mldsa65", "mldsa87"] {
             let chain = load_chain(dir);
-            let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+            let result = verify_chain(&chain);
             assert!(
                 result.is_ok(),
                 "{} ML-DSA chain should validate: {:?}",
@@ -98,9 +124,9 @@ mod tests {
     /// Fail path: a single flipped byte inside the leaf certificate's ML-DSA
     /// signature must cause chain validation to fail — proving the verifier
     /// actually checks the signature rather than accepting unconditionally.
+    #[cfg(feature = "ml-dsa-87")]
     #[test]
     fn test_ml_dsa_cert_chain_tampered_signature_rejected() {
-        register();
         let mut chain = load_chain("mldsa87");
 
         // The leaf certificate is last in the SPDM chain; its ML-DSA signature
@@ -108,7 +134,7 @@ mod tests {
         let len = chain.len();
         chain[len - 16] ^= 0xFF;
 
-        let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+        let result = verify_chain(&chain);
         assert!(
             result.is_err(),
             "tampered ML-DSA leaf signature must be rejected"
@@ -117,9 +143,9 @@ mod tests {
 
     /// Fail path: tampering with the intermediate certificate's TBS content
     /// (which is signed by the root) must be rejected during the chain walk.
+    #[cfg(feature = "ml-dsa-87")]
     #[test]
     fn test_ml_dsa_cert_chain_tampered_intermediate_rejected() {
-        register();
         let mut chain = load_chain("mldsa87");
 
         // Corrupt a byte in the first cert (root) region's later portion, which
@@ -128,7 +154,7 @@ mod tests {
         // Use an offset comfortably past the header but before the leaf.
         chain[1380] ^= 0xFF;
 
-        let result = spdm_x509::x509::chain::verify_cert_chain(&chain);
+        let result = verify_chain(&chain);
         assert!(
             result.is_err(),
             "tampered certificate in ML-DSA chain must be rejected"


### PR DESCRIPTION
## Summary

Add AWS-LC as a selectable `no_std` spdm-rs cryptographic backend with
classical algorithms, ML-DSA, and ML-KEM support.

This is Part 1 of the AWS-LC/PQC series. It provides the operational crypto
backend and dependency integration. Backend-neutral FIPS startup tests and
PQC known-answer tests are intentionally left for Part 2.

## Changes

- Add independent features for classical hash, AEAD, signature, and
  key-exchange algorithms while retaining the full default profile.
- Extend `spdmlib_crypto_aws_lc` into a standalone backend providing:
  - SHA-256, SHA-384, and SHA-512
  - HMAC and HKDF
  - AES-GCM and ChaCha20-Poly1305
  - ECDSA, RSA, and Ed25519 verification
  - ECDH
  - Certificate-chain verification
  - ML-DSA signing and verification
  - ML-KEM encapsulation and decapsulation
  - Checkpointable streaming hash contexts
- Add `no_std` allocation, entropy, and termination hooks for AWS-LC.
- Clear the complete entropy destination before reporting a transient
  `RDRAND` failure, so partial output is not exposed.
- Generate the SPDM checkpoint workspace size from project configuration.

## Dependency integration

Carry patches against pinned public aws-lc-rs and AWS-LC revisions to add:

- `no_std` runtime support
- Algorithm-scoped native builds
- Selectable ML-DSA and ML-KEM support
- Pregenerated binding support without consumer-side bindgen

Checked-in bindings are copied to the build output and converted to
`core`-compatible paths. Regenerated binding files are intentionally not
included in this repository.

Pinned revisions:

- aws-lc-rs: `9232f4df24627662243a1a7cf71d885b2ff6ce72`
- AWS-LC: `683ebde4bf3bcc016a9a710ad6b49c0c91b59161`

The dependency patches are temporary integration patches and can be
proposed to their respective upstream projects separately.

## Review guide

The commits are organized by review boundary:

1. Integrate the pinned `no_std` AWS-LC patch stack.
2. Add selectable classical spdmlib algorithms.
3. Add selectable AWS-LC crypto profiles, PQC, and `no_std` support.

## Validation

The following checks pass at the Part 1 endpoint:

- AWS-LC backend unit suite: 33 tests
- AWS-LC entropy failure regression
- ML-DSA signing and verification tests
- ML-KEM encapsulation and decapsulation tests
- Classical AWS-LC backend tests
- `x86_64-unknown-none` AWS-LC check using Clang

## Follow-up

Part 2 adds backend-neutral FIPS startup tests and ML-DSA-87/ML-KEM-1024
known-answer tests on top of this branch.

The carried AWS-LC patches target pinned revisions. Some PQC operations use
symbols tied to that pinned build and should move behind supported
aws-lc-rs APIs when the dependency changes are upstreamed.