### PR TITLE
feat(spdmlib): size checkpoint workspace dynamically

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -1316,53 +1316,61 @@ impl SpdmContext {
         Ok(used.0)
     }
 
-    /// Export all serializable data components of the SpdmContext
-    pub fn export(&self) -> SpdmResult<Vec<u8>> {
-        // Use a large heap-allocated buffer for encoding
-        let mut buffer = Box::new([0u8; 0x20000]); // 128 KiB buffer on heap
-        let mut writer = Writer::init(&mut buffer[..]);
-
+    fn encode_checkpoint_data(&self, writer: &mut Writer) -> Result<usize, codec::EncodeErr> {
         // Serialize core data structures
-        self.config_info
-            .encode(&mut writer)
-            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
-        self.negotiate_info
-            .encode(&mut writer)
-            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
-        self.runtime_info
-            .encode(&mut writer)
-            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
-        self.provision_info
-            .encode(&mut writer)
-            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
-        self.peer_info
-            .encode(&mut writer)
-            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+        self.config_info.encode(writer)?;
+        self.negotiate_info.encode(writer)?;
+        self.runtime_info.encode(writer)?;
+        self.provision_info.encode(writer)?;
+        self.peer_info.encode(writer)?;
 
         #[cfg(feature = "mut-auth")]
         {
-            self.encap_context
-                .encode(&mut writer)
-                .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+            self.encap_context.encode(writer)?;
         }
 
         #[cfg(feature = "mandatory-mut-auth")]
         {
-            (self.mut_auth_done as u8)
-                .encode(&mut writer)
-                .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+            (self.mut_auth_done as u8).encode(writer)?;
         }
 
         // Serialize sessions
         for session in &self.session {
-            session
-                .encode(&mut writer)
-                .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+            session.encode(writer)?;
         }
 
-        // Convert the used portion of the buffer to a Vec
-        let used_size = writer.used();
-        Ok(buffer[..used_size].to_vec())
+        Ok(writer.used())
+    }
+
+    /// Export all serializable data components of the SpdmContext
+    pub fn export(&self) -> SpdmResult<Vec<u8>> {
+        let mut buffer = Vec::new();
+        buffer
+            .try_reserve_exact(config::MAX_SPDM_MSG_SIZE)
+            .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+        buffer.resize(config::MAX_SPDM_MSG_SIZE, 0);
+
+        loop {
+            let encode_result = {
+                let mut writer = Writer::init(&mut buffer);
+                self.encode_checkpoint_data(&mut writer)
+            };
+
+            match encode_result {
+                Ok(used_size) => {
+                    buffer.truncate(used_size);
+                    return Ok(buffer);
+                }
+                Err(codec::EncodeErr) => {
+                    let current_size = buffer.len();
+                    let new_size = current_size.checked_mul(2).ok_or(SPDM_STATUS_BUFFER_FULL)?;
+                    buffer
+                        .try_reserve_exact(current_size)
+                        .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
+                    buffer.resize(new_size, 0);
+                }
+            }
+        }
     }
 
     /// Import serializable data components into the SpdmContext

--- a/test/spdmlib-test/src/test_library.rs
+++ b/test/spdmlib-test/src/test_library.rs
@@ -902,6 +902,16 @@ fn test_case3_spdm_context_export_import_boundary_conditions() {
         original_context.peer_info.peer_cert_chain[slot] = Some(cert_chain_buffer);
     }
 
+    let max_cert_data = spdmlib::protocol::SpdmCertChainData {
+        data_size: spdmlib::config::MAX_SPDM_CERT_CHAIN_DATA_SIZE as u32,
+        data: [0xCD; spdmlib::config::MAX_SPDM_CERT_CHAIN_DATA_SIZE],
+    };
+    for root_cert in &mut original_context.provision_info.peer_root_cert_data {
+        *root_cert = Some(max_cert_data);
+    }
+    original_context.provision_info.my_pub_key = Some(max_cert_data);
+    original_context.provision_info.peer_pub_key = Some(max_cert_data);
+
     // Set all slot masks
     original_context.provision_info.local_supported_slot_mask = 0xFF;
     original_context.peer_info.peer_supported_slot_mask = 0xFF;
@@ -944,6 +954,11 @@ fn test_case3_spdm_context_export_import_boundary_conditions() {
     assert!(
         !exported_data.is_empty(),
         "Exported data should not be empty"
+    );
+    const PREVIOUS_WORKSPACE_SIZE: usize = 128 * 1024;
+    assert!(
+        exported_data.len() > PREVIOUS_WORKSPACE_SIZE,
+        "Boundary fixture must exceed the previous 128 KiB workspace"
     );
 
     // Create a new context and import


### PR DESCRIPTION
Grow the checkpoint serialization workspace until the complete SPDM context
can be encoded. Return only bytes used and report allocation or size
overflow as SPDM_STATUS_BUFFER_FULL.

Remove the project-configured workspace bound so callers do not need to
predict serialized context size.

Assisted-by: GitHub Copilot:GPT-5.6 Sol