### PR TITLE
spdmlib: bind chunked transfers to their session

### DIFF
--- a/spdmlib/src/common/mod.rs
+++ b/spdmlib/src/common/mod.rs
@@ -2918,6 +2918,9 @@ pub struct SpdmChunkContext {
     pub chunk_message_size: usize,
     pub chunk_message_data: [u8; config::MAX_SPDM_MSG_SIZE],
     pub transferred_size: usize,
+    // Session the staged large response belongs to (`None` when unsecured), so a
+    // CHUNK_GET can be rejected if it arrives on a different session.
+    pub session_id: Option<u32>,
 }
 
 #[cfg(feature = "chunk-cap")]
@@ -2929,6 +2932,7 @@ impl Default for SpdmChunkContext {
             chunk_message_size: 0,
             chunk_message_data: [0u8; config::MAX_SPDM_MSG_SIZE],
             transferred_size: 0,
+            session_id: None,
         }
     }
 }

--- a/spdmlib/src/requester/context.rs
+++ b/spdmlib/src/requester/context.rs
@@ -463,12 +463,12 @@ impl RequesterContext {
                 }),
             };
             let used = chunk_get_request.spdm_encode(&mut self.common, &mut writer)?;
-            self.send_single_message(None, &send_buffer[..used], false)
+            self.send_single_message(session_id, &send_buffer[..used], false)
                 .await?;
 
             let mut receive_buffer = [0u8; config::SPDM_DATA_TRANSFER_SIZE];
             let used = self
-                .receive_single_message(None, &mut receive_buffer, crypto_request)
+                .receive_single_message(session_id, &mut receive_buffer, crypto_request)
                 .await?;
 
             self.handle_spdm_chunk_response(&receive_buffer[..used], session_id)

--- a/spdmlib/src/responder/context.rs
+++ b/spdmlib/src/responder/context.rs
@@ -85,6 +85,8 @@ impl ResponderContext {
                 self.common.chunk_context.transferred_size = 0;
                 self.common.chunk_context.chunk_status =
                     common::SpdmChunkStatus::ChunkGetAndResponse;
+                // Bind the staged response to the session it belongs to.
+                self.common.chunk_context.session_id = session_id;
                 self.write_spdm_error(SpdmErrorCode::SpdmErrorLargeResponse, 0, &mut writer);
                 let _ = self.common.chunk_rsp_handle.encode(&mut writer);
                 writer.used_slice()
@@ -137,6 +139,7 @@ impl ResponderContext {
                 self.common.chunk_context.chunk_message_data.fill(0);
                 self.common.chunk_context.transferred_size = 0;
                 self.common.chunk_context.chunk_status = common::SpdmChunkStatus::Idle;
+                self.common.chunk_context.session_id = None;
             }
         } else if self.common.chunk_context.chunk_status
             == common::SpdmChunkStatus::ChunkGetAndResponse
@@ -149,6 +152,7 @@ impl ResponderContext {
             self.common.chunk_context.chunk_message_data.fill(0);
             self.common.chunk_context.transferred_size = 0;
             self.common.chunk_context.chunk_status = common::SpdmChunkStatus::Idle;
+            self.common.chunk_context.session_id = None;
         }
         if opcode == SpdmRequestResponseCode::SpdmResponseVersion.get_u8() {
             self.common
@@ -817,6 +821,7 @@ impl ResponderContext {
             self.common.chunk_context.chunk_message_data.fill(0);
             self.common.chunk_context.transferred_size = 0;
             self.common.chunk_context.chunk_status = common::SpdmChunkStatus::Idle;
+            self.common.chunk_context.session_id = None;
         }
 
         (result, rsp_slice)
@@ -933,9 +938,17 @@ impl ResponderContext {
                 self.common.chunk_context.chunk_seq_num = chunk_send_request.chunk_seq_num;
                 self.common.chunk_context.chunk_message_size = large_message_size;
                 self.common.chunk_context.chunk_status = common::SpdmChunkStatus::ChunkSendAndAck;
+                self.common.chunk_context.session_id = session_id;
             } else if self.common.chunk_context.chunk_status
                 == common::SpdmChunkStatus::ChunkSendAndAck
             {
+                if session_id != self.common.chunk_context.session_id {
+                    self.write_spdm_error(SpdmErrorCode::SpdmErrorUnexpectedRequest, 0, writer);
+                    return (
+                        Err(SPDM_STATUS_INVALID_STATE_PEER),
+                        Some(writer.used_slice()),
+                    );
+                }
                 let max_chunk_size = (config::SPDM_DATA_TRANSFER_SIZE
                     - SPDM_VERSION_1_2_OFFSET_OF_SPDM_CHUNK_IN_CHUNK_SEND)
                     as u32;
@@ -1089,6 +1102,7 @@ impl ResponderContext {
             self.common.chunk_context.chunk_message_size = 0;
             self.common.chunk_context.transferred_size = 0;
             self.common.chunk_context.chunk_message_data.fill(0);
+            self.common.chunk_context.session_id = None;
         }
 
         (result, rsp_slice)
@@ -1097,7 +1111,7 @@ impl ResponderContext {
     #[cfg(feature = "chunk-cap")]
     fn write_spdm_chunk_get_response<'a>(
         &mut self,
-        _session_id: Option<u32>,
+        session_id: Option<u32>,
         bytes: &[u8],
         writer: &'a mut Writer,
     ) -> (SpdmResult, Option<&'a [u8]>) {
@@ -1135,6 +1149,14 @@ impl ResponderContext {
                 && self.common.runtime_info.get_connection_state()
                     == SpdmConnectionState::SpdmConnectionAfterVersion)
         {
+            self.write_spdm_error(SpdmErrorCode::SpdmErrorUnexpectedRequest, 0, writer);
+            return (
+                Err(SPDM_STATUS_INVALID_STATE_PEER),
+                Some(writer.used_slice()),
+            );
+        }
+
+        if chunk_get_in_progress && session_id != self.common.chunk_context.session_id {
             self.write_spdm_error(SpdmErrorCode::SpdmErrorUnexpectedRequest, 0, writer);
             return (
                 Err(SPDM_STATUS_INVALID_STATE_PEER),
@@ -1258,3 +1280,7 @@ impl ResponderContext {
         (Ok(()), Some(writer.used_slice()))
     }
 }
+
+#[cfg(all(test, feature = "chunk-cap"))]
+#[path = "context_test.rs"]
+mod context_test;

--- a/spdmlib/src/responder/context_test.rs
+++ b/spdmlib/src/responder/context_test.rs
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+
+//! Session-binding tests for the chunked-transfer handlers: a CHUNK_GET /
+//! CHUNK_SEND that arrives on a session different from the one the transfer was
+//! staged for must be rejected with ERROR/UnexpectedRequest.
+
+use super::ResponderContext;
+use crate::common::{
+    SpdmChunkStatus, SpdmCodec, SpdmConfigInfo, SpdmConnectionState, SpdmDeviceIo,
+    SpdmProvisionInfo, SpdmTransportEncap,
+};
+use crate::config;
+use crate::message::*;
+use crate::protocol::{SpdmRequestCapabilityFlags, SpdmResponseCapabilityFlags, SpdmVersion};
+use codec::{Codec, Reader, Writer};
+extern crate alloc;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+#[path = "../message/mod_test.common.inc.rs"]
+mod testlib;
+
+fn new_responder() -> ResponderContext {
+    let transport_encap: Arc<Mutex<dyn SpdmTransportEncap + Send + Sync>> =
+        Arc::new(Mutex::new(testlib::TransportEncap {}));
+    let device_io: Arc<Mutex<dyn SpdmDeviceIo + Send + Sync>> =
+        Arc::new(Mutex::new(testlib::DeviceIO {}));
+    let mut ctx = ResponderContext::new(
+        device_io,
+        transport_encap,
+        SpdmConfigInfo::default(),
+        SpdmProvisionInfo::default(),
+    );
+    ctx.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion12;
+    ctx.common.negotiate_info.req_capabilities_sel |= SpdmRequestCapabilityFlags::CHUNK_CAP;
+    ctx.common.negotiate_info.rsp_capabilities_sel |= SpdmResponseCapabilityFlags::CHUNK_CAP;
+    ctx.common.negotiate_info.req_data_transfer_size_sel =
+        config::SPDM_SENDER_DATA_TRANSFER_SIZE as u32;
+    ctx.common
+        .runtime_info
+        .set_connection_state(SpdmConnectionState::SpdmConnectionAfterCapabilities);
+    ctx
+}
+
+/// Stage a large response for retrieval bound to `session_id`.
+fn stage_get(ctx: &mut ResponderContext, session_id: Option<u32>) {
+    ctx.common.chunk_rsp_handle = 7;
+    ctx.common.chunk_context.chunk_status = SpdmChunkStatus::ChunkGetAndResponse;
+    ctx.common.chunk_context.chunk_seq_num = 0;
+    ctx.common.chunk_context.chunk_message_size = 64;
+    ctx.common.chunk_context.transferred_size = 0;
+    ctx.common.chunk_context.session_id = session_id;
+}
+
+/// Stage an in-progress large-request reassembly bound to `session_id`.
+fn stage_send(ctx: &mut ResponderContext, session_id: Option<u32>) {
+    ctx.common.chunk_req_handle = 0;
+    ctx.common.chunk_context.chunk_status = SpdmChunkStatus::ChunkSendAndAck;
+    ctx.common.chunk_context.chunk_seq_num = 0;
+    ctx.common.chunk_context.chunk_message_size = 64;
+    ctx.common.chunk_context.transferred_size = 0;
+    ctx.common.chunk_context.session_id = session_id;
+}
+
+fn encode_chunk_get(handle: u8, seq: u32) -> Vec<u8> {
+    let mut enc = new_responder();
+    let msg = SpdmMessage {
+        header: SpdmMessageHeader {
+            version: SpdmVersion::SpdmVersion12,
+            request_response_code: SpdmRequestResponseCode::SpdmRequestChunkGet,
+        },
+        payload: SpdmMessagePayload::SpdmChunkGetRequest(SpdmChunkGetRequestPayload {
+            handle,
+            chunk_seq_num: seq,
+        }),
+    };
+    let mut buf = [0u8; 64];
+    let mut w = Writer::init(&mut buf);
+    let used = msg.spdm_encode(&mut enc.common, &mut w).unwrap();
+    buf[..used].to_vec()
+}
+
+fn encode_chunk_send(handle: u8, seq: u32, chunk_size: u32) -> Vec<u8> {
+    // Encode with a throwaway context primed with chunk data so the encoder can
+    // emit `chunk_size` payload bytes; its chunk_context mutation is harmless.
+    let mut enc = new_responder();
+    enc.common.chunk_context.chunk_message_size = config::MAX_SPDM_MSG_SIZE;
+    enc.common.chunk_context.transferred_size = 0;
+    let large_message_size = if seq == 0 { Some(64u32) } else { None };
+    let msg = SpdmMessage {
+        header: SpdmMessageHeader {
+            version: SpdmVersion::SpdmVersion12,
+            request_response_code: SpdmRequestResponseCode::SpdmRequestChunkSend,
+        },
+        payload: SpdmMessagePayload::SpdmChunkSendRequest(SpdmChunkSendRequestPayload {
+            chunk_sender_attributes: SpdmChunkSenderAttributes::default(),
+            handle,
+            chunk_seq_num: seq,
+            chunk_size,
+            large_message_size,
+        }),
+    };
+    let mut buf = [0u8; 128];
+    let mut w = Writer::init(&mut buf);
+    let used = msg.spdm_encode(&mut enc.common, &mut w).unwrap();
+    buf[..used].to_vec()
+}
+
+/// Whether `resp` is an ERROR/UnexpectedRequest message (the session-mismatch
+/// rejection). Byte layout: [version, ResponseError, error_code, error_data].
+fn is_unexpected_request(resp: &[u8]) -> bool {
+    let mut r = Reader::init(resp);
+    match SpdmMessageHeader::read(&mut r) {
+        Some(h) if h.request_response_code == SpdmRequestResponseCode::SpdmResponseError => {
+            resp.get(2).copied() == Some(SpdmErrorCode::SpdmErrorUnexpectedRequest.get_u8())
+        }
+        _ => false,
+    }
+}
+
+// ── CHUNK_GET / CHUNK_RESPONSE ──
+
+#[test]
+fn chunk_get_matching_session_is_served() {
+    let mut ctx = new_responder();
+    stage_get(&mut ctx, Some(0x1234));
+    let req = encode_chunk_get(7, 0);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (_res, resp) = ctx.write_spdm_chunk_get_response(Some(0x1234), &req, &mut w);
+    assert!(!is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_get_different_session_is_rejected() {
+    let mut ctx = new_responder();
+    stage_get(&mut ctx, Some(0x1234));
+    let req = encode_chunk_get(7, 0);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_get_response(Some(0x9999), &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_get_unsecured_for_session_response_is_rejected() {
+    let mut ctx = new_responder();
+    stage_get(&mut ctx, Some(0x1234));
+    let req = encode_chunk_get(7, 0);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_get_response(None, &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_get_secured_for_unsecured_response_is_rejected() {
+    let mut ctx = new_responder();
+    stage_get(&mut ctx, None);
+    let req = encode_chunk_get(7, 0);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_get_response(Some(0x1234), &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_get_unsecured_matching_is_served() {
+    let mut ctx = new_responder();
+    stage_get(&mut ctx, None);
+    let req = encode_chunk_get(7, 0);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (_res, resp) = ctx.write_spdm_chunk_get_response(None, &req, &mut w);
+    assert!(!is_unexpected_request(resp.unwrap()));
+}
+
+// ── CHUNK_SEND / CHUNK_SEND_ACK ──
+
+#[test]
+fn chunk_send_matching_session_passes() {
+    let mut ctx = new_responder();
+    stage_send(&mut ctx, Some(0x1234));
+    let req = encode_chunk_send(0, 1, 4);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (_res, resp) = ctx.write_spdm_chunk_send_response(Some(0x1234), &req, &mut w);
+    assert!(!is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_send_different_session_is_rejected() {
+    let mut ctx = new_responder();
+    stage_send(&mut ctx, Some(0x1234));
+    let req = encode_chunk_send(0, 1, 4);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_send_response(Some(0x9999), &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_send_unsecured_for_session_request_is_rejected() {
+    let mut ctx = new_responder();
+    stage_send(&mut ctx, Some(0x1234));
+    let req = encode_chunk_send(0, 1, 4);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_send_response(None, &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_send_secured_for_unsecured_request_is_rejected() {
+    let mut ctx = new_responder();
+    stage_send(&mut ctx, None);
+    let req = encode_chunk_send(0, 1, 4);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (res, resp) = ctx.write_spdm_chunk_send_response(Some(0x1234), &req, &mut w);
+    assert!(res.is_err());
+    assert!(is_unexpected_request(resp.unwrap()));
+}
+
+#[test]
+fn chunk_send_unsecured_matching_passes() {
+    let mut ctx = new_responder();
+    stage_send(&mut ctx, None);
+    let req = encode_chunk_send(0, 1, 4);
+    let mut buf = [0u8; 1024];
+    let mut w = Writer::init(&mut buf);
+    let (_res, resp) = ctx.write_spdm_chunk_send_response(None, &req, &mut w);
+    assert!(!is_unexpected_request(resp.unwrap()));
+}


### PR DESCRIPTION
receive_large_response now sends CHUNK_GET on the response's session (was None); the responder rejects a CHUNK_GET or CHUNK_SEND arriving on a different session than the transfer was staged for.


Assisted-by: GitHub Copilot:Claude Opus 4.8