### PR TITLE
build(spdmlib_crypto_aws_lc): enable AWS-LC small mode

### DIFF
--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -14,6 +14,7 @@ aws-lc-rs = { path = "../external/aws-lc-rs/aws-lc-rs", default-features = false
     "ring-sig-verify",
     "ml-kem",
     "ml-dsa",
+    "small",
     "unstable",
 ] }
 log = { version = "0.4", default-features = false }


### PR DESCRIPTION
Select aws-lc-rs small mode unconditionally so native AWS-LC favors code size without exposing another backend feature flag.

Assisted-by: GitHub Copilot:GPT-5.6 Sol