### PR TITLE
feat(spdmlib_crypto_mbedtls): support SHA-512

### DIFF
--- a/spdmlib_crypto_mbedtls/src/asym_verify_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/asym_verify_impl.rs
@@ -15,6 +15,7 @@ fn get_hash_algo(base_hash_algo: SpdmBaseHashAlgo) -> SpdmResult<hash::Type> {
     match base_hash_algo {
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => Ok(hash::Type::Sha256),
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => Ok(hash::Type::Sha384),
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => Ok(hash::Type::Sha512),
         _ => Err(SPDM_STATUS_INVALID_PARAMETER),
     }
 }

--- a/spdmlib_crypto_mbedtls/src/dhe_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/dhe_impl.rs
@@ -8,6 +8,7 @@ use alloc::{boxed::Box, vec::Vec};
 #[cfg(feature = "std")]
 use std::{boxed::Box, vec::Vec};
 
+use mbedtls::bignum::Mpi;
 use mbedtls::ecp::EcPoint;
 use mbedtls::pk::{EcGroup, EcGroupId, Pk};
 use mbedtls::rng::RngCallback;
@@ -17,7 +18,7 @@ use spdmlib::crypto::{SpdmDhe, SpdmDheKeyExchange};
 use spdmlib::protocol::{SpdmDheAlgo, SpdmDheExchangeStruct, SpdmSharedSecretFinalKeyStruct};
 pub static DEFAULT: SpdmDhe = SpdmDhe {
     generate_key_pair_cb: generate_key_pair,
-    import_private_key_cb: None,
+    import_private_key_cb: Some(import_private_key),
 };
 
 fn generate_key_pair(
@@ -26,6 +27,30 @@ fn generate_key_pair(
     match dhe_algo {
         SpdmDheAlgo::SECP_256_R1 => SpdmDheKeyExchangeP256::generate_key_pair(),
         SpdmDheAlgo::SECP_384_R1 => SpdmDheKeyExchangeP384::generate_key_pair(),
+        _ => None,
+    }
+}
+
+fn import_private_key(
+    dhe_algo: SpdmDheAlgo,
+    private_key_data: &[u8],
+) -> Option<Box<dyn SpdmDheKeyExchange + Send>> {
+    let (group_id, private_key_size) = match dhe_algo {
+        SpdmDheAlgo::SECP_256_R1 => (EcGroupId::SecP256R1, 32),
+        SpdmDheAlgo::SECP_384_R1 => (EcGroupId::SecP384R1, 48),
+        _ => return None,
+    };
+    if private_key_data.len() != private_key_size {
+        return None;
+    }
+
+    let group = EcGroup::new(group_id).ok()?;
+    let private_key = Mpi::from_binary(private_key_data).ok()?;
+    let key = Pk::private_from_ec_components(group, private_key).ok()?;
+
+    match dhe_algo {
+        SpdmDheAlgo::SECP_256_R1 => Some(Box::new(SpdmDheKeyExchangeP256(key))),
+        SpdmDheAlgo::SECP_384_R1 => Some(Box::new(SpdmDheKeyExchangeP384(key))),
         _ => None,
     }
 }
@@ -67,6 +92,10 @@ impl SpdmDheKeyExchange for SpdmDheKeyExchangeP256 {
         final_key.data_size = len as u16;
         Some(final_key)
     }
+
+    fn export_private_key(&self) -> Option<Vec<u8>> {
+        self.0.ec_private().ok()?.to_binary_padded(32).ok()
+    }
 }
 
 pub struct SpdmDheKeyExchangeP384(Pk);
@@ -106,6 +135,10 @@ impl SpdmDheKeyExchange for SpdmDheKeyExchangeP384 {
         final_key.data_size = len as u16;
         Some(final_key)
     }
+
+    fn export_private_key(&self) -> Option<Vec<u8>> {
+        self.0.ec_private().ok()?.to_binary_padded(48).ok()
+    }
 }
 
 #[derive(Default)]
@@ -141,4 +174,23 @@ fn test_case0_dhe() {
 fn test_case1_dhe() {
     let dhe_algo = SpdmDheAlgo::empty();
     assert!(generate_key_pair(dhe_algo).is_none());
+}
+
+#[test]
+fn test_case2_dhe_export_import() {
+    for (dhe_algo, private_key_size) in [
+        (SpdmDheAlgo::SECP_256_R1, 32),
+        (SpdmDheAlgo::SECP_384_R1, 48),
+    ] {
+        let (_, private_key) = generate_key_pair(dhe_algo).unwrap();
+        let exported = private_key.export_private_key().unwrap();
+        assert_eq!(exported.len(), private_key_size);
+
+        let imported_key = import_private_key(dhe_algo, &exported).unwrap();
+        let (peer_public_key, _) = generate_key_pair(dhe_algo).unwrap();
+        let original_secret = private_key.compute_final_key(&peer_public_key).unwrap();
+        let imported_secret = imported_key.compute_final_key(&peer_public_key).unwrap();
+
+        assert_eq!(original_secret.as_ref(), imported_secret.as_ref());
+    }
 }

--- a/spdmlib_crypto_mbedtls/src/hash_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hash_impl.rs
@@ -37,6 +37,7 @@ mod hash_ext {
         let hash_algo = match base_hash_algo {
             SpdmBaseHashAlgo::TPM_ALG_SHA_256 => Some(hash::Type::Sha256),
             SpdmBaseHashAlgo::TPM_ALG_SHA_384 => Some(hash::Type::Sha384),
+            SpdmBaseHashAlgo::TPM_ALG_SHA_512 => Some(hash::Type::Sha512),
             _ => None,
         }?;
 
@@ -108,6 +109,7 @@ fn hash_all(base_hash_algo: SpdmBaseHashAlgo, data: &[u8]) -> Option<SpdmDigestS
     let hash_algo = match base_hash_algo {
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => Some(hash::Type::Sha256),
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => Some(hash::Type::Sha384),
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => Some(hash::Type::Sha512),
         _ => None,
     }?;
 
@@ -138,4 +140,21 @@ fn test_case1_hash_all() {
         res,
         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".to_string()
     )
+}
+
+#[test]
+fn test_case2_hash_all_sha512() {
+    let digest = hash_all(SpdmBaseHashAlgo::TPM_ALG_SHA_512, b"hello").unwrap();
+
+    assert_eq!(digest.data_size, 64);
+    assert_eq!(
+        digest.as_ref(),
+        &[
+            0x9b, 0x71, 0xd2, 0x24, 0xbd, 0x62, 0xf3, 0x78, 0x5d, 0x96, 0xd4, 0x6a, 0xd3, 0xea,
+            0x3d, 0x73, 0x31, 0x9b, 0xfb, 0xc2, 0x89, 0x0c, 0xaa, 0xda, 0xe2, 0xdf, 0xf7, 0x25,
+            0x19, 0x67, 0x3c, 0xa7, 0x23, 0x23, 0xc3, 0xd9, 0x9b, 0xa5, 0xc1, 0x1d, 0x7c, 0x7a,
+            0xcc, 0x6e, 0x14, 0xb8, 0xc5, 0xda, 0x0c, 0x46, 0x63, 0x47, 0x5c, 0x2e, 0x5c, 0x3a,
+            0xde, 0xf4, 0x6f, 0x73, 0xbc, 0xde, 0xc0, 0x43,
+        ]
+    );
 }

--- a/spdmlib_crypto_mbedtls/src/hmac_impl.rs
+++ b/spdmlib_crypto_mbedtls/src/hmac_impl.rs
@@ -16,6 +16,7 @@ fn hmac(base_hash_algo: SpdmBaseHashAlgo, key: &[u8], data: &[u8]) -> Option<Spd
     let hash_algo = match base_hash_algo {
         SpdmBaseHashAlgo::TPM_ALG_SHA_256 => Some(hash::Type::Sha256),
         SpdmBaseHashAlgo::TPM_ALG_SHA_384 => Some(hash::Type::Sha384),
+        SpdmBaseHashAlgo::TPM_ALG_SHA_512 => Some(hash::Type::Sha512),
         _ => None,
     }?;
     let mut ctx = hash::Hmac::new(hash_algo, key).ok()?;


### PR DESCRIPTION
Add SHA-512 support to the mbedTLS asymmetric verification, hash, and HMAC adapters, with a direct SHA-512 known-answer test.

This support is required by the backend-neutral FIPS KATs in #450, which exercise RSA and HMAC SHA-512 vectors.

PR order:
1. #449
2. This PR

Validation:
- `cargo test -p spdmlib_crypto_mbedtls test_case2_hash_all_sha512 -- --test-threads=1`
- With this PR and #450 combined, the exact previously failing LLVM 14 FIPS command passes:
  `cargo test -p spdmlib_crypto_mbedtls --no-default-features --features=fips test_spdm_fips_self_tests -- --test-threads=1`