### PR TITLE
refactor(spdmlib): select startup KATs from config

### DIFF
--- a/spdmlib/src/crypto/fips/aead_st/mod.rs
+++ b/spdmlib/src/crypto/fips/aead_st/mod.rs
@@ -20,7 +20,7 @@ use crate::error::{SpdmResult, SPDM_STATUS_FIPS_SELF_TEST_FAIL};
 use crate::crypto::fips::cavs_vectors::gcm_decrypt256;
 use crate::crypto::fips::cavs_vectors::gcm_encrypt_ext_iv256;
 
-fn encrypt_self_test() -> SpdmResult {
+fn aes_256_gcm_encrypt_self_test() -> SpdmResult {
     let aead_algo = SpdmAeadAlgo::AES_256_GCM;
     let cavs_vectors = gcm_encrypt_ext_iv256::get_cavs_vectors();
 
@@ -70,7 +70,7 @@ fn encrypt_self_test() -> SpdmResult {
     Ok(())
 }
 
-fn decrypt_self_test() -> SpdmResult {
+fn aes_256_gcm_decrypt_self_test() -> SpdmResult {
     let aead_algo = SpdmAeadAlgo::AES_256_GCM;
     let cavs_vectors = gcm_decrypt256::get_cavs_vectors();
 
@@ -118,9 +118,14 @@ fn decrypt_self_test() -> SpdmResult {
     Ok(())
 }
 
-pub fn run_self_tests() -> SpdmResult {
-    encrypt_self_test()?;
-    decrypt_self_test()?;
+pub fn run_self_tests(configured: SpdmAeadAlgo) -> SpdmResult<bool> {
+    let mut tested = false;
 
-    Ok(())
+    if configured.contains(SpdmAeadAlgo::AES_256_GCM) {
+        tested = true;
+        aes_256_gcm_encrypt_self_test()?;
+        aes_256_gcm_decrypt_self_test()?;
+    }
+
+    Ok(tested)
 }

--- a/spdmlib/src/crypto/fips/asym_verify_st/mod.rs
+++ b/spdmlib/src/crypto/fips/asym_verify_st/mod.rs
@@ -210,7 +210,12 @@ fn ecdsa_verify(
     .is_ok()
 }
 
-pub fn run_self_tests() -> SpdmResult {
+pub fn run_self_tests(
+    configured_hash: SpdmBaseHashAlgo,
+    configured_asym: SpdmBaseAsymAlgo,
+) -> SpdmResult<bool> {
+    let mut tested = false;
+
     // RSA
     {
         let cavs_vectors = rsa_sig_ver::get_cavs_vectors();
@@ -227,33 +232,39 @@ pub fn run_self_tests() -> SpdmResult {
                 512 => SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096,
                 _ => continue,
             };
-            let public_key = rsa_spki(cv.n, cv.e);
-            let mut signature = SpdmSignatureStruct {
-                data_size: cv.sig.len() as u16,
-                ..Default::default()
-            };
-            signature.data[..cv.sig.len()].copy_from_slice(cv.sig);
-            let verified = asym_verify::verify(
-                hash_algo,
-                asym_algo,
-                SpdmDer::SpdmDerPubKeyRfc7250(&public_key),
-                cv.msg,
-                &signature,
-            )
-            .is_ok();
-            match (cv.res, verified) {
-                // Expecting positive result but got an error
-                ("P", false) |
-                // Expecting negative result but got a success
-                ("F", true) => return Err(SPDM_STATUS_FIPS_SELF_TEST_FAIL),
-                // All other cases are ok
-                _ => continue,
+            if configured_hash.contains(hash_algo) && configured_asym.contains(asym_algo) {
+                tested = true;
+                let public_key = rsa_spki(cv.n, cv.e);
+                let mut signature = SpdmSignatureStruct {
+                    data_size: cv.sig.len() as u16,
+                    ..Default::default()
+                };
+                signature.data[..cv.sig.len()].copy_from_slice(cv.sig);
+                let verified = asym_verify::verify(
+                    hash_algo,
+                    asym_algo,
+                    SpdmDer::SpdmDerPubKeyRfc7250(&public_key),
+                    cv.msg,
+                    &signature,
+                )
+                .is_ok();
+                match (cv.res, verified) {
+                    // Expecting positive result but got an error
+                    ("P", false) |
+                    // Expecting negative result but got a success
+                    ("F", true) => return Err(SPDM_STATUS_FIPS_SELF_TEST_FAIL),
+                    // All other cases are ok
+                    _ => continue,
+                }
             }
         }
     }
 
     // ECDSA P-256, SHA-256
+    if configured_asym.contains(SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256)
+        && configured_hash.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_256)
     {
+        tested = true;
         let cavs_vectors = ecdsa_p256_sha256_sig_ver::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let ret = ecdsa_verify(
@@ -279,7 +290,10 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // ECDSA P-256, SHA-384
+    if configured_asym.contains(SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256)
+        && configured_hash.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_384)
     {
+        tested = true;
         let cavs_vectors = ecdsa_p256_sha384_sig_ver::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let ret = ecdsa_verify(
@@ -305,7 +319,10 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // ECDSA P-384, SHA-256
+    if configured_asym.contains(SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384)
+        && configured_hash.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_256)
     {
+        tested = true;
         let cavs_vectors = ecdsa_p384_sha256_sig_ver::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let ret = ecdsa_verify(
@@ -331,7 +348,10 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // ECDSA P-384, SHA-384
+    if configured_asym.contains(SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384)
+        && configured_hash.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_384)
     {
+        tested = true;
         let cavs_vectors = ecdsa_p384_sha384_sig_ver::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let ret = ecdsa_verify(
@@ -356,5 +376,5 @@ pub fn run_self_tests() -> SpdmResult {
         }
     }
 
-    Ok(())
+    Ok(tested)
 }

--- a/spdmlib/src/crypto/fips/dhe_st/mod.rs
+++ b/spdmlib/src/crypto/fips/dhe_st/mod.rs
@@ -35,9 +35,12 @@ fn verify_vector(
     &secret.data[..secret.data_size as usize] == expected_secret
 }
 
-pub fn run_self_tests() -> SpdmResult {
+pub fn run_self_tests(configured: SpdmDheAlgo) -> SpdmResult<bool> {
+    let mut tested = false;
+
     // P256
-    {
+    if configured.contains(SpdmDheAlgo::SECP_256_R1) {
+        tested = true;
         let cavs_vectors = dhe_vectors_p256::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             if !verify_vector(
@@ -53,7 +56,8 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // P384
-    {
+    if configured.contains(SpdmDheAlgo::SECP_384_R1) {
+        tested = true;
         let cavs_vectors = dhe_vectors_p384::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             if !verify_vector(
@@ -68,5 +72,5 @@ pub fn run_self_tests() -> SpdmResult {
         }
     }
 
-    Ok(())
+    Ok(tested)
 }

--- a/spdmlib/src/crypto/fips/hash_st/mod.rs
+++ b/spdmlib/src/crypto/fips/hash_st/mod.rs
@@ -13,9 +13,12 @@ use crate::error::{SpdmResult, SPDM_STATUS_FIPS_SELF_TEST_FAIL};
 use crate::crypto::fips::cavs_vectors::sha256_short_msg;
 use crate::crypto::fips::cavs_vectors::sha384_short_msg;
 
-pub fn run_self_tests() -> SpdmResult {
+pub fn run_self_tests(configured: SpdmBaseHashAlgo) -> SpdmResult<bool> {
+    let mut tested = false;
+
     // SHA2-256
-    {
+    if configured.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_256) {
+        tested = true;
         let cavs_vectors = sha256_short_msg::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let res = hash::hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_256, cv.msg).unwrap();
@@ -27,7 +30,8 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // SHA2-384
-    {
+    if configured.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_384) {
+        tested = true;
         let cavs_vectors = sha384_short_msg::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let res = hash::hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_384, cv.msg).unwrap();
@@ -38,5 +42,5 @@ pub fn run_self_tests() -> SpdmResult {
         }
     }
 
-    Ok(())
+    Ok(tested)
 }

--- a/spdmlib/src/crypto/fips/hmac_st/mod.rs
+++ b/spdmlib/src/crypto/fips/hmac_st/mod.rs
@@ -16,9 +16,12 @@ use crate::crypto::fips::cavs_vectors::hmac_sha256;
 use crate::crypto::fips::cavs_vectors::hmac_sha384;
 use crate::crypto::fips::cavs_vectors::hmac_sha512;
 
-pub fn run_self_tests() -> SpdmResult {
+pub fn run_self_tests(configured: SpdmBaseHashAlgo) -> SpdmResult<bool> {
+    let mut tested = false;
+
     // SHA2-256
-    {
+    if configured.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_256) {
+        tested = true;
         let cavs_vectors = hmac_sha256::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let mut mac = SpdmDigestStruct {
@@ -37,7 +40,8 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // SHA2-384
-    {
+    if configured.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_384) {
+        tested = true;
         let cavs_vectors = hmac_sha384::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let mut mac = SpdmDigestStruct {
@@ -56,7 +60,8 @@ pub fn run_self_tests() -> SpdmResult {
     }
 
     // SHA2-512
-    {
+    if configured.contains(SpdmBaseHashAlgo::TPM_ALG_SHA_512) {
+        tested = true;
         let cavs_vectors = hmac_sha512::get_cavs_vectors();
         for cv in cavs_vectors.iter() {
             let mut mac = SpdmDigestStruct {
@@ -74,5 +79,5 @@ pub fn run_self_tests() -> SpdmResult {
         }
     }
 
-    Ok(())
+    Ok(tested)
 }

--- a/spdmlib/src/crypto/fips/mod.rs
+++ b/spdmlib/src/crypto/fips/mod.rs
@@ -13,7 +13,43 @@ mod dhe_st;
 mod hash_st;
 mod hmac_st;
 
-use crate::error::SpdmResult;
+use crate::{
+    common::SpdmConfigInfo,
+    error::{SpdmResult, SPDM_STATUS_FIPS_SELF_TEST_FAIL},
+    protocol::{
+        SpdmAeadAlgo, SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmDheAlgo, SpdmMeasurementHashAlgo,
+    },
+};
+
+/// Classical algorithms covered by startup known-answer tests.
+struct SupportedAlgorithms {
+    base_hash: SpdmBaseHashAlgo,
+    measurement_hash: SpdmMeasurementHashAlgo,
+    asym: SpdmBaseAsymAlgo,
+    dhe: SpdmDheAlgo,
+    aead: SpdmAeadAlgo,
+}
+
+const SUPPORTED_ALGORITHMS: SupportedAlgorithms = SupportedAlgorithms {
+    base_hash: SpdmBaseHashAlgo::from_bits_truncate(
+        SpdmBaseHashAlgo::TPM_ALG_SHA_256.bits() | SpdmBaseHashAlgo::TPM_ALG_SHA_384.bits(),
+    ),
+    measurement_hash: SpdmMeasurementHashAlgo::from_bits_truncate(
+        SpdmMeasurementHashAlgo::TPM_ALG_SHA_256.bits()
+            | SpdmMeasurementHashAlgo::TPM_ALG_SHA_384.bits(),
+    ),
+    asym: SpdmBaseAsymAlgo::from_bits_truncate(
+        SpdmBaseAsymAlgo::TPM_ALG_RSASSA_2048.bits()
+            | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072.bits()
+            | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_4096.bits()
+            | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256.bits()
+            | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384.bits(),
+    ),
+    dhe: SpdmDheAlgo::from_bits_truncate(
+        SpdmDheAlgo::SECP_256_R1.bits() | SpdmDheAlgo::SECP_384_R1.bits(),
+    ),
+    aead: SpdmAeadAlgo::AES_256_GCM,
+};
 
 /// Drop guard that restores the previous log level on scope exit,
 /// even if an early return (e.g. `?`) occurs.
@@ -31,27 +67,166 @@ fn run_silenced<T>(test: impl FnOnce() -> SpdmResult<T>) -> SpdmResult<T> {
     test()
 }
 
-pub fn run_self_tests() -> SpdmResult {
+fn configured_hash_algorithms(config: &SpdmConfigInfo) -> SpdmBaseHashAlgo {
+    let mut algorithms = config.base_hash_algo;
+
+    if config
+        .measurement_hash_algo
+        .contains(SpdmMeasurementHashAlgo::TPM_ALG_SHA_256)
     {
-        run_silenced(aead_st::run_self_tests)?;
-        log::info!("AES-256-GCM FIPS CAVP passed");
+        algorithms |= SpdmBaseHashAlgo::TPM_ALG_SHA_256;
     }
+    if config
+        .measurement_hash_algo
+        .contains(SpdmMeasurementHashAlgo::TPM_ALG_SHA_384)
     {
-        run_silenced(asym_verify_st::run_self_tests)?;
+        algorithms |= SpdmBaseHashAlgo::TPM_ALG_SHA_384;
+    }
+    if config
+        .measurement_hash_algo
+        .contains(SpdmMeasurementHashAlgo::TPM_ALG_SHA_512)
+    {
+        algorithms |= SpdmBaseHashAlgo::TPM_ALG_SHA_512;
+    }
+
+    algorithms
+}
+
+fn configured_asym_algorithms(config: &SpdmConfigInfo) -> SpdmBaseAsymAlgo {
+    config.base_asym_algo | config.req_asym_algo.to_base()
+}
+
+impl SupportedAlgorithms {
+    fn supports(&self, config: &SpdmConfigInfo) -> bool {
+        self.base_hash.contains(config.base_hash_algo)
+            && self.measurement_hash.contains(config.measurement_hash_algo)
+            && self.asym.contains(configured_asym_algorithms(config))
+            && self.dhe.contains(config.dhe_algo)
+            && self.aead.contains(config.aead_algo)
+    }
+}
+
+fn ensure_self_test_coverage(config: &SpdmConfigInfo) -> SpdmResult {
+    if SUPPORTED_ALGORITHMS.supports(config) {
+        Ok(())
+    } else {
+        Err(SPDM_STATUS_FIPS_SELF_TEST_FAIL)
+    }
+}
+
+/// Run startup known-answer tests for the classical algorithms enabled by `config`.
+///
+/// Requester and responder authentication capabilities are combined because
+/// they use the same verification primitives. Hash tests cover both base and
+/// measurement hashes, while HMAC tests cover only configured base hashes.
+pub fn run_self_tests(config: &SpdmConfigInfo) -> SpdmResult {
+    ensure_self_test_coverage(config)?;
+
+    let hash_algorithms = configured_hash_algorithms(config);
+    let asym_algorithms = configured_asym_algorithms(config);
+
+    if run_silenced(|| aead_st::run_self_tests(config.aead_algo))? {
+        log::info!("AEAD FIPS CAVP passed");
+    }
+    if run_silenced(|| asym_verify_st::run_self_tests(hash_algorithms, asym_algorithms))? {
         log::info!("Asymmetric verification FIPS CAVP passed");
     }
-    {
-        run_silenced(dhe_st::run_self_tests)?;
+    if run_silenced(|| dhe_st::run_self_tests(config.dhe_algo))? {
         log::info!("DHE FIPS CAVP passed");
     }
-    {
-        run_silenced(hash_st::run_self_tests)?;
+    if run_silenced(|| hash_st::run_self_tests(hash_algorithms))? {
         log::info!("Hash FIPS CAVP passed");
     }
-    {
-        run_silenced(hmac_st::run_self_tests)?;
+    if run_silenced(|| hmac_st::run_self_tests(config.base_hash_algo))? {
         log::info!("HMAC FIPS CAVP passed");
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::SpdmReqAsymAlgo;
+
+    #[test]
+    fn test_empty_config_runs_no_self_tests() {
+        assert!(run_self_tests(&SpdmConfigInfo::default()).is_ok());
+    }
+
+    #[test]
+    fn test_configured_algorithms_include_all_consumer_uses() {
+        let config = SpdmConfigInfo {
+            measurement_hash_algo: SpdmMeasurementHashAlgo::TPM_ALG_SHA_256,
+            base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+            req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            configured_hash_algorithms(&config),
+            SpdmBaseHashAlgo::TPM_ALG_SHA_256 | SpdmBaseHashAlgo::TPM_ALG_SHA_384
+        );
+        assert_eq!(
+            configured_asym_algorithms(&config),
+            SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
+        );
+    }
+
+    #[test]
+    fn test_example_supported_profile_has_self_test_coverage() {
+        let config = SpdmConfigInfo {
+            measurement_hash_algo: SpdmMeasurementHashAlgo::TPM_ALG_SHA_256
+                | SpdmMeasurementHashAlgo::TPM_ALG_SHA_384,
+            base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256 | SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384
+                | SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072,
+            req_asym_algo: SpdmReqAsymAlgo::empty(),
+            dhe_algo: SpdmDheAlgo::SECP_256_R1 | SpdmDheAlgo::SECP_384_R1,
+            aead_algo: SpdmAeadAlgo::AES_256_GCM,
+            ..Default::default()
+        };
+
+        assert_eq!(ensure_self_test_coverage(&config), Ok(()));
+    }
+
+    /**
+    The following test ensures that each classical algorithm enabled in the configuration has a corresponding self-test implemented.
+    If a new classical algorithm is added to the configuration, this test will fail until a self-test is implemented for that algorithm.
+    */
+    #[test]
+    fn test_configured_algorithms_require_self_test_coverage() {
+        let unsupported_configs = [
+            SpdmConfigInfo {
+                base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_512,
+                ..Default::default()
+            },
+            SpdmConfigInfo {
+                measurement_hash_algo: SpdmMeasurementHashAlgo::TPM_ALG_SHA3_256,
+                ..Default::default()
+            },
+            SpdmConfigInfo {
+                base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSAPSS_3072,
+                ..Default::default()
+            },
+            SpdmConfigInfo {
+                req_asym_algo: SpdmReqAsymAlgo::TPM_ALG_RSAPSS_3072,
+                ..Default::default()
+            },
+            SpdmConfigInfo {
+                aead_algo: SpdmAeadAlgo::CHACHA20_POLY1305,
+                ..Default::default()
+            },
+        ];
+
+        for config in unsupported_configs {
+            assert_eq!(
+                ensure_self_test_coverage(&config),
+                Err(SPDM_STATUS_FIPS_SELF_TEST_FAIL)
+            );
+        }
+    }
 }

--- a/spdmlib/src/crypto/spdm_ring/mod.rs
+++ b/spdmlib/src/crypto/spdm_ring/mod.rs
@@ -16,8 +16,23 @@ extern crate alloc;
 
 #[cfg(all(test, feature = "fips"))]
 mod tests {
+    use crate::{
+        common::SpdmConfigInfo,
+        protocol::{SpdmAeadAlgo, SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmDheAlgo},
+    };
+
     #[test]
     fn test_spdm_fips_self_tests() {
-        assert!(crate::crypto::fips::run_self_tests().is_ok());
+        let config = SpdmConfigInfo {
+            base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256 | SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+            dhe_algo: SpdmDheAlgo::SECP_256_R1 | SpdmDheAlgo::SECP_384_R1,
+            aead_algo: SpdmAeadAlgo::AES_256_GCM,
+            ..Default::default()
+        };
+
+        assert!(crate::crypto::fips::run_self_tests(&config).is_ok());
     }
 }

--- a/spdmlib_crypto_aws_lc/src/lib.rs
+++ b/spdmlib_crypto_aws_lc/src/lib.rs
@@ -131,7 +131,9 @@ pub mod rand_impl;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use spdmlib::protocol::SpdmKemAlgo;
+    use spdmlib::protocol::{
+        SpdmAeadAlgo, SpdmBaseAsymAlgo, SpdmBaseHashAlgo, SpdmDheAlgo, SpdmKemAlgo,
+    };
 
     #[cfg(target_arch = "x86_64")]
     #[test]
@@ -159,13 +161,23 @@ mod tests {
     #[cfg(feature = "fips")]
     #[test]
     fn test_spdm_fips_self_tests() {
+        let config = spdmlib::common::SpdmConfigInfo {
+            base_hash_algo: SpdmBaseHashAlgo::TPM_ALG_SHA_256 | SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            base_asym_algo: SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+            dhe_algo: SpdmDheAlgo::SECP_256_R1 | SpdmDheAlgo::SECP_384_R1,
+            aead_algo: SpdmAeadAlgo::AES_256_GCM,
+            ..Default::default()
+        };
+
         spdmlib::crypto::hash::register(hash_impl::DEFAULT.clone());
         spdmlib::crypto::hmac::register(hmac_impl::DEFAULT.clone());
         spdmlib::crypto::aead::register(aead_impl::DEFAULT.clone());
         spdmlib::crypto::asym_verify::register(asym_verify_impl::DEFAULT.clone());
         spdmlib::crypto::dhe::register(dhe_impl::DEFAULT.clone());
 
-        assert!(spdmlib::crypto::fips::run_self_tests().is_ok());
+        assert!(spdmlib::crypto::fips::run_self_tests(&config).is_ok());
     }
 
     #[test]

--- a/spdmlib_crypto_mbedtls/src/lib.rs
+++ b/spdmlib_crypto_mbedtls/src/lib.rs
@@ -29,12 +29,24 @@ mod tests {
 
     #[test]
     fn test_spdm_fips_self_tests() {
+        let config = spdmlib::common::SpdmConfigInfo {
+            base_hash_algo: spdmlib::protocol::SpdmBaseHashAlgo::TPM_ALG_SHA_256
+                | spdmlib::protocol::SpdmBaseHashAlgo::TPM_ALG_SHA_384,
+            base_asym_algo: spdmlib::protocol::SpdmBaseAsymAlgo::TPM_ALG_RSASSA_3072
+                | spdmlib::protocol::SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P256
+                | spdmlib::protocol::SpdmBaseAsymAlgo::TPM_ALG_ECDSA_ECC_NIST_P384,
+            dhe_algo: spdmlib::protocol::SpdmDheAlgo::SECP_256_R1
+                | spdmlib::protocol::SpdmDheAlgo::SECP_384_R1,
+            aead_algo: spdmlib::protocol::SpdmAeadAlgo::AES_256_GCM,
+            ..Default::default()
+        };
+
         spdmlib::crypto::hash::register(hash_impl::DEFAULT.clone());
         spdmlib::crypto::hmac::register(hmac_impl::DEFAULT.clone());
         spdmlib::crypto::aead::register(aead_impl::DEFAULT.clone());
         spdmlib::crypto::asym_verify::register(asym_verify_impl::DEFAULT.clone());
         spdmlib::crypto::dhe::register(dhe_impl::DEFAULT.clone());
 
-        assert!(spdmlib::crypto::fips::run_self_tests().is_ok());
+        assert!(spdmlib::crypto::fips::run_self_tests(&config).is_ok());
     }
 }


### PR DESCRIPTION
Select classical startup tests from the consumer SPDM configuration, combining requester and responder authentication uses and including measurement hashes. Fail closed when a configured classical algorithm lacks coverage, and test empty, unsupported, union, and supported profiles.

Rebased on #450 