### PR TITLE
fix(spdmlib): size certificate portions dynamically

### DIFF
--- a/spdmlib/src/message/certificate.rs
+++ b/spdmlib/src/message/certificate.rs
@@ -7,10 +7,37 @@ use crate::error::SPDM_STATUS_BUFFER_FULL;
 use crate::protocol::{
     SpdmRequestCapabilityFlags, SpdmResponseCapabilityFlags, SpdmVersion, SPDM_MAX_SLOT_NUMBER,
 };
-use crate::{common, error::SpdmStatus};
+use crate::{common, config, error::SpdmStatus};
 use codec::{Codec, Reader, Writer};
 
-pub const MAX_SPDM_CERT_PORTION_LEN: usize = 512;
+pub const MAX_SPDM_CERT_PORTION_LEN: usize = config::MAX_SPDM_CERT_CHAIN_DATA_SIZE;
+
+const SPDM_CERTIFICATE_RESPONSE_HEADER_SIZE: u32 = 8;
+const SPDM_LARGE_CERTIFICATE_RESPONSE_HEADER_SIZE: u32 = 16;
+
+impl common::SpdmContext {
+    pub fn get_max_spdm_cert_portion_len(&self, data_transfer_size: u32) -> u32 {
+        let large_cert = self.negotiate_info.spdm_version_sel >= SpdmVersion::SpdmVersion14
+            && self
+                .negotiate_info
+                .rsp_capabilities_sel
+                .contains(SpdmResponseCapabilityFlags::LARGE_RESP_CAP)
+            && self
+                .negotiate_info
+                .req_capabilities_sel
+                .contains(SpdmRequestCapabilityFlags::LARGE_RESP_CAP);
+        let header_size = if large_cert {
+            SPDM_LARGE_CERTIFICATE_RESPONSE_HEADER_SIZE
+        } else {
+            SPDM_CERTIFICATE_RESPONSE_HEADER_SIZE
+        };
+
+        data_transfer_size
+            .min(config::MAX_SPDM_MSG_SIZE as u32)
+            .saturating_sub(header_size)
+            .min(MAX_SPDM_CERT_PORTION_LEN as u32)
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct SpdmGetCertificateRequestPayload {
@@ -283,6 +310,27 @@ mod tests {
         for i in 0..MAX_SPDM_CERT_PORTION_LEN {
             assert_eq!(spdm_get_certificate_request_payload.cert_chain[i], 100u8);
         }
+    }
+
+    #[test]
+    fn test_get_max_spdm_cert_portion_len() {
+        create_spdm_context!(context);
+
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion13;
+        assert_eq!(context.get_max_spdm_cert_portion_len(1024), 1016);
+        assert_eq!(context.get_max_spdm_cert_portion_len(u32::MAX), 4088);
+
+        context.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion14;
+        context
+            .negotiate_info
+            .req_capabilities_sel
+            .insert(SpdmRequestCapabilityFlags::LARGE_RESP_CAP);
+        context
+            .negotiate_info
+            .rsp_capabilities_sel
+            .insert(SpdmResponseCapabilityFlags::LARGE_RESP_CAP);
+        assert_eq!(context.get_max_spdm_cert_portion_len(1024), 1008);
+        assert_eq!(context.get_max_spdm_cert_portion_len(u32::MAX), 4080);
     }
 }
 

--- a/spdmlib/src/message/encapsulated.rs
+++ b/spdmlib/src/message/encapsulated.rs
@@ -9,6 +9,7 @@ use crate::protocol::SpdmVersion;
 use codec::{enum_builder, u24, Codec, Reader, Writer};
 
 pub const ENCAPSULATED_RESPONSE_ACK_HEADER_SIZE: usize = 8;
+pub const DELIVER_ENCAPSULATED_RESPONSE_HEADER_SIZE: u32 = 4;
 
 #[derive(Debug, Clone, Default)]
 pub struct SpdmGetEncapsulatedRequestPayload {}

--- a/spdmlib/src/message/mod.rs
+++ b/spdmlib/src/message/mod.rs
@@ -950,6 +950,8 @@ mod tests {
     }
     #[test]
     fn test_case5_spdm_message() {
+        const PORTION_LENGTH: usize = config::MAX_SPDM_MSG_SIZE - 8;
+
         let value = SpdmMessage {
             header: SpdmMessageHeader {
                 version: SpdmVersion::SpdmVersion10,
@@ -957,7 +959,7 @@ mod tests {
             },
             payload: SpdmMessagePayload::SpdmCertificateResponse(SpdmCertificateResponsePayload {
                 slot_id: 4,
-                portion_length: MAX_SPDM_CERT_PORTION_LEN as u32,
+                portion_length: PORTION_LENGTH as u32,
                 remainder_length: 100,
                 cert_chain: [100u8; MAX_SPDM_CERT_PORTION_LEN],
             }),
@@ -971,9 +973,9 @@ mod tests {
         );
         if let SpdmMessagePayload::SpdmCertificateResponse(payload) = &spdm_message.payload {
             assert_eq!(payload.slot_id, 4);
-            assert_eq!(payload.portion_length, MAX_SPDM_CERT_PORTION_LEN as u32);
+            assert_eq!(payload.portion_length, PORTION_LENGTH as u32);
             assert_eq!(payload.remainder_length, 100);
-            for i in 0..MAX_SPDM_CERT_PORTION_LEN {
+            for i in 0..PORTION_LENGTH {
                 assert_eq!(payload.cert_chain[i], 100u8);
             }
         }

--- a/spdmlib/src/requester/encap_certificate.rs
+++ b/spdmlib/src/requester/encap_certificate.rs
@@ -6,6 +6,7 @@ use codec::{Codec, Reader, Writer};
 
 use crate::{
     common::SpdmCodec,
+    config,
     message::{
         SpdmCertificateResponsePayload, SpdmErrorCode, SpdmGetCertificateRequestPayload,
         SpdmMessage, SpdmMessageHeader, SpdmMessagePayload, SpdmRequestResponseCode,
@@ -95,9 +96,17 @@ impl RequesterContext {
             .as_ref()
             .unwrap();
 
+        let data_transfer_size = if self.common.negotiate_info.rsp_data_transfer_size_sel == 0 {
+            config::SPDM_SENDER_DATA_TRANSFER_SIZE as u32
+        } else {
+            self.common.negotiate_info.rsp_data_transfer_size_sel
+        };
+        let max_cert_portion_len = self.common.get_max_spdm_cert_portion_len(
+            data_transfer_size.saturating_sub(encap_response.used() as u32),
+        );
         let mut length = get_certificate.length;
-        if length > MAX_SPDM_CERT_PORTION_LEN as u32 {
-            length = MAX_SPDM_CERT_PORTION_LEN as u32;
+        if length > max_cert_portion_len {
+            length = max_cert_portion_len;
         }
 
         let offset = get_certificate.offset;

--- a/spdmlib/src/requester/get_certificate_req.rs
+++ b/spdmlib/src/requester/get_certificate_req.rs
@@ -192,7 +192,15 @@ impl RequesterContext {
         slot_id: u8,
     ) -> SpdmResult {
         let mut offset = 0u32;
-        let mut length = MAX_SPDM_CERT_PORTION_LEN as u32;
+        let data_transfer_size = if self.common.config_info.data_transfer_size == 0 {
+            config::SPDM_DATA_TRANSFER_SIZE as u32
+        } else {
+            self.common.config_info.data_transfer_size
+        };
+        let max_cert_portion_len = self
+            .common
+            .get_max_spdm_cert_portion_len(data_transfer_size);
+        let mut length = max_cert_portion_len;
         let mut total_size = 0u32;
 
         if slot_id >= SPDM_MAX_SLOT_NUMBER as u8 {
@@ -228,8 +236,8 @@ impl RequesterContext {
             }
             offset += portion_length;
             length = remainder_length;
-            if length > MAX_SPDM_CERT_PORTION_LEN as u32 {
-                length = MAX_SPDM_CERT_PORTION_LEN as u32;
+            if length > max_cert_portion_len {
+                length = max_cert_portion_len;
             }
         }
         if total_size == 0 {

--- a/spdmlib/src/responder/certificate_rsp.rs
+++ b/spdmlib/src/responder/certificate_rsp.rs
@@ -4,6 +4,7 @@
 
 use crate::common::SpdmCodec;
 use crate::common::SpdmConnectionState;
+use crate::config;
 use crate::error::SpdmResult;
 use crate::error::SPDM_STATUS_INVALID_MSG_FIELD;
 use crate::error::SPDM_STATUS_INVALID_STATE_LOCAL;
@@ -111,9 +112,17 @@ impl ResponderContext {
             .as_ref()
             .unwrap();
 
+        let data_transfer_size = if self.common.negotiate_info.req_data_transfer_size_sel == 0 {
+            config::SPDM_SENDER_DATA_TRANSFER_SIZE as u32
+        } else {
+            self.common.negotiate_info.req_data_transfer_size_sel
+        };
+        let max_cert_portion_len = self
+            .common
+            .get_max_spdm_cert_portion_len(data_transfer_size);
         let mut length = get_certificate.length;
-        if length > MAX_SPDM_CERT_PORTION_LEN as u32 {
-            length = MAX_SPDM_CERT_PORTION_LEN as u32;
+        if length > max_cert_portion_len {
+            length = max_cert_portion_len;
         }
 
         let offset = get_certificate.offset;

--- a/spdmlib/src/responder/encap_get_certificate.rs
+++ b/spdmlib/src/responder/encap_get_certificate.rs
@@ -16,7 +16,7 @@ use crate::{
     message::{
         SpdmCertificateResponsePayload, SpdmGetCertificateRequestPayload, SpdmMessage,
         SpdmMessageGeneralPayload, SpdmMessageHeader, SpdmMessagePayload, SpdmRequestResponseCode,
-        MAX_SPDM_CERT_PORTION_LEN,
+        DELIVER_ENCAPSULATED_RESPONSE_HEADER_SIZE, MAX_SPDM_CERT_PORTION_LEN,
     },
     protocol::{SpdmCertChainBuffer, SpdmCertChainData},
 };
@@ -32,6 +32,14 @@ impl ResponderContext {
             self.common.peer_info.peer_cert_chain_temp = Some(SpdmCertChainBuffer::default());
         }
 
+        let data_transfer_size = if self.common.config_info.data_transfer_size == 0 {
+            config::SPDM_DATA_TRANSFER_SIZE as u32
+        } else {
+            self.common.config_info.data_transfer_size
+        };
+        let max_cert_portion_len = self.common.get_max_spdm_cert_portion_len(
+            data_transfer_size.saturating_sub(DELIVER_ENCAPSULATED_RESPONSE_HEADER_SIZE),
+        );
         let encapsulated_request = SpdmMessage {
             header: SpdmMessageHeader {
                 version: self.common.negotiate_info.spdm_version_sel,
@@ -46,7 +54,7 @@ impl ResponderContext {
                         .as_ref()
                         .unwrap()
                         .data_size,
-                    length: MAX_SPDM_CERT_PORTION_LEN as u32,
+                    length: max_cert_portion_len,
                     slot_id: self.common.encap_context.req_slot_id,
                 },
             ),

--- a/test/spdmlib-test/src/requester_tests/encap_certificate.rs
+++ b/test/spdmlib-test/src/requester_tests/encap_certificate.rs
@@ -72,6 +72,10 @@ fn test_encap_handle_get_certificate() {
 
     let encap_response = &mut [0u8; config::MAX_SPDM_MSG_SIZE];
     let mut writer = Writer::init(encap_response);
+    let expected_portion_length = context
+        .common
+        .get_max_spdm_cert_portion_len(config::SPDM_SENDER_DATA_TRANSFER_SIZE as u32)
+        .min(CERT_PORTION_LEN as u32);
 
     context.encap_handle_get_certificate(encap_request, &mut writer);
     let mut reader = Reader::init(encap_response);
@@ -84,7 +88,7 @@ fn test_encap_handle_get_certificate() {
         header.request_response_code,
         SpdmRequestResponseCode::SpdmResponseCertificate
     );
-    assert_eq!(cert_rsp.portion_length, 512);
-    assert_eq!(cert_rsp.remainder_length, 512);
+    assert_eq!(cert_rsp.portion_length, expected_portion_length);
+    assert_eq!(cert_rsp.remainder_length, 1024 - expected_portion_length);
     assert_eq!(cert_rsp.slot_id, 0);
 }

--- a/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/certificate_rsp.rs
@@ -17,7 +17,7 @@ use {
     crate::common::secret_callback::*,
     crate::common::transport::PciDoeTransportEncap,
     alloc::sync::Arc,
-    codec::{Codec, Writer},
+    codec::{Codec, Reader, Writer},
     spdmlib::common::*,
     spdmlib::error::SPDM_STATUS_INVALID_MSG_FIELD,
     spdmlib::message::*,
@@ -48,6 +48,7 @@ fn test_case0_handle_spdm_certificate() {
         );
 
         context.common.negotiate_info.spdm_version_sel = SpdmVersion::SpdmVersion12;
+        context.common.negotiate_info.req_data_transfer_size_sel = 256;
 
         context.common.provision_info.my_cert_chain = [
             Some(SpdmCertChainBuffer {
@@ -76,7 +77,7 @@ fn test_case0_handle_spdm_certificate() {
         let value = SpdmGetCertificateRequestPayload {
             slot_id: 0,
             offset: 0,
-            length: 200,
+            length: 600,
         };
         assert!(value.spdm_encode(&mut context.common, &mut writer).is_ok());
         let bytes = &mut [0u8; 1024];
@@ -93,6 +94,13 @@ fn test_case0_handle_spdm_certificate() {
             .handle_spdm_certificate(bytes, None, &mut writer)
             .0
             .is_ok());
+        let mut reader = Reader::init(writer.used_slice());
+        let response = SpdmMessage::spdm_read(&mut context.common, &mut reader).unwrap();
+        let SpdmMessagePayload::SpdmCertificateResponse(payload) = response.payload else {
+            panic!("expected CERTIFICATE response");
+        };
+        assert_eq!(payload.portion_length, 248);
+        assert_eq!(payload.remainder_length, 264);
 
         bytes[2] = 1;
         let mut response_buffer = [0u8; MAX_SPDM_MSG_SIZE];

--- a/test/spdmlib-test/src/responder_tests/encap_get_certificate.rs
+++ b/test/spdmlib-test/src/responder_tests/encap_get_certificate.rs
@@ -17,10 +17,12 @@ extern crate alloc;
 use alloc::sync::Arc;
 
 const CERT_PORTION_LEN: usize = 512;
+const TEST_DATA_TRANSFER_SIZE: u32 = 1024;
 
 #[test]
 fn test_encode_encap_requst_get_certificate() {
-    let (config_info, provision_info) = create_info();
+    let (mut config_info, provision_info) = create_info();
+    config_info.data_transfer_size = TEST_DATA_TRANSFER_SIZE;
     let pcidoe_transport_encap = Arc::new(Mutex::new(PciDoeTransportEncap {}));
     let shared_buffer = SharedBuffer::new();
     let socket_io_transport = Arc::new(Mutex::new(FakeSpdmDeviceIoReceve::new(Arc::new(
@@ -57,7 +59,10 @@ fn test_encode_encap_requst_get_certificate() {
         header.request_response_code,
         SpdmRequestResponseCode::SpdmRequestGetCertificate
     );
-    assert_eq!(payload.length, CERT_PORTION_LEN as u32);
+    assert_eq!(
+        payload.length,
+        TEST_DATA_TRANSFER_SIZE - DELIVER_ENCAPSULATED_RESPONSE_HEADER_SIZE - 8
+    );
     assert_eq!(payload.offset, 0);
     assert_eq!(payload.slot_id, 0);
 }
@@ -95,7 +100,7 @@ fn test_handle_encap_response_certificate() {
             slot_id: 0,
             portion_length: CERT_PORTION_LEN as u32,
             remainder_length: 0x600,
-            cert_chain: [0xa; CERT_PORTION_LEN],
+            cert_chain: [0xa; MAX_SPDM_CERT_PORTION_LEN],
         }),
     };
     assert!(cert_rsp
@@ -132,7 +137,7 @@ fn test_handle_encap_response_certificate() {
             slot_id: 0xa,
             portion_length: CERT_PORTION_LEN as u32,
             remainder_length: 0x400,
-            cert_chain: [0xa; CERT_PORTION_LEN],
+            cert_chain: [0xa; MAX_SPDM_CERT_PORTION_LEN],
         });
     assert!(cert_rsp
         .spdm_encode(&mut context.common, &mut writer)
@@ -149,7 +154,7 @@ fn test_handle_encap_response_certificate() {
             slot_id: 0,
             portion_length: CERT_PORTION_LEN as u32,
             remainder_length: 0x400,
-            cert_chain: [0xa; CERT_PORTION_LEN],
+            cert_chain: [0xa; MAX_SPDM_CERT_PORTION_LEN],
         });
     assert!(cert_rsp
         .spdm_encode(&mut context.common, &mut writer)

--- a/test/spdmlib-test/src/responder_tests/encap_rsp.rs
+++ b/test/spdmlib-test/src/responder_tests/encap_rsp.rs
@@ -378,7 +378,7 @@ fn write_spdm_get_certificate_response(
             slot_id: 0,
             portion_length: CERT_PORTION_LEN as u32,
             remainder_length: 0x200,
-            cert_chain: [0xffu8; CERT_PORTION_LEN],
+            cert_chain: [0xffu8; MAX_SPDM_CERT_PORTION_LEN],
         }),
     };
     let _ = response


### PR DESCRIPTION
Derive certificate portion lengths from configured and negotiated data transfer sizes while reserving standard, large-certificate, and encapsulated response framing.

Fixes #430 

Assisted-by: GitHub Copilot:GPT-5.6 Sol