### PR TITLE
feat(spdmlib): introduce support for no_std in aws-lc-rs - Part 2

### DIFF
--- a/sh_script/build.sh
+++ b/sh_script/build.sh
@@ -117,12 +117,24 @@ build() {
     echo_command unset SPDM_CONFIG
 
     # Standalone aws-lc backend (no ring, no mbedtls): aws-lc-rs supplies both
-    # classical and PQC crypto. std-only. Compile-checked here on every build.
+    # classical and PQC crypto. Compile-checked here on every build.
     echo "Building spdm-requester-emu with standalone aws-lc (spdm-aws-lc, no ring/mbedtls)..."
     echo_command cargo build -p spdm-requester-emu --no-default-features --features="spdm-aws-lc,hashed-transcript-data,async-executor"
 
     echo "Building spdm-responder-emu with standalone aws-lc (spdm-aws-lc, no ring/mbedtls)..."
     echo_command cargo build -p spdm-responder-emu --no-default-features --features="spdm-aws-lc,hashed-transcript-data,async-executor"
+
+    # no_std target: compile-check the standalone aws-lc backend for bare metal
+    # (x86_64-unknown-none) so the crate's #![no_std] path stays buildable.
+    # aws-lc-sys' no-std build passes clang-only flags (e.g. -nostdlibinc), so
+    # force clang/llvm-ar for this target unless the caller already set them.
+    if [ -z "$RUSTFLAGS" ]; then
+        : "${CC_x86_64_unknown_none:=clang}"
+        : "${AR_x86_64_unknown_none:=llvm-ar}"
+        export CC_x86_64_unknown_none AR_x86_64_unknown_none
+        echo "Building spdmlib_crypto_aws_lc for no_std target (${TARGET_OPTION})..."
+        echo_command cargo build -p spdmlib_crypto_aws_lc --target ${TARGET_OPTION} --release
+    fi
 }
 
 RUN_REQUESTER_FEATURES=${RUN_REQUESTER_FEATURES:-spdm-ring,hashed-transcript-data,async-executor}

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -7,7 +7,15 @@ license = "Apache-2.0 or MIT"
 [dependencies]
 spdmlib = { path = "../spdmlib", default-features = false }
 spdm_x509 = { path = "../spdmlib/src/crypto/spdm_x509", default-features = false }
-aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", features = ["unstable"] }
+# alloc (not std) so the backend builds for no_std targets such as x86_64-unknown-none.
+aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", default-features = false, features = [
+    "aws-lc-sys",
+    "alloc",
+    "ring-sig-verify",
+    "ml-kem",
+    "ml-dsa",
+    "unstable",
+] }
 log = { version = "0.4", default-features = false }
 # For the streaming hash-context handle table (hashed-transcript-data).
 lazy_static = { version = "1.0", features = ["spin_no_std"] }

--- a/spdmlib_crypto_aws_lc/src/kem_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/kem_impl.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+use alloc::{boxed::Box, vec::Vec};
 use aws_lc_rs::kem::{
     Ciphertext, DecapsulationKey, EncapsulationKey, ML_KEM_1024, ML_KEM_512, ML_KEM_768,
 };

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+#![no_std]
+
 //! spdm-rs crypto backend using aws-lc-rs.
 //!
 //! Historically this crate supplied only the post-quantum primitives (ML-KEM,
@@ -9,8 +11,102 @@
 //! provides the traditional primitives (hash, HMAC, AEAD, ECDHE, RSA/ECDSA
 //! verify, HKDF, rand, certificate-chain verification), so aws-lc-rs can be
 //! used as a **standalone** backend for both traditional and PQC crypto on
-//! std targets (no ring, no mbedtls). See `register_crypto_callbacks` in the
+//! std and no-std targets (no ring, no mbedtls). See `register_crypto_callbacks` in the
 //! emulator layer.
+
+#[cfg(test)]
+extern crate std;
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_alloc(size: usize, align: usize) -> *mut u8 {
+    let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) else {
+        return core::ptr::null_mut();
+    };
+    alloc::alloc::alloc(layout)
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_dealloc(ptr: *mut u8, size: usize, align: usize) {
+    if let Ok(layout) = alloc::alloc::Layout::from_size_align(size, align) {
+        alloc::alloc::dealloc(ptr, layout);
+    }
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_realloc(
+    ptr: *mut u8,
+    old_size: usize,
+    new_size: usize,
+    align: usize,
+) -> *mut u8 {
+    let Ok(layout) = alloc::alloc::Layout::from_size_align(old_size, align) else {
+        return core::ptr::null_mut();
+    };
+    alloc::alloc::realloc(ptr, layout, new_size)
+}
+
+#[cfg(all(target_arch = "x86_64", any(target_os = "none", test)))]
+unsafe fn fill_entropy_with_rdrand(
+    output: *mut u8,
+    len: usize,
+    mut rdrand_step: impl FnMut(&mut u64) -> bool,
+) -> bool {
+    const MAX_RETRIES: usize = 10;
+
+    let mut offset = 0;
+    while offset < len {
+        let mut value = 0u64;
+        let mut ready = false;
+        for _ in 0..MAX_RETRIES {
+            if rdrand_step(&mut value) {
+                ready = true;
+                break;
+            }
+        }
+        if !ready {
+            core::ptr::write_bytes(output, 0, len);
+            return false;
+        }
+
+        let count = core::cmp::min(core::mem::size_of::<u64>(), len - offset);
+        core::ptr::copy_nonoverlapping(value.to_ne_bytes().as_ptr(), output.add(offset), count);
+        offset += count;
+    }
+    true
+}
+
+#[cfg(all(target_os = "none", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern "C" fn aws_lc_nostd_entropy(output: *mut u8, len: usize) -> i32 {
+    use core::arch::x86_64::{__cpuid, _rdrand64_step};
+
+    const RDRAND_BIT: u32 = 1 << 30;
+
+    if (__cpuid(1).ecx & RDRAND_BIT) == 0 {
+        if len != 0 {
+            core::ptr::write_bytes(output, 0, len);
+        }
+        return 0;
+    }
+
+    if fill_entropy_with_rdrand(output, len, |value| _rdrand64_step(value) == 1) {
+        1
+    } else {
+        0
+    }
+}
+
+#[cfg(target_os = "none")]
+#[no_mangle]
+pub extern "C" fn aws_lc_nostd_abort() -> ! {
+    panic!("AWS-LC terminated the no-std runtime")
+}
 
 // PQC (post-quantum) primitives.
 pub mod kem_impl;
@@ -32,6 +128,29 @@ pub mod rand_impl;
 mod tests {
     use super::*;
     use spdmlib::protocol::SpdmKemAlgo;
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn entropy_failure_clears_partial_output() {
+        let mut output = [0xa5; 16];
+        let mut calls = 0;
+
+        let result = unsafe {
+            fill_entropy_with_rdrand(output.as_mut_ptr(), output.len(), |value| {
+                calls += 1;
+                if calls == 1 {
+                    *value = u64::MAX;
+                    true
+                } else {
+                    false
+                }
+            })
+        };
+
+        assert!(!result);
+        assert_eq!(calls, 11);
+        assert_eq!(output, [0; 16]);
+    }
 
     #[test]
     fn test_kem_512_roundtrip() {

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 
+use alloc::vec::Vec;
 use core::ffi::{c_int, c_uchar};
 use log::error;
 use spdmlib::crypto::SpdmPqcAsymVerify;


### PR DESCRIPTION
## Summary

Makes the standalone AWS-LC crypto backend (`spdmlib_crypto_aws_lc`) build for
bare-metal `no_std` targets such as `x86_64-unknown-none`, and wires a
compile-check into `build.sh` so the `#![no_std]` path stays green in CI.

## What changed

### `feat(spdmlib_crypto_aws_lc): support no_std targets`
- Add `#![no_std]` with an `alloc`-based runtime:
  - Expose the AWS-LC allocator, entropy (RDRAND), and abort callbacks required
    when building without `std` (`#[cfg(target_os = "none")]`).
  - Add the `alloc` imports (`Vec`/`Box`) that are no longer provided by the
    `std` prelude in `kem_impl.rs` and `pqc_asym_verify_impl.rs`.
  - Cover the entropy fill path with a focused unit test.
- Build `aws-lc-rs` with `default-features = false` and the `alloc` (not `std`)
  feature set: `aws-lc-sys`, `alloc`, `ring-sig-verify`, `ml-kem`, `ml-dsa`,
  `unstable`.

### `ci: build spdmlib_crypto_aws_lc for the no_std target`
- Add a `cargo build -p spdmlib_crypto_aws_lc --target x86_64-unknown-none
  --release` compile-check to `build.sh`, guarded by an empty `RUSTFLAGS` like
  the other bare-metal builds.
- Default `CC`/`AR` for the target to `clang`/`llvm-ar` unless the caller
  already set them. `aws-lc-sys`' no-std build passes clang-only flags (e.g.
  `-nostdlibinc`), so falling back to `gcc` breaks the C build.

## Notes

- `ring-io` is intentionally **not** enabled: the vendored `aws-lc-rs` has a
  `no_std` gap under that feature (`rsa/key.rs` uses `Vec` without importing it),
  and the backend does not need `ring-io`. This keeps the fix local to this repo
  rather than patching the submodule.

## Testing

- `cargo build -p spdmlib_crypto_aws_lc` (host) — succeeds.
- `cargo test -p spdmlib_crypto_aws_lc -- --test-threads=1` — all tests pass.
- `cargo build -p spdmlib_crypto_aws_lc --target x86_64-unknown-none --release`
  — succeeds, verified with `CC`/`AR` env unset (defaults applied by `build.sh`).
