### PR TITLE
fix(spdmlib_crypto_aws_lc): harden PQC checkpoint secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "spdm_x509",
  "spdmlib",
  "spin 0.9.8",
+ "zeroize",
 ]
 
 [[package]]

--- a/spdmlib/src/crypto/crypto_callbacks.rs
+++ b/spdmlib/src/crypto/crypto_callbacks.rs
@@ -184,8 +184,10 @@ pub trait SpdmKemEncapKeyExchange {
         kem_cipher_text: &SpdmKemCipherTextStruct,
     ) -> Option<SpdmSharedSecretFinalKeyStruct>;
 
-    /// Export decapsulation (private) key bytes for serialization (checkpoint
-    /// support). Returns algorithm-specific decapsulation key data.
+    /// Export decapsulation (private) key bytes for checkpoint serialization.
+    ///
+    /// The caller owns the returned secret and must move it immediately into
+    /// zeroizing storage such as `KeyExchangeContextData`.
     fn export_decap_key(&self) -> Option<alloc::vec::Vec<u8>> {
         None // Default: not supported
     }

--- a/spdmlib_crypto_aws_lc/Cargo.toml
+++ b/spdmlib_crypto_aws_lc/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = { version = "1.0", features = ["spin_no_std"] }
 spin = "0.9.8"
 # For building SpdmDheExchangeStruct via its From<BytesMut> impl.
 bytes = { version = "1", default-features = false }
+zeroize = { version = "1.5", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 # std so the cert-chain tests can read test-key DER files. No ring-backend: the

--- a/spdmlib_crypto_aws_lc/src/kem_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/kem_impl.rs
@@ -13,6 +13,7 @@ use spdmlib::protocol::{
     SpdmKemAlgo, SpdmKemCipherTextStruct, SpdmKemEncapKeyStruct, SpdmSharedSecretFinalKeyStruct,
     SPDM_MAX_KEM_CIPHER_TEXT_SIZE, SPDM_MAX_KEM_ENCAP_KEY_SIZE, SPDM_MAX_KEM_SHARED_SECRET_SIZE,
 };
+use zeroize::Zeroizing;
 
 pub static DEFAULT_DECAP: SpdmKemDecap = SpdmKemDecap {
     generate_key_pair_cb: kem_generate_key_pair,
@@ -25,7 +26,7 @@ pub static DEFAULT_ENCAP: SpdmKemEncap = SpdmKemEncap {
 
 struct AwsLcKemDecapKey {
     kem_algo: SpdmKemAlgo,
-    decap_key_bytes: Vec<u8>,
+    decap_key_bytes: Zeroizing<Vec<u8>>,
 }
 
 impl SpdmKemEncapKeyExchange for AwsLcKemDecapKey {
@@ -63,7 +64,7 @@ impl SpdmKemEncapKeyExchange for AwsLcKemDecapKey {
     fn export_decap_key(&self) -> Option<Vec<u8>> {
         // Raw decapsulation (private) key bytes, the same encoding accepted by
         // `kem_import_decap_key` (and by `DecapsulationKey::new`).
-        Some(self.decap_key_bytes.clone())
+        Some(self.decap_key_bytes.to_vec())
     }
 }
 
@@ -146,7 +147,7 @@ fn kem_generate_key_pair(
 
     let exchange: Box<dyn SpdmKemEncapKeyExchange + Send> = Box::new(AwsLcKemDecapKey {
         kem_algo,
-        decap_key_bytes,
+        decap_key_bytes: Zeroizing::new(decap_key_bytes),
     });
 
     Some((ek_struct, exchange))
@@ -175,7 +176,7 @@ fn kem_import_decap_key(
 
     Some(Box::new(AwsLcKemDecapKey {
         kem_algo,
-        decap_key_bytes: Vec::from(decap_key_bytes),
+        decap_key_bytes: Zeroizing::new(Vec::from(decap_key_bytes)),
     }))
 }
 

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -57,6 +57,8 @@ unsafe fn fill_entropy_with_rdrand(
     len: usize,
     mut rdrand_step: impl FnMut(&mut u64) -> bool,
 ) -> bool {
+    use zeroize::Zeroize;
+
     const MAX_RETRIES: usize = 10;
 
     let mut offset = 0;
@@ -70,12 +72,14 @@ unsafe fn fill_entropy_with_rdrand(
             }
         }
         if !ready {
+            value.zeroize();
             core::ptr::write_bytes(output, 0, len);
             return false;
         }
 
         let count = core::cmp::min(core::mem::size_of::<u64>(), len - offset);
         core::ptr::copy_nonoverlapping(value.to_ne_bytes().as_ptr(), output.add(offset), count);
+        value.zeroize();
         offset += count;
     }
     true

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_sign_impl.rs
@@ -14,6 +14,9 @@ const MLDSA_44_SIG_SIZE: usize = 2420;
 const MLDSA_65_SIG_SIZE: usize = 3309;
 const MLDSA_87_SIG_SIZE: usize = 4627;
 
+// These context-signing functions are not exposed by the safe aws-lc-rs API.
+// Their prefixed names are tied to the aws-lc-sys revision pinned in
+// external/patches/aws-lc-rs/README.md and must be updated with that pin.
 extern "C" {
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_sign"]
     fn ml_dsa_44_sign(

--- a/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
+++ b/spdmlib_crypto_aws_lc/src/pqc_asym_verify_impl.rs
@@ -18,6 +18,9 @@ const MLDSA_87_KEY_SIZE: usize = 2592;
 const SPDM_SIGNING_PREFIX_LEN: usize = 64;
 const SPDM_SIGNING_CONTEXT_FIELD_LEN: usize = 36;
 
+// These context-verification functions are not exposed by the safe aws-lc-rs
+// API. Their prefixed names are tied to the aws-lc-sys revision pinned in
+// external/patches/aws-lc-rs/README.md and must be updated with that pin.
 extern "C" {
     #[link_name = "aws_lc_0_43_0_ml_dsa_44_verify"]
     fn ml_dsa_44_verify(


### PR DESCRIPTION
Allocate the SPDM checkpoint workspace directly on the heap. Zeroize ML-KEM decapsulation-key copies and RDRAND temporary words.

Document the pinned ML-DSA FFI symbols, backend feature mapping, and trusted build-specific hash checkpoint format.

Assisted-by: GitHub Copilot:GPT-5.6 Sol