### PR TITLE
fix(spdmlib): increase MAX_SPDM_CERT_PORTION_LEN to 1024

### DIFF
--- a/spdmlib/src/message/certificate.rs
+++ b/spdmlib/src/message/certificate.rs
@@ -10,7 +10,7 @@ use crate::protocol::{
 use crate::{common, error::SpdmStatus};
 use codec::{Codec, Reader, Writer};
 
-pub const MAX_SPDM_CERT_PORTION_LEN: usize = 512;
+pub const MAX_SPDM_CERT_PORTION_LEN: usize = 1024;
 
 #[derive(Debug, Clone, Default)]
 pub struct SpdmGetCertificateRequestPayload {


### PR DESCRIPTION
Raise MAX_SPDM_CERT_PORTION_LEN from 512 to 1024 to reduce the number of GET_CERTIFICATE commands needed to retrieve a certificate chain.

Fixes #430

With PQC-enabled, where cert chain, worst case, can be up to 25 KiB with ML-DSA-87, this lowers number of messages required for certificate transmission from around 50 to 25 (by half).